### PR TITLE
fix(ci): format bookmark_entity and group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,20 +5,31 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     labels:
       - dependencies
       - dart
+    groups:
+      # Bundle all non-major pub bumps into a single PR.
+      pub-minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
   # Android Gradle dependencies
   - package-ecosystem: gradle
     directory: "/android"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     labels:
       - dependencies
       - android
+    groups:
+      gradle-minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
   # Note: iOS CocoaPods is intentionally omitted — Dependabot has no
   # CocoaPods support, and there is no Gemfile in /ios to track.
@@ -31,3 +42,8 @@ updates:
     labels:
       - dependencies
       - ci
+    groups:
+      # All action bumps in one PR — they rarely conflict.
+      github-actions:
+        patterns:
+          - "*"

--- a/lib/features/bookmarks/data/local/bookmark_entity.dart
+++ b/lib/features/bookmarks/data/local/bookmark_entity.dart
@@ -8,8 +8,7 @@ enum SyncState {
   synced(0),
   pendingCreate(1),
   pendingUpdate(2),
-  pendingDelete(3)
-  ;
+  pendingDelete(3);
 
   const SyncState(this.code);
 


### PR DESCRIPTION
The CI "Verify formatting" step failed on main (and therefore on every Dependabot PR) because bookmark_entity.dart had a stray semicolon on its own line in the BookmarkSyncStatus enum. Running dart format collapses it to `pendingDelete(3);`.

Also group Dependabot updates so routine bumps arrive as a few combined PRs instead of one per dependency: pub and gradle minor/patch bumps are each bundled, all github-actions bumps share one PR, and PR limits are lowered (pub 10->5, gradle 5->3).