### PR TITLE
fix(android): repair broken release build configuration

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,6 +16,12 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    buildFeatures {
+        // Flavors below define custom resource values via resValue(...).
+        // AGP 9 disables this feature by default, so opt in explicitly.
+        resValues = true
+    }
+
     flavorDimensions += "environment"
     productFlavors {
         create("dev") {

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     id("com.android.application") version "9.0.1" apply false
     id("org.jetbrains.kotlin.android") version "2.3.20" apply false
     id("com.google.gms.google-services") version "4.4.2" apply false
+    id("com.google.firebase.crashlytics") version "3.0.2" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Two latent issues prevented the Android app from building (the build was never run locally and CI does not assemble an APK, so neither surfaced):

1. The com.google.firebase.crashlytics plugin was applied in app/build.gradle.kts but never declared with a version in settings.gradle.kts, so Gradle could not resolve it ("plugin dependency must include a version number"). Declared it alongside google-services.

2. Product flavors define custom resource values via resValue(...), but AGP 9 disables the resValues build feature by default, failing with "Product Flavor dev contains custom resource values, but the feature is disabled." Enabled buildFeatures { resValues = true }.

Verified with `flutter build apk --debug`: the build now compiles fully through Gradle/AGP and resource processing. (It then stops at the Firebase google-services step because google-services.json lacks client entries for the .dev/.staging flavor application IDs — a Firebase project-config matter, not a build-script issue.)