### PR TITLE
docs: add security policy for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub
+issues, discussions, or pull requests.
+
+Instead, report them privately through GitHub's built-in advisory flow:
+
+1. Go to the **[Security tab](https://github.com/kido-luci/flutter-starter-template/security/advisories/new)**
+   of this repository.
+2. Click **Report a vulnerability**.
+3. Fill in the details of the issue, including steps to reproduce and the
+   affected version or commit.
+
+You should receive an acknowledgement within a few days. We will work with
+you to understand and resolve the issue, and will keep you informed of the
+progress toward a fix and full announcement.
+
+## Supported Versions
+
+This is a starter template intended to be forked. Security fixes are applied
+to the `main` branch only. If you have forked this repository, you are
+responsible for keeping your copy up to date.
+
+## Scope
+
+This policy covers the template code in this repository. It does **not**
+cover vulnerabilities in third-party dependencies — please report those to
+the respective upstream projects (and feel free to open a regular issue here
+if a dependency bump is needed).


### PR DESCRIPTION
Add SECURITY.md pointing reporters to GitHub's private vulnerability reporting flow. Enables the repository's "Security policy" indicator and gives forkers a clear template to adapt.