### PR TITLE
ci: add CodeQL scanning scoped to GitHub Actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,36 @@
+name: CodeQL
+
+# Scoped to the `actions` language only. CodeQL has no Dart support, so the
+# Flutter app code is covered by `flutter analyze` in ci.yml instead; this
+# workflow just scans the GitHub Actions workflows for insecure patterns.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so advisories that land after a PR is merged still get caught.
+    - cron: "27 4 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze Actions
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: actions
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
CodeQL has no Dart support, so this workflow only scans the Actions workflows for insecure patterns. Dart code remains covered by `flutter analyze` in ci.yml.