### PR TITLE
fix: APNs token wait without blocking startup

### DIFF
--- a/lib/core/notifications/firebase_messaging_service.dart
+++ b/lib/core/notifications/firebase_messaging_service.dart
@@ -37,8 +37,6 @@ class FirebaseMessagingService {
     final notificationsAllowed = await _localNotifications.requestPermissions();
     if (!notificationsAllowed) return;
 
-    await _saveInitialToken();
-
     if (Platform.isIOS || Platform.isMacOS) {
       // APNs token registration — required for iOS push delivery.
       await _messaging.setForegroundNotificationPresentationOptions(
@@ -47,6 +45,11 @@ class FirebaseMessagingService {
         sound: true,
       );
     }
+
+    // Fetching the initial token can block for several seconds on Apple
+    // platforms while waiting for the APNs token. Don't hold up app startup for
+    // it — the token is delivered through `_tokenStream` once it's ready.
+    _saveInitialToken().uw();
 
     _messaging.onTokenRefresh.listen(_onTokenRefresh);
 
@@ -66,10 +69,36 @@ class FirebaseMessagingService {
   Future<String?> getToken() => _messaging.getToken();
 
   Future<void> _saveInitialToken() async {
+    // On Apple platforms, `getToken()` throws `apns-token-not-set` until the
+    // device has received its APNs token from Apple, which happens
+    // asynchronously after registration. Wait for it before requesting the FCM
+    // token.
+    if (Platform.isIOS || Platform.isMacOS) {
+      final apnsReady = await _waitForApnsToken();
+      if (!apnsReady) return;
+    }
+
     final token = await _messaging.getToken();
     if (token != null) {
       _tokenStream.add(token);
     }
+  }
+
+  /// Polls for the APNs token until it is available or [timeout] elapses.
+  ///
+  /// Returns `true` once the token is set, or `false` if it never arrives
+  /// (e.g. on a simulator without push capability, or when offline).
+  Future<bool> _waitForApnsToken({
+    Duration timeout = const Duration(seconds: 10),
+    Duration interval = const Duration(milliseconds: 500),
+  }) async {
+    final deadline = DateTime.now().add(timeout);
+    while (DateTime.now().isBefore(deadline)) {
+      final apnsToken = await _messaging.getAPNSToken();
+      if (apnsToken != null) return true;
+      await Future<void>.delayed(interval);
+    }
+    return false;
   }
 
   void _onTokenRefresh(String token) {


### PR DESCRIPTION
## Problem

Two related issues in `FirebaseMessagingService`:

1. **Crash on iOS launch** — `getToken()` was called before the device's APNs token was available, throwing `[firebase_messaging/apns-token-not-set]` and dumping a stack trace to Crashlytics on every launch.
2. **Blank screen for ~5–10s on launch** — the initial fix waited (up to 10s) for the APNs token *inside* `init()`, which `main()` awaits before `runApp`, delaying the first frame.

## Fix

- Reorder `init()` so the iOS/macOS foreground-presentation setup (which triggers APNs registration) runs **before** fetching the token.
- Add `_waitForApnsToken()` — polls `getAPNSToken()` until non-null with a bounded 10s timeout (returns gracefully on simulators / when offline).
- Run `_saveInitialToken()` **unawaited** so the APNs wait happens in the background and no longer blocks `runApp`. The token still flows through `_tokenStream` / `onTokenRefresh` once ready.

## Testing

- `dart analyze` clean.
- APNs tokens are not delivered on older iOS simulators; verify real push delivery on a physical device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)