### PR TITLE
feat(ui): polished bottom nav, skeleton loading & splash screen

### DIFF
--- a/lib/core/widgets/app_adaptive_scaffold.dart
+++ b/lib/core/widgets/app_adaptive_scaffold.dart
@@ -51,18 +51,12 @@ class AppAdaptiveScaffold extends StatelessWidget {
         final width = constraints.maxWidth;
         if (width < AppBreakpoints.medium) {
           return Scaffold(
+            extendBody: true,
             body: body,
-            bottomNavigationBar: NavigationBar(
+            bottomNavigationBar: _FloatingBottomBar(
+              destinations: destinations,
               selectedIndex: selectedIndex,
               onDestinationSelected: onDestinationSelected,
-              destinations: [
-                for (final d in destinations)
-                  NavigationDestination(
-                    icon: Icon(d.icon),
-                    selectedIcon: Icon(d.selectedIcon),
-                    label: d.label,
-                  ),
-              ],
             ),
           );
         }
@@ -93,6 +87,151 @@ class AppAdaptiveScaffold extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// A floating, pill-shaped bottom navigation bar.
+///
+/// The selected destination expands into a tinted pill that reveals its label,
+/// while the others collapse to icons. The bar floats above the body with a
+/// rounded surface and a soft shadow for a lifted, tactile feel.
+class _FloatingBottomBar extends StatelessWidget {
+  const _FloatingBottomBar({
+    required this.destinations,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+  });
+
+  final List<AppDestination> destinations;
+  final int selectedIndex;
+  final ValueChanged<int> onDestinationSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return SafeArea(
+      top: false,
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainer,
+            borderRadius: BorderRadius.circular(28),
+            boxShadow: [
+              BoxShadow(
+                color: colorScheme.shadow.withValues(alpha: 0.18),
+                blurRadius: 24,
+                offset: const Offset(0, 8),
+              ),
+            ],
+          ),
+          child: SizedBox(
+            height: 64,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 6),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  for (var index = 0; index < destinations.length; index++)
+                    _BottomBarItem(
+                      destination: destinations[index],
+                      selected: index == selectedIndex,
+                      onTap: () => onDestinationSelected(index),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// A single tappable destination within the [_FloatingBottomBar].
+class _BottomBarItem extends StatelessWidget {
+  const _BottomBarItem({
+    required this.destination,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final AppDestination destination;
+  final bool selected;
+  final VoidCallback onTap;
+
+  static const Duration _duration = Duration(milliseconds: 250);
+  static const Curve _curve = Curves.easeOutCubic;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+    final foreground = selected
+        ? colorScheme.onSecondaryContainer
+        : colorScheme.onSurfaceVariant;
+
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: destination.label,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(20),
+        child: AnimatedContainer(
+          duration: _duration,
+          curve: _curve,
+          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+          decoration: BoxDecoration(
+            color: selected
+                ? colorScheme.secondaryContainer
+                : Colors.transparent,
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              AnimatedSwitcher(
+                duration: _duration,
+                child: Icon(
+                  selected ? destination.selectedIcon : destination.icon,
+                  key: ValueKey<bool>(selected),
+                  color: foreground,
+                  size: 24,
+                ),
+              ),
+              ClipRect(
+                child: AnimatedAlign(
+                  duration: _duration,
+                  curve: _curve,
+                  alignment: Alignment.centerLeft,
+                  widthFactor: selected ? 1 : 0,
+                  child: AnimatedOpacity(
+                    duration: _duration,
+                    curve: _curve,
+                    opacity: selected ? 1 : 0,
+                    child: Padding(
+                      padding: const EdgeInsets.only(left: 8),
+                      child: Text(
+                        destination.label,
+                        maxLines: 1,
+                        overflow: TextOverflow.clip,
+                        softWrap: false,
+                        style: textTheme.labelLarge?.copyWith(
+                          color: foreground,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/core/widgets/app_skeleton.dart
+++ b/lib/core/widgets/app_skeleton.dart
@@ -189,7 +189,11 @@ class AppSkeletonListTile extends StatelessWidget {
 
 /// A shimmering list of [AppSkeletonListTile]s for full-screen list loading.
 class AppSkeletonList extends StatelessWidget {
-  const AppSkeletonList({super.key, this.itemCount = 8, this.hasLeading = true});
+  const AppSkeletonList({
+    super.key,
+    this.itemCount = 8,
+    this.hasLeading = true,
+  });
 
   final int itemCount;
   final bool hasLeading;

--- a/lib/core/widgets/app_skeleton.dart
+++ b/lib/core/widgets/app_skeleton.dart
@@ -1,0 +1,208 @@
+import 'package:flutter/material.dart';
+
+import '../theme/app_spacing.dart';
+
+/// Animates a bright highlight sweeping across its [child] subtree.
+///
+/// Wrap one or more [AppSkeleton] shapes in a single [AppShimmer] so they all
+/// share one synchronized sweep. The highlight is painted over the opaque parts
+/// of the subtree using [BlendMode.srcATop], so the shapes' own color only acts
+/// as a fallback when [enabled] is `false`.
+class AppShimmer extends StatefulWidget {
+  const AppShimmer({
+    super.key,
+    required this.child,
+    this.enabled = true,
+    this.duration = const Duration(milliseconds: 1400),
+  });
+
+  final Widget child;
+
+  /// When `false`, the static placeholder shapes are shown without animation.
+  final bool enabled;
+
+  /// Time for one full left-to-right sweep.
+  final Duration duration;
+
+  @override
+  State<AppShimmer> createState() => _AppShimmerState();
+}
+
+class _AppShimmerState extends State<AppShimmer>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _controller = AnimationController(
+    vsync: this,
+    duration: widget.duration,
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.enabled) _controller.repeat();
+  }
+
+  @override
+  void didUpdateWidget(AppShimmer oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _controller.duration = widget.duration;
+    if (widget.enabled && !_controller.isAnimating) {
+      _controller.repeat();
+    } else if (!widget.enabled && _controller.isAnimating) {
+      _controller.stop();
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!widget.enabled) return widget.child;
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final isDark = colorScheme.brightness == Brightness.dark;
+    final base = colorScheme.surfaceContainerHighest;
+    final highlight = Color.alphaBlend(
+      Colors.white.withValues(alpha: isDark ? 0.10 : 0.55),
+      base,
+    );
+
+    return AnimatedBuilder(
+      animation: _controller,
+      child: widget.child,
+      builder: (context, child) {
+        return ShaderMask(
+          blendMode: BlendMode.srcATop,
+          shaderCallback: (bounds) => LinearGradient(
+            begin: Alignment.centerLeft,
+            end: Alignment.centerRight,
+            colors: [base, highlight, base],
+            stops: const [0.2, 0.5, 0.8],
+            transform: _SlidingGradientTransform(_controller.value),
+          ).createShader(bounds),
+          child: child,
+        );
+      },
+    );
+  }
+}
+
+/// Translates a gradient horizontally to drive the shimmer sweep.
+class _SlidingGradientTransform extends GradientTransform {
+  const _SlidingGradientTransform(this.slidePercent);
+
+  final double slidePercent;
+
+  @override
+  Matrix4 transform(Rect bounds, {TextDirection? textDirection}) {
+    return Matrix4.translationValues(
+      bounds.width * (slidePercent * 2 - 1),
+      0,
+      0,
+    );
+  }
+}
+
+/// A single placeholder shape used to compose loading skeletons.
+///
+/// Place these inside an [AppShimmer] to animate them. Use [AppSkeleton.line]
+/// for text rows, [AppSkeleton.circle] for avatars, and the default
+/// constructor for blocks such as images or cards.
+class AppSkeleton extends StatelessWidget {
+  const AppSkeleton({
+    super.key,
+    this.width,
+    this.height = 16,
+    this.borderRadius = const BorderRadius.all(Radius.circular(8)),
+  }) : shape = BoxShape.rectangle;
+
+  /// A thin rounded bar approximating a line of text.
+  const AppSkeleton.line({super.key, this.width, this.height = 12})
+    : shape = BoxShape.rectangle,
+      borderRadius = const BorderRadius.all(Radius.circular(6));
+
+  /// A circular placeholder, e.g. an avatar.
+  const AppSkeleton.circle({super.key, required double size})
+    : width = size,
+      height = size,
+      shape = BoxShape.circle,
+      borderRadius = null;
+
+  final double? width;
+  final double height;
+  final BoxShape shape;
+  final BorderRadius? borderRadius;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        shape: shape,
+        borderRadius: shape == BoxShape.circle ? null : borderRadius,
+      ),
+    );
+  }
+}
+
+/// A skeleton placeholder shaped like a [ListTile]: a leading square, a wide
+/// title line, and a shorter subtitle line.
+class AppSkeletonListTile extends StatelessWidget {
+  const AppSkeletonListTile({super.key, this.hasLeading = true});
+
+  /// Whether to render the leading square placeholder.
+  final bool hasLeading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.lg,
+        vertical: AppSpacing.md,
+      ),
+      child: Row(
+        children: [
+          if (hasLeading) ...[
+            const AppSkeleton(width: 40, height: 40),
+            const SizedBox(width: AppSpacing.lg),
+          ],
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AppSkeleton.line(width: 180),
+                SizedBox(height: AppSpacing.sm),
+                AppSkeleton.line(width: 120),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// A shimmering list of [AppSkeletonListTile]s for full-screen list loading.
+class AppSkeletonList extends StatelessWidget {
+  const AppSkeletonList({super.key, this.itemCount = 8, this.hasLeading = true});
+
+  final int itemCount;
+  final bool hasLeading;
+
+  @override
+  Widget build(BuildContext context) {
+    return AppShimmer(
+      child: ListView.separated(
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: itemCount,
+        separatorBuilder: (_, _) => const Divider(height: 1),
+        itemBuilder: (_, _) => AppSkeletonListTile(hasLeading: hasLeading),
+      ),
+    );
+  }
+}

--- a/lib/core/widgets/widgets.dart
+++ b/lib/core/widgets/widgets.dart
@@ -10,5 +10,6 @@ export 'app_loading.dart';
 export 'app_network_image.dart';
 export 'app_photo_view.dart';
 export 'app_scaffold.dart';
+export 'app_skeleton.dart';
 export 'app_slidable.dart';
 export 'app_text_field.dart';

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_widgets.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_widgets.dart
@@ -169,7 +169,7 @@ class _BookmarksListViewState extends State<BookmarksListView> {
           child: BlocBuilder<BookmarksListBloc, BookmarksListState>(
             builder: (context, state) {
               if (state.isLoading && state.items.isEmpty) {
-                return const AppLoading();
+                return const AppSkeletonList(hasLeading: false);
               }
               if (state.failure != null && state.items.isEmpty) {
                 return AppErrorView(

--- a/lib/features/splash/presentation/widgets/splash_widgets.dart
+++ b/lib/features/splash/presentation/widgets/splash_widgets.dart
@@ -1,31 +1,97 @@
 import 'package:flutter/material.dart';
 
+import '../../../../core/animation/app_durations.dart';
+import '../../../../core/animation/widget_animations.dart';
 import '../../../../core/build_context_extensions.dart';
 import '../../../../core/theme/app_spacing.dart';
+import '../../../../gen/assets.gen.dart';
 
 class SplashContent extends StatelessWidget {
   const SplashContent({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = context.colorScheme;
     return Scaffold(
-      backgroundColor: context.colorScheme.surface,
+      backgroundColor: colorScheme.surface,
       body: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
+            Container(
+              padding: const EdgeInsets.all(AppSpacing.xl),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(28),
+                boxShadow: [
+                  BoxShadow(
+                    color: colorScheme.shadow.withValues(alpha: 0.15),
+                    blurRadius: 30,
+                    offset: const Offset(0, 12),
+                  ),
+                ],
+              ),
+              child: Assets.icons.logo.svg(width: 72, height: 72),
+            ).animateScale(),
+            const SizedBox(height: AppSpacing.xxl),
             Text(
               context.l10n.appTitle,
               style: context.textTheme.headlineSmall?.copyWith(
-                color: context.colorScheme.onSurface,
+                color: colorScheme.onSurface,
                 fontWeight: FontWeight.w600,
               ),
-            ),
-            const SizedBox(height: AppSpacing.xxl),
-            CircularProgressIndicator(color: context.colorScheme.primary),
+            ).animateSlideUp(delay: AppDurations.medium),
+            const SizedBox(height: AppSpacing.xxxl),
+            const _LoadingDots().animateFadeIn(delay: AppDurations.slow),
           ],
         ),
       ),
     );
+  }
+}
+
+/// Three dots that pulse in sequence, a softer loading cue than a spinner.
+class _LoadingDots extends StatelessWidget {
+  const _LoadingDots();
+
+  static const int _count = 3;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = context.colorScheme.primary;
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var i = 0; i < _count; i++) ...[
+          if (i > 0) const SizedBox(width: AppSpacing.sm),
+          _Dot(color: color, delay: Duration(milliseconds: i * 160)),
+        ],
+      ],
+    );
+  }
+}
+
+class _Dot extends StatelessWidget {
+  const _Dot({required this.color, required this.delay});
+
+  final Color color;
+  final Duration delay;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+          width: 10,
+          height: 10,
+          decoration: BoxDecoration(color: color, shape: BoxShape.circle),
+        )
+        .animate(onPlay: (controller) => controller.repeat(reverse: true))
+        .scaleXY(
+          begin: 0.6,
+          end: 1,
+          duration: AppDurations.xslow,
+          delay: delay,
+          curve: Curves.easeInOut,
+        )
+        .fadeIn(begin: 0.4, duration: AppDurations.xslow);
   }
 }

--- a/lib/features/splash/presentation/widgets/splash_widgets.dart
+++ b/lib/features/splash/presentation/widgets/splash_widgets.dart
@@ -64,7 +64,10 @@ class _LoadingDots extends StatelessWidget {
       children: [
         for (var i = 0; i < _count; i++) ...[
           if (i > 0) const SizedBox(width: AppSpacing.sm),
-          _Dot(color: color, delay: Duration(milliseconds: i * 160)),
+          _Dot(
+            color: color,
+            delay: Duration(milliseconds: i * 160),
+          ),
         ],
       ],
     );

--- a/test/core/widgets/app_adaptive_scaffold_test.dart
+++ b/test/core/widgets/app_adaptive_scaffold_test.dart
@@ -8,7 +8,11 @@ void main() {
     AppDestination(icon: Icons.settings, label: 'Settings'),
   ];
 
-  Future<void> pumpAt(WidgetTester tester, double width) async {
+  Future<void> pumpAt(
+    WidgetTester tester,
+    double width, {
+    ValueChanged<int>? onDestinationSelected,
+  }) async {
     tester.view.physicalSize = Size(width, 800);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.reset);
@@ -17,7 +21,7 @@ void main() {
         home: AppAdaptiveScaffold(
           destinations: destinations,
           selectedIndex: 0,
-          onDestinationSelected: (_) {},
+          onDestinationSelected: onDestinationSelected ?? (_) {},
           body: const Center(child: Text('body')),
         ),
       ),
@@ -25,11 +29,19 @@ void main() {
   }
 
   group('AppAdaptiveScaffold', () {
-    testWidgets('compact width uses a bottom NavigationBar', (tester) async {
-      await pumpAt(tester, 500);
+    testWidgets('compact width uses a floating bottom bar, not a rail', (
+      tester,
+    ) async {
+      int? selected;
+      await pumpAt(tester, 500, onDestinationSelected: (i) => selected = i);
 
-      expect(find.byType(NavigationBar), findsOneWidget);
       expect(find.byType(NavigationRail), findsNothing);
+      // The selected destination reveals its label.
+      expect(find.text('Home'), findsOneWidget);
+
+      // Tapping another destination reports its index.
+      await tester.tap(find.byIcon(Icons.settings));
+      expect(selected, 1);
     });
 
     testWidgets('medium width uses a collapsed NavigationRail', (tester) async {


### PR DESCRIPTION
## Summary

UI polish across three areas, all dependency-free (reuses existing `flutter_animate`, `flutter_svg`/`flutter_gen`, and the app's spacing/duration tokens).

### 1. Floating bottom navigation bar
- Replaces the stock compact `NavigationBar` with a custom floating, pill-shaped bar (`_FloatingBottomBar`).
- The selected destination expands into a tinted pill revealing its label; others collapse to icons, with animated icon cross-fade and label slide/fade.
- Theme-aware (`ColorScheme`), accessible (`Semantics` + `InkWell` ripple). `NavigationRail` for medium/expanded widths is unchanged; public API of `AppAdaptiveScaffold` is unchanged.

### 2. Shimmer / skeleton loading (`app_skeleton.dart`)
- `AppShimmer` — animated highlight sweep via `ShaderMask`, theme-aware, with an `enabled` toggle.
- `AppSkeleton` — shape primitives (`.line`, `.circle`, block) plus `AppSkeletonListTile` and a ready-to-use `AppSkeletonList`.
- Wired into the Bookmarks list initial-load state in place of `AppLoading`.

### 3. Friendlier splash screen
- App logo in a soft-shadowed rounded card with an elastic scale-in entrance.
- Animated title and a sequential pulsing three-dot loader replacing the bare `CircularProgressIndicator`.

## Testing
- `dart analyze` clean on all touched files.
- Manual: verified the bottom bar fixed-height layout and edge-item selection (no stray edge gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)