### PR TITLE
feat(auth): add delete account feature

### DIFF
--- a/lib/core/analytics/analytics_events.dart
+++ b/lib/core/analytics/analytics_events.dart
@@ -1,6 +1,7 @@
 abstract final class AnalyticsEvents {
   static const loginFailed = 'login_failed';
   static const signOut = 'sign_out';
+  static const accountDeleted = 'account_deleted';
   static const themeModeChanged = 'theme_mode_changed';
   static const themeSchemeChanged = 'theme_scheme_changed';
   static const bookmarkViewed = 'bookmark_viewed';

--- a/lib/core/analytics/analytics_extensions.dart
+++ b/lib/core/analytics/analytics_extensions.dart
@@ -12,6 +12,9 @@ extension AuthAnalytics on AnalyticsService {
   }
 
   Future<void> trackSignOut() => logEvent(AnalyticsEvents.signOut);
+
+  Future<void> trackAccountDeleted() =>
+      logEvent(AnalyticsEvents.accountDeleted);
 }
 
 extension ThemeAnalytics on AnalyticsService {

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -60,6 +60,8 @@ import 'package:flutter_starter_template/features/auth/domain/repositories/auth_
     as _i987;
 import 'package:flutter_starter_template/features/auth/domain/usecases/change_password.dart'
     as _i780;
+import 'package:flutter_starter_template/features/auth/domain/usecases/delete_account.dart'
+    as _i625;
 import 'package:flutter_starter_template/features/auth/domain/usecases/register.dart'
     as _i699;
 import 'package:flutter_starter_template/features/auth/domain/usecases/restore_session.dart'
@@ -72,6 +74,8 @@ import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_bl
     as _i269;
 import 'package:flutter_starter_template/features/auth/presentation/bloc/change_password_cubit.dart'
     as _i11;
+import 'package:flutter_starter_template/features/auth/presentation/bloc/delete_account_cubit.dart'
+    as _i329;
 import 'package:flutter_starter_template/features/bookmarks/data/datasources/bookmarks_remote_data_source.dart'
     as _i729;
 import 'package:flutter_starter_template/features/bookmarks/data/datasources/bookmarks_remote_module.dart'
@@ -250,6 +254,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i780.ChangePassword>(
       () => _i780.ChangePassword(gh<_i987.AuthRepository>()),
     );
+    gh.factory<_i625.DeleteAccount>(
+      () => _i625.DeleteAccount(gh<_i987.AuthRepository>()),
+    );
     gh.factory<_i699.Register>(
       () => _i699.Register(gh<_i987.AuthRepository>()),
     );
@@ -267,6 +274,12 @@ extension GetItInjectableX on _i174.GetIt {
     );
     gh.factory<_i11.ChangePasswordCubit>(
       () => _i11.ChangePasswordCubit(gh<_i780.ChangePassword>()),
+    );
+    gh.factory<_i329.DeleteAccountCubit>(
+      () => _i329.DeleteAccountCubit(
+        gh<_i625.DeleteAccount>(),
+        gh<_i838.AnalyticsService>(),
+      ),
     );
     gh.lazySingleton<_i269.AuthBloc>(
       () => _i269.AuthBloc(

--- a/lib/features/auth/data/datasources/auth_remote_data_source.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.dart
@@ -25,4 +25,7 @@ abstract class AuthRemoteDataSource {
 
   @POST('/api/auth/sign-out')
   Future<void> signOut(@Body() RefreshTokenRequest body);
+
+  @DELETE('/api/auth/account')
+  Future<void> deleteAccount();
 }

--- a/lib/features/auth/data/datasources/auth_remote_data_source.g.dart
+++ b/lib/features/auth/data/datasources/auth_remote_data_source.g.dart
@@ -115,6 +115,25 @@ class _AuthRemoteDataSource implements AuthRemoteDataSource {
     await _dio.fetch<void>(_options);
   }
 
+  @override
+  Future<void> deleteAccount() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<void>(
+      Options(method: 'DELETE', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/auth/account',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
+  }
+
   RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
     if (T != dynamic &&
         !(requestOptions.responseType == ResponseType.bytes ||

--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -100,6 +100,19 @@ class AuthRepositoryImpl implements AuthRepository {
   }
 
   @override
+  Future<Result<void>> deleteAccount() async {
+    try {
+      await _remote.deleteAccount();
+      // Only drop the local session once the server confirms deletion, so a
+      // failed request leaves the user signed in to retry.
+      await _local.clearSession();
+      return const Ok(null);
+    } on DioException catch (e) {
+      return Err(_mapDioError(e));
+    }
+  }
+
+  @override
   Future<Result<AuthUser>> restoreSession() async {
     await _local.load();
     final user = _local.currentUser;

--- a/lib/features/auth/domain/repositories/auth_repository.dart
+++ b/lib/features/auth/domain/repositories/auth_repository.dart
@@ -19,6 +19,11 @@ abstract interface class AuthRepository {
 
   Future<Result<void>> signOut();
 
+  /// Permanently deletes the current account on the server and clears the
+  /// local session. Unlike [signOut], the local session is only cleared when
+  /// the server confirms the deletion, so a failure leaves the user signed in.
+  Future<Result<void>> deleteAccount();
+
   /// Loads any persisted session and attempts to refresh its access token.
   /// Returns `Ok(user)` if a valid session can be restored, otherwise `Err`.
   Future<Result<AuthUser>> restoreSession();

--- a/lib/features/auth/domain/usecases/delete_account.dart
+++ b/lib/features/auth/domain/usecases/delete_account.dart
@@ -1,0 +1,17 @@
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/usecases/use_case.dart';
+import '../../../../core/utils/result.dart';
+import '../repositories/auth_repository.dart';
+
+@injectable
+class DeleteAccount extends NoParamUseCase<void> {
+  const DeleteAccount(this._repository);
+
+  final AuthRepository _repository;
+
+  @override
+  Future<Result<void>> call([NoParams param = noParams]) {
+    return runResultGuarded(_repository.deleteAccount);
+  }
+}

--- a/lib/features/auth/presentation/bloc/delete_account_cubit.dart
+++ b/lib/features/auth/presentation/bloc/delete_account_cubit.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/analytics/analytics_extensions.dart';
+import '../../../../core/analytics/analytics_service.dart';
+import '../../../../core/future_extensions.dart';
+import '../../../../core/utils/result.dart';
+import '../../domain/usecases/delete_account.dart';
+import 'delete_account_state.dart';
+
+@injectable
+class DeleteAccountCubit extends Cubit<DeleteAccountState> {
+  DeleteAccountCubit(this._deleteAccount, this._analytics)
+    : super(const DeleteAccountState.initial());
+
+  final DeleteAccount _deleteAccount;
+  final AnalyticsService _analytics;
+
+  Future<void> submit() async {
+    if (state is DeleteAccountSubmitting) return;
+
+    emit(const DeleteAccountState.submitting());
+
+    final result = await _deleteAccount();
+
+    switch (result) {
+      case Ok():
+        _analytics.trackAccountDeleted().uw();
+        _analytics.setCurrentUser(null).uw();
+        emit(const DeleteAccountState.success());
+      case Err(:final failure):
+        emit(DeleteAccountState.failure(failure));
+    }
+  }
+}

--- a/lib/features/auth/presentation/bloc/delete_account_state.dart
+++ b/lib/features/auth/presentation/bloc/delete_account_state.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/error/failure.dart';
+
+part 'delete_account_state.freezed.dart';
+
+@freezed
+sealed class DeleteAccountState with _$DeleteAccountState {
+  const factory DeleteAccountState.initial() = DeleteAccountInitial;
+  const factory DeleteAccountState.submitting() = DeleteAccountSubmitting;
+  const factory DeleteAccountState.success() = DeleteAccountSuccess;
+  const factory DeleteAccountState.failure(Failure failure) =
+      DeleteAccountFailure;
+}

--- a/lib/features/auth/presentation/bloc/delete_account_state.freezed.dart
+++ b/lib/features/auth/presentation/bloc/delete_account_state.freezed.dart
@@ -1,0 +1,348 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'delete_account_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$DeleteAccountState {
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeleteAccountState);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'DeleteAccountState()';
+}
+
+
+}
+
+/// @nodoc
+class $DeleteAccountStateCopyWith<$Res>  {
+$DeleteAccountStateCopyWith(DeleteAccountState _, $Res Function(DeleteAccountState) __);
+}
+
+
+/// Adds pattern-matching-related methods to [DeleteAccountState].
+extension DeleteAccountStatePatterns on DeleteAccountState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>({TResult Function( DeleteAccountInitial value)?  initial,TResult Function( DeleteAccountSubmitting value)?  submitting,TResult Function( DeleteAccountSuccess value)?  success,TResult Function( DeleteAccountFailure value)?  failure,required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case DeleteAccountInitial() when initial != null:
+return initial(_that);case DeleteAccountSubmitting() when submitting != null:
+return submitting(_that);case DeleteAccountSuccess() when success != null:
+return success(_that);case DeleteAccountFailure() when failure != null:
+return failure(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>({required TResult Function( DeleteAccountInitial value)  initial,required TResult Function( DeleteAccountSubmitting value)  submitting,required TResult Function( DeleteAccountSuccess value)  success,required TResult Function( DeleteAccountFailure value)  failure,}){
+final _that = this;
+switch (_that) {
+case DeleteAccountInitial():
+return initial(_that);case DeleteAccountSubmitting():
+return submitting(_that);case DeleteAccountSuccess():
+return success(_that);case DeleteAccountFailure():
+return failure(_that);}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>({TResult? Function( DeleteAccountInitial value)?  initial,TResult? Function( DeleteAccountSubmitting value)?  submitting,TResult? Function( DeleteAccountSuccess value)?  success,TResult? Function( DeleteAccountFailure value)?  failure,}){
+final _that = this;
+switch (_that) {
+case DeleteAccountInitial() when initial != null:
+return initial(_that);case DeleteAccountSubmitting() when submitting != null:
+return submitting(_that);case DeleteAccountSuccess() when success != null:
+return success(_that);case DeleteAccountFailure() when failure != null:
+return failure(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>({TResult Function()?  initial,TResult Function()?  submitting,TResult Function()?  success,TResult Function( Failure failure)?  failure,required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case DeleteAccountInitial() when initial != null:
+return initial();case DeleteAccountSubmitting() when submitting != null:
+return submitting();case DeleteAccountSuccess() when success != null:
+return success();case DeleteAccountFailure() when failure != null:
+return failure(_that.failure);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>({required TResult Function()  initial,required TResult Function()  submitting,required TResult Function()  success,required TResult Function( Failure failure)  failure,}) {final _that = this;
+switch (_that) {
+case DeleteAccountInitial():
+return initial();case DeleteAccountSubmitting():
+return submitting();case DeleteAccountSuccess():
+return success();case DeleteAccountFailure():
+return failure(_that.failure);}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>({TResult? Function()?  initial,TResult? Function()?  submitting,TResult? Function()?  success,TResult? Function( Failure failure)?  failure,}) {final _that = this;
+switch (_that) {
+case DeleteAccountInitial() when initial != null:
+return initial();case DeleteAccountSubmitting() when submitting != null:
+return submitting();case DeleteAccountSuccess() when success != null:
+return success();case DeleteAccountFailure() when failure != null:
+return failure(_that.failure);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class DeleteAccountInitial implements DeleteAccountState {
+  const DeleteAccountInitial();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeleteAccountInitial);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'DeleteAccountState.initial()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class DeleteAccountSubmitting implements DeleteAccountState {
+  const DeleteAccountSubmitting();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeleteAccountSubmitting);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'DeleteAccountState.submitting()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class DeleteAccountSuccess implements DeleteAccountState {
+  const DeleteAccountSuccess();
+  
+
+
+
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeleteAccountSuccess);
+}
+
+
+@override
+int get hashCode => runtimeType.hashCode;
+
+@override
+String toString() {
+  return 'DeleteAccountState.success()';
+}
+
+
+}
+
+
+
+
+/// @nodoc
+
+
+class DeleteAccountFailure implements DeleteAccountState {
+  const DeleteAccountFailure(this.failure);
+  
+
+ final  Failure failure;
+
+/// Create a copy of DeleteAccountState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$DeleteAccountFailureCopyWith<DeleteAccountFailure> get copyWith => _$DeleteAccountFailureCopyWithImpl<DeleteAccountFailure>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is DeleteAccountFailure&&(identical(other.failure, failure) || other.failure == failure));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,failure);
+
+@override
+String toString() {
+  return 'DeleteAccountState.failure(failure: $failure)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $DeleteAccountFailureCopyWith<$Res> implements $DeleteAccountStateCopyWith<$Res> {
+  factory $DeleteAccountFailureCopyWith(DeleteAccountFailure value, $Res Function(DeleteAccountFailure) _then) = _$DeleteAccountFailureCopyWithImpl;
+@useResult
+$Res call({
+ Failure failure
+});
+
+
+
+
+}
+/// @nodoc
+class _$DeleteAccountFailureCopyWithImpl<$Res>
+    implements $DeleteAccountFailureCopyWith<$Res> {
+  _$DeleteAccountFailureCopyWithImpl(this._self, this._then);
+
+  final DeleteAccountFailure _self;
+  final $Res Function(DeleteAccountFailure) _then;
+
+/// Create a copy of DeleteAccountState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') $Res call({Object? failure = null,}) {
+  return _then(DeleteAccountFailure(
+null == failure ? _self.failure : failure // ignore: cast_nullable_to_non_nullable
+as Failure,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/profile/presentation/screens/profile_screen.dart
+++ b/lib/features/profile/presentation/screens/profile_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../../../core/di/injection.dart';
+import '../../../auth/presentation/bloc/delete_account_cubit.dart';
 import '../bloc/profile_bloc.dart';
 import '../widgets/profile_widgets.dart';
 
@@ -10,8 +11,15 @@ class ProfileScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<ProfileBloc>(
-      create: (_) => getIt<ProfileBloc>()..add(const ProfileLoaded()),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<ProfileBloc>(
+          create: (_) => getIt<ProfileBloc>()..add(const ProfileLoaded()),
+        ),
+        BlocProvider<DeleteAccountCubit>(
+          create: (_) => getIt<DeleteAccountCubit>(),
+        ),
+      ],
       child: const ProfileBody(),
     );
   }

--- a/lib/features/profile/presentation/widgets/profile_widgets.dart
+++ b/lib/features/profile/presentation/widgets/profile_widgets.dart
@@ -19,41 +19,65 @@ import '../../../../core/widgets/widgets.dart';
 import '../../../auth/domain/entities/auth_user.dart';
 import '../../../auth/presentation/bloc/auth_bloc.dart';
 import '../../../auth/presentation/bloc/auth_state.dart';
+import '../../../auth/presentation/bloc/delete_account_cubit.dart';
+import '../../../auth/presentation/bloc/delete_account_state.dart';
 import '../bloc/profile_bloc.dart';
 import '../bloc/profile_state.dart';
 
 class ProfileBody extends StatelessWidget {
   const ProfileBody({super.key});
 
+  void _onDeleteAccountState(BuildContext context, DeleteAccountState state) {
+    switch (state) {
+      case DeleteAccountSuccess():
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.profileDeleteAccountSuccess)),
+        );
+        // Clearing the session flips AuthBloc to initial, so the router
+        // redirects to the login screen.
+        context.read<AuthBloc>().add(const AuthSessionCleared());
+      case DeleteAccountFailure():
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.profileDeleteAccountError)),
+        );
+      case DeleteAccountInitial() || DeleteAccountSubmitting():
+        break;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
-    return AppScaffold(
-      title: context.l10n.profileAppBarTitle,
-      padding: EdgeInsets.zero,
-      body: ListView(
-        padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
-        children: [
-          const _ProfileHeader(),
-          const SizedBox(height: AppSpacing.xxl),
-          _SectionLabel(
-            context.l10n.profileSectionAccount,
-          ).animateSlideRight(delay: 300.ms),
-          const _ChangePasswordTile().animateSlideRight(delay: 325.ms),
-          const SizedBox(height: AppSpacing.xxl),
-          _SectionLabel(
-            context.l10n.profileSectionAppearance,
-          ).animateSlideRight(delay: 350.ms),
-          const _ThemeModeSelector().animateSlideRight(delay: 375.ms),
-          const SizedBox(height: AppSpacing.sm),
-          const _ColorSchemeSelector().animateSlideRight(delay: 400.ms),
-          const SizedBox(height: AppSpacing.xxl),
-          _SectionLabel(
-            context.l10n.profileSectionAbout,
-          ).animateSlideRight(delay: 425.ms),
-          const _AppInfoTile().animateSlideRight(delay: 450.ms),
-          const SizedBox(height: AppSpacing.xxxl),
-          const _SignOutButton().animateSlideUp(delay: 500.ms),
-        ],
+    return BlocListener<DeleteAccountCubit, DeleteAccountState>(
+      listener: _onDeleteAccountState,
+      child: AppScaffold(
+        title: context.l10n.profileAppBarTitle,
+        padding: EdgeInsets.zero,
+        body: ListView(
+          padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
+          children: [
+            const _ProfileHeader(),
+            const SizedBox(height: AppSpacing.xxl),
+            _SectionLabel(
+              context.l10n.profileSectionAccount,
+            ).animateSlideRight(delay: 300.ms),
+            const _ChangePasswordTile().animateSlideRight(delay: 325.ms),
+            const _DeleteAccountTile().animateSlideRight(delay: 340.ms),
+            const SizedBox(height: AppSpacing.xxl),
+            _SectionLabel(
+              context.l10n.profileSectionAppearance,
+            ).animateSlideRight(delay: 350.ms),
+            const _ThemeModeSelector().animateSlideRight(delay: 375.ms),
+            const SizedBox(height: AppSpacing.sm),
+            const _ColorSchemeSelector().animateSlideRight(delay: 400.ms),
+            const SizedBox(height: AppSpacing.xxl),
+            _SectionLabel(
+              context.l10n.profileSectionAbout,
+            ).animateSlideRight(delay: 425.ms),
+            const _AppInfoTile().animateSlideRight(delay: 450.ms),
+            const SizedBox(height: AppSpacing.xxxl),
+            const _SignOutButton().animateSlideUp(delay: 500.ms),
+          ],
+        ),
       ),
     );
   }
@@ -182,6 +206,107 @@ class _ChangePasswordTile extends StatelessWidget {
       onTap: () {
         const ChangePasswordRoute().push<void>(context);
       },
+    );
+  }
+}
+
+class _DeleteAccountTile extends StatelessWidget {
+  const _DeleteAccountTile();
+
+  @override
+  Widget build(BuildContext context) {
+    final error = Theme.of(context).colorScheme.error;
+    return BlocBuilder<DeleteAccountCubit, DeleteAccountState>(
+      builder: (context, state) {
+        final isSubmitting = state is DeleteAccountSubmitting;
+        return ListTile(
+          leading: Icon(Icons.delete_forever, color: error),
+          title: Text(
+            context.l10n.profileDeleteAccount,
+            style: TextStyle(color: error),
+          ),
+          trailing: isSubmitting
+              ? const SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : null,
+          onTap: isSubmitting ? null : () => _confirmAndDelete(context),
+        );
+      },
+    );
+  }
+
+  Future<void> _confirmAndDelete(BuildContext context) async {
+    final username = switch (context.read<AuthBloc>().state) {
+      AuthAuthenticated(:final user) ||
+      AuthSigningOut(:final user) => user.username,
+      _ => null,
+    };
+    if (username == null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (_) => _DeleteAccountDialog(username: username),
+    );
+    if (confirmed == true && context.mounted) {
+      await context.read<DeleteAccountCubit>().submit();
+    }
+  }
+}
+
+/// Confirmation dialog that requires the user to type their username before
+/// the destructive delete button becomes enabled.
+class _DeleteAccountDialog extends StatefulWidget {
+  const _DeleteAccountDialog({required this.username});
+
+  final String username;
+
+  @override
+  State<_DeleteAccountDialog> createState() => _DeleteAccountDialogState();
+}
+
+class _DeleteAccountDialogState extends State<_DeleteAccountDialog> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = context.l10n;
+    final canDelete = _controller.text.trim() == widget.username;
+    return AlertDialog(
+      title: Text(l10n.profileDeleteAccountDialogTitle),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(l10n.profileDeleteAccountDialogMessage),
+          const SizedBox(height: AppSpacing.lg),
+          AppTextField(
+            controller: _controller,
+            label: l10n.profileDeleteAccountConfirmLabel(widget.username),
+            autofocus: true,
+            onChanged: (_) => setState(() {}),
+          ),
+        ],
+      ),
+      actions: [
+        AppButton(
+          label: l10n.commonCancel,
+          variant: AppButtonVariant.text,
+          onPressed: () => Navigator.of(context).pop(false),
+        ),
+        AppButton(
+          label: l10n.commonDelete,
+          variant: AppButtonVariant.tonal,
+          onPressed: canDelete ? () => Navigator.of(context).pop(true) : null,
+        ),
+      ],
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -52,6 +52,20 @@
   "profileSectionAppearance": "Appearance",
   "profileSectionAccount": "Account",
   "profileChangePassword": "Change Password",
+  "profileDeleteAccount": "Delete Account",
+  "profileDeleteAccountDialogTitle": "Delete account?",
+  "profileDeleteAccountDialogMessage": "This permanently removes your account and all of its data. This action cannot be undone.",
+  "profileDeleteAccountConfirmLabel": "Type \"{username}\" to confirm",
+  "@profileDeleteAccountConfirmLabel": {
+    "placeholders": {
+      "username": {
+        "type": "String",
+        "example": "alice"
+      }
+    }
+  },
+  "profileDeleteAccountSuccess": "Your account has been deleted.",
+  "profileDeleteAccountError": "Couldn't delete your account. Please try again.",
   "changePasswordAppBarTitle": "Change Password",
   "changePasswordCurrentLabel": "Current Password",
   "changePasswordNewLabel": "New Password",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -362,6 +362,42 @@ abstract class AppLocalizations {
   /// **'Change Password'**
   String get profileChangePassword;
 
+  /// No description provided for @profileDeleteAccount.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete Account'**
+  String get profileDeleteAccount;
+
+  /// No description provided for @profileDeleteAccountDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete account?'**
+  String get profileDeleteAccountDialogTitle;
+
+  /// No description provided for @profileDeleteAccountDialogMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'This permanently removes your account and all of its data. This action cannot be undone.'**
+  String get profileDeleteAccountDialogMessage;
+
+  /// No description provided for @profileDeleteAccountConfirmLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Type \"{username}\" to confirm'**
+  String profileDeleteAccountConfirmLabel(String username);
+
+  /// No description provided for @profileDeleteAccountSuccess.
+  ///
+  /// In en, this message translates to:
+  /// **'Your account has been deleted.'**
+  String get profileDeleteAccountSuccess;
+
+  /// No description provided for @profileDeleteAccountError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t delete your account. Please try again.'**
+  String get profileDeleteAccountError;
+
   /// No description provided for @changePasswordAppBarTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -143,6 +143,28 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileChangePassword => 'Change Password';
 
   @override
+  String get profileDeleteAccount => 'Delete Account';
+
+  @override
+  String get profileDeleteAccountDialogTitle => 'Delete account?';
+
+  @override
+  String get profileDeleteAccountDialogMessage =>
+      'This permanently removes your account and all of its data. This action cannot be undone.';
+
+  @override
+  String profileDeleteAccountConfirmLabel(String username) {
+    return 'Type \"$username\" to confirm';
+  }
+
+  @override
+  String get profileDeleteAccountSuccess => 'Your account has been deleted.';
+
+  @override
+  String get profileDeleteAccountError =>
+      'Couldn\'t delete your account. Please try again.';
+
+  @override
   String get changePasswordAppBarTitle => 'Change Password';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -144,6 +144,28 @@ class AppLocalizationsVi extends AppLocalizations {
   String get profileChangePassword => 'Đổi mật khẩu';
 
   @override
+  String get profileDeleteAccount => 'Xóa tài khoản';
+
+  @override
+  String get profileDeleteAccountDialogTitle => 'Xóa tài khoản?';
+
+  @override
+  String get profileDeleteAccountDialogMessage =>
+      'Thao tác này sẽ xóa vĩnh viễn tài khoản và toàn bộ dữ liệu của bạn. Không thể hoàn tác.';
+
+  @override
+  String profileDeleteAccountConfirmLabel(String username) {
+    return 'Nhập \"$username\" để xác nhận';
+  }
+
+  @override
+  String get profileDeleteAccountSuccess => 'Tài khoản của bạn đã được xóa.';
+
+  @override
+  String get profileDeleteAccountError =>
+      'Không thể xóa tài khoản. Vui lòng thử lại.';
+
+  @override
   String get changePasswordAppBarTitle => 'Đổi mật khẩu';
 
   @override

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -44,6 +44,20 @@
   "profileSectionAppearance": "Giao diện",
   "profileSectionAccount": "Tài khoản",
   "profileChangePassword": "Đổi mật khẩu",
+  "profileDeleteAccount": "Xóa tài khoản",
+  "profileDeleteAccountDialogTitle": "Xóa tài khoản?",
+  "profileDeleteAccountDialogMessage": "Thao tác này sẽ xóa vĩnh viễn tài khoản và toàn bộ dữ liệu của bạn. Không thể hoàn tác.",
+  "profileDeleteAccountConfirmLabel": "Nhập \"{username}\" để xác nhận",
+  "@profileDeleteAccountConfirmLabel": {
+    "placeholders": {
+      "username": {
+        "type": "String",
+        "example": "alice"
+      }
+    }
+  },
+  "profileDeleteAccountSuccess": "Tài khoản của bạn đã được xóa.",
+  "profileDeleteAccountError": "Không thể xóa tài khoản. Vui lòng thử lại.",
   "changePasswordAppBarTitle": "Đổi mật khẩu",
   "changePasswordCurrentLabel": "Mật khẩu hiện tại",
   "changePasswordNewLabel": "Mật khẩu mới",

--- a/test/features/auth/data/repositories/auth_repository_impl_test.dart
+++ b/test/features/auth/data/repositories/auth_repository_impl_test.dart
@@ -188,6 +188,33 @@ void main() {
     });
   });
 
+  group('deleteAccount', () {
+    test('clears local session and returns Ok on success', () async {
+      when(() => mockRemote.deleteAccount()).thenAnswer((_) async {});
+      when(() => mockLocal.clearSession()).thenAnswer((_) async {});
+
+      final result = await repository.deleteAccount();
+
+      expect(result, isA<Ok<void>>());
+      verify(() => mockLocal.clearSession()).called(1);
+    });
+
+    test('keeps session and returns Err when server call fails', () async {
+      when(() => mockRemote.deleteAccount()).thenThrow(
+        DioException(
+          requestOptions: RequestOptions(path: '/api/auth/account'),
+          message: 'Network error',
+        ),
+      );
+
+      final result = await repository.deleteAccount();
+
+      expect(result, isA<Err<void>>());
+      expect((result as Err<void>).failure, isA<UnknownFailure>());
+      verifyNever(() => mockLocal.clearSession());
+    });
+  });
+
   group('restoreSession', () {
     setUp(() {
       when(() => mockLocal.load()).thenAnswer((_) async {});

--- a/test/features/auth/presentation/bloc/delete_account_cubit_test.dart
+++ b/test/features/auth/presentation/bloc/delete_account_cubit_test.dart
@@ -1,0 +1,89 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_starter_template/core/utils/result.dart';
+import 'package:flutter_starter_template/features/auth/presentation/bloc/delete_account_cubit.dart';
+import 'package:flutter_starter_template/features/auth/presentation/bloc/delete_account_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../test_utils.dart';
+
+void main() {
+  late MockDeleteAccount mockDeleteAccount;
+  late MockAnalyticsService mockAnalytics;
+
+  setUp(() {
+    mockDeleteAccount = MockDeleteAccount();
+    mockAnalytics = MockAnalyticsService();
+    stubAnalyticsService(mockAnalytics);
+  });
+
+  DeleteAccountCubit buildCubit() =>
+      DeleteAccountCubit(mockDeleteAccount, mockAnalytics);
+
+  group('DeleteAccountCubit', () {
+    test('initial state is DeleteAccountInitial', () {
+      expect(buildCubit().state, const DeleteAccountState.initial());
+    });
+
+    blocTest<DeleteAccountCubit, DeleteAccountState>(
+      'emits submitting then success and tracks analytics on success',
+      build: () {
+        when(() => mockDeleteAccount()).thenAnswer((_) async => const Ok(null));
+        return buildCubit();
+      },
+      act: (cubit) => cubit.submit(),
+      expect: () => [
+        const DeleteAccountState.submitting(),
+        const DeleteAccountState.success(),
+      ],
+      verify: (_) {
+        verify(() => mockAnalytics.logEvent('account_deleted')).called(1);
+        verify(() => mockAnalytics.setCurrentUser(null)).called(1);
+      },
+    );
+
+    blocTest<DeleteAccountCubit, DeleteAccountState>(
+      'emits submitting then failure on error',
+      build: () {
+        when(
+          () => mockDeleteAccount(),
+        ).thenAnswer((_) async => const Err(testFailure));
+        return buildCubit();
+      },
+      act: (cubit) => cubit.submit(),
+      expect: () => [
+        const DeleteAccountState.submitting(),
+        const DeleteAccountState.failure(testFailure),
+      ],
+      verify: (_) {
+        verifyNever(() => mockAnalytics.logEvent('account_deleted'));
+      },
+    );
+
+    blocTest<DeleteAccountCubit, DeleteAccountState>(
+      'ignores a second submit while one is in flight',
+      build: () {
+        when(() => mockDeleteAccount()).thenAnswer(
+          (_) => Future.delayed(
+            const Duration(milliseconds: 50),
+            () => const Ok(null),
+          ),
+        );
+        return buildCubit();
+      },
+      act: (cubit) {
+        cubit
+          ..submit()
+          ..submit();
+      },
+      wait: const Duration(milliseconds: 100),
+      expect: () => [
+        const DeleteAccountState.submitting(),
+        const DeleteAccountState.success(),
+      ],
+      verify: (_) {
+        verify(() => mockDeleteAccount()).called(1);
+      },
+    );
+  });
+}

--- a/test/features/profile/presentation/widgets/delete_account_flow_test.dart
+++ b/test/features/profile/presentation/widgets/delete_account_flow_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_starter_template/core/theme/theme_bloc.dart';
+import 'package:flutter_starter_template/core/theme/theme_state.dart';
+import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_bloc.dart';
+import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_state.dart';
+import 'package:flutter_starter_template/features/auth/presentation/bloc/delete_account_cubit.dart';
+import 'package:flutter_starter_template/features/auth/presentation/bloc/delete_account_state.dart';
+import 'package:flutter_starter_template/features/profile/presentation/bloc/profile_bloc.dart';
+import 'package:flutter_starter_template/features/profile/presentation/bloc/profile_state.dart';
+import 'package:flutter_starter_template/features/profile/presentation/widgets/profile_widgets.dart';
+import 'package:flutter_starter_template/l10n/app_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../test_utils.dart';
+
+class MockAuthBloc extends Mock implements AuthBloc {}
+
+class MockThemeBloc extends Mock implements ThemeBloc {}
+
+class MockProfileBloc extends Mock implements ProfileBloc {}
+
+class MockDeleteAccountCubit extends Mock implements DeleteAccountCubit {}
+
+void main() {
+  late MockAuthBloc authBloc;
+  late MockThemeBloc themeBloc;
+  late MockProfileBloc profileBloc;
+  late MockDeleteAccountCubit deleteAccountCubit;
+
+  setUp(() {
+    authBloc = MockAuthBloc();
+    themeBloc = MockThemeBloc();
+    profileBloc = MockProfileBloc();
+    deleteAccountCubit = MockDeleteAccountCubit();
+
+    const authState = AuthState.authenticated(testUser);
+    when(() => authBloc.state).thenReturn(authState);
+    when(() => authBloc.stream).thenAnswer((_) => const Stream.empty());
+
+    const themeState = ThemeState(
+      mode: ThemeMode.system,
+      scheme: ThemeState.defaultScheme,
+    );
+    when(() => themeBloc.state).thenReturn(themeState);
+    when(() => themeBloc.stream).thenAnswer((_) => const Stream.empty());
+
+    const profileState = ProfileState();
+    when(() => profileBloc.state).thenReturn(profileState);
+    when(() => profileBloc.stream).thenAnswer((_) => const Stream.empty());
+
+    when(
+      () => deleteAccountCubit.state,
+    ).thenReturn(const DeleteAccountState.initial());
+    when(
+      () => deleteAccountCubit.stream,
+    ).thenAnswer((_) => const Stream.empty());
+    when(() => deleteAccountCubit.submit()).thenAnswer((_) async {});
+  });
+
+  Future<void> pumpProfile(WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<AuthBloc>.value(value: authBloc),
+            BlocProvider<ThemeBloc>.value(value: themeBloc),
+            BlocProvider<ProfileBloc>.value(value: profileBloc),
+            BlocProvider<DeleteAccountCubit>.value(value: deleteAccountCubit),
+          ],
+          child: const ProfileBody(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('Delete stays disabled until the username is typed', (
+    tester,
+  ) async {
+    await pumpProfile(tester);
+
+    await tester.tap(find.text('Delete Account'));
+    await tester.pumpAndSettle();
+
+    // Dialog is shown with a disabled Delete button.
+    expect(find.text('Delete account?'), findsOneWidget);
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+    verifyNever(() => deleteAccountCubit.submit());
+
+    // Wrong text keeps it disabled.
+    await tester.enterText(find.byType(TextField), 'bob');
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+    verifyNever(() => deleteAccountCubit.submit());
+  });
+
+  testWidgets('typing the username enables Delete and invokes submit', (
+    tester,
+  ) async {
+    await pumpProfile(tester);
+
+    await tester.tap(find.text('Delete Account'));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField), testUser.username);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    verify(() => deleteAccountCubit.submit()).called(1);
+  });
+}

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -2,6 +2,7 @@ import 'package:flutter_starter_template/core/analytics/analytics_service.dart';
 import 'package:flutter_starter_template/core/media/image_picker_service.dart';
 import 'package:flutter_starter_template/core/permissions/permission_service.dart';
 import 'package:flutter_starter_template/features/auth/domain/repositories/auth_repository.dart';
+import 'package:flutter_starter_template/features/auth/domain/usecases/delete_account.dart';
 import 'package:flutter_starter_template/features/auth/domain/usecases/register.dart';
 import 'package:flutter_starter_template/features/auth/domain/usecases/restore_session.dart';
 import 'package:flutter_starter_template/features/auth/domain/usecases/sign_in.dart';
@@ -21,6 +22,8 @@ class MockSignIn extends Mock implements SignIn {}
 class MockRegister extends Mock implements Register {}
 
 class MockSignOut extends Mock implements SignOut {}
+
+class MockDeleteAccount extends Mock implements DeleteAccount {}
 
 class MockRestoreSession extends Mock implements RestoreSession {}
 


### PR DESCRIPTION
## Summary

Adds a **Delete Account** feature for signed-in users, accessible from the Profile → Account section. Because deletion is irreversible, it is guarded by a **type-to-confirm dialog**: the destructive button stays disabled until the user types their username.

## Flow

1. User taps **Delete Account** in the Profile Account section.
2. A dialog explains the action is permanent and requires typing the username to enable **Delete**.
3. On confirm, `DeleteAccountCubit.submit()` calls the `DeleteAccount` use case → `AuthRepository.deleteAccount()`.
4. The repository calls `DELETE /api/auth/account` and **only clears the local session if the server confirms** — a failed request leaves the user signed in to retry.
5. On success the cubit tracks `account_deleted`, clears the analytics user, and the UI dispatches `AuthSessionCleared`, so the existing router redirect sends the user to login. On failure, a snackbar is shown and the user stays put.

## Changes

**Domain / data**
- `AuthRepository.deleteAccount()` + impl (success-gated local session clear).
- `DELETE /api/auth/account` on `AuthRemoteDataSource`.
- `DeleteAccount` use case.

**Presentation**
- `DeleteAccountCubit` + `DeleteAccountState` (initial/submitting/success/failure), mirroring `ChangePasswordCubit`.
- Profile `_DeleteAccountTile` (destructive styling, inline spinner while submitting) + type-to-confirm `_DeleteAccountDialog`.
- `ProfileScreen` now provides the cubit; `ProfileBody` listens for success/failure.

**Other**
- `account_deleted` analytics event + `trackAccountDeleted()`.
- en/vi localization for all new strings.

## Testing
- `fvm flutter analyze` → no issues
- `fvm flutter test` → all pass (245 prior + 8 new)
  - Repository: success clears session; failure keeps session + returns `Err`.
  - Cubit: success (tracks analytics) / failure / in-flight dedupe.
  - Widget: Delete disabled until username typed, then `submit()` invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)