### PR TITLE
fix(bookmarks): stop GET /api/bookmarks request storm from sync reload loop

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -108,6 +108,8 @@ import 'package:flutter_starter_template/features/bookmarks/domain/usecases/get_
     as _i690;
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_bookmarks.dart'
     as _i568;
+import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_local_bookmarks.dart'
+    as _i428;
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/update_bookmark.dart'
     as _i412;
 import 'package:flutter_starter_template/features/bookmarks/presentation/bloc/bookmark_detail/bookmark_detail_bloc.dart'
@@ -322,6 +324,9 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i568.ListBookmarks>(
       () => _i568.ListBookmarks(gh<_i630.BookmarksRepository>()),
     );
+    gh.factory<_i428.ListLocalBookmarks>(
+      () => _i428.ListLocalBookmarks(gh<_i630.BookmarksRepository>()),
+    );
     gh.factory<_i412.UpdateBookmark>(
       () => _i412.UpdateBookmark(gh<_i630.BookmarksRepository>()),
     );
@@ -346,6 +351,7 @@ extension GetItInjectableX on _i174.GetIt {
     gh.factory<_i566.BookmarksListBloc>(
       () => _i566.BookmarksListBloc(
         gh<_i568.ListBookmarks>(),
+        gh<_i428.ListLocalBookmarks>(),
         gh<_i244.DeleteBookmark>(),
         gh<_i627.BookmarksSyncController>(),
         gh<_i838.AnalyticsService>(),

--- a/lib/features/bookmarks/data/repositories/bookmarks_repository_impl.dart
+++ b/lib/features/bookmarks/data/repositories/bookmarks_repository_impl.dart
@@ -23,9 +23,15 @@ class BookmarksRepositoryImpl implements BookmarksRepository {
 
   @override
   Future<Result<List<Bookmark>>> list() async {
-    final rows = await _local.listVisible();
+    final result = await listLocal();
     // Trigger a refresh in the background; reads return immediately.
     _sync.sync().uw();
+    return result;
+  }
+
+  @override
+  Future<Result<List<Bookmark>>> listLocal() async {
+    final rows = await _local.listVisible();
     return Ok(rows.map((e) => e.toDomain()).toList(growable: false));
   }
 

--- a/lib/features/bookmarks/domain/repositories/bookmarks_repository.dart
+++ b/lib/features/bookmarks/domain/repositories/bookmarks_repository.dart
@@ -3,6 +3,12 @@ import '../entities/bookmark.dart';
 
 abstract interface class BookmarksRepository {
   Future<Result<List<Bookmark>>> list();
+
+  /// Reads the local store without triggering a background sync.
+  ///
+  /// Used for re-reads that follow a sync cycle, so reloading the freshly
+  /// pulled data does not kick off yet another sync.
+  Future<Result<List<Bookmark>>> listLocal();
   Future<Result<Bookmark>> get(String id);
   Future<Result<Bookmark>> create(BookmarkInput input);
   Future<Result<Bookmark>> update(String id, BookmarkInput input);

--- a/lib/features/bookmarks/domain/usecases/list_local_bookmarks.dart
+++ b/lib/features/bookmarks/domain/usecases/list_local_bookmarks.dart
@@ -1,0 +1,22 @@
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/usecases/use_case.dart';
+import '../../../../core/utils/result.dart';
+import '../entities/bookmark.dart';
+import '../repositories/bookmarks_repository.dart';
+
+/// Reads bookmarks from the local store without triggering a sync.
+///
+/// Used to refresh the list after a sync cycle completes, avoiding the
+/// read-triggers-sync feedback loop that `ListBookmarks` would cause.
+@injectable
+class ListLocalBookmarks extends NoParamUseCase<List<Bookmark>> {
+  const ListLocalBookmarks(this._repository);
+
+  final BookmarksRepository _repository;
+
+  @override
+  Future<Result<List<Bookmark>>> call([NoParams param = noParams]) {
+    return runResultGuarded(_repository.listLocal);
+  }
+}

--- a/lib/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_bloc.dart
+++ b/lib/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_bloc.dart
@@ -11,14 +11,20 @@ import '../../../../../core/utils/result.dart';
 import '../../../domain/services/bookmarks_sync_controller.dart';
 import '../../../domain/usecases/delete_bookmark.dart';
 import '../../../domain/usecases/list_bookmarks.dart';
+import '../../../domain/usecases/list_local_bookmarks.dart';
 import 'bookmarks_list_state.dart';
 
 part 'bookmarks_list_event.dart';
 
 @injectable
 class BookmarksListBloc extends Bloc<BookmarksListEvent, BookmarksListState> {
-  BookmarksListBloc(this._list, this._delete, this._sync, this._analytics)
-    : super(const BookmarksListState()) {
+  BookmarksListBloc(
+    this._list,
+    this._listLocal,
+    this._delete,
+    this._sync,
+    this._analytics,
+  ) : super(const BookmarksListState()) {
     on<BookmarksListLoadRequested>(
       _onLoadRequested,
       transformer: sequential(),
@@ -52,6 +58,7 @@ class BookmarksListBloc extends Bloc<BookmarksListEvent, BookmarksListState> {
   static const searchAnalyticsDebounce = Duration(milliseconds: 350);
 
   final ListBookmarks _list;
+  final ListLocalBookmarks _listLocal;
   final DeleteBookmark _delete;
   final BookmarksSyncController _sync;
   final AnalyticsService _analytics;
@@ -94,7 +101,9 @@ class BookmarksListBloc extends Bloc<BookmarksListEvent, BookmarksListState> {
     _BookmarksReloadSilentlyRequested event,
     Emitter<BookmarksListState> emit,
   ) async {
-    final result = await _list();
+    // Read local only: reloading via _list() would trigger another sync,
+    // which would emit syncing → idle and schedule another reload, looping.
+    final result = await _listLocal();
     if (result case Ok(value: final items)) {
       emit(state.copyWith(items: items));
     }

--- a/test/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_bloc_test.dart
+++ b/test/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_bloc_test.dart
@@ -13,6 +13,7 @@ import '../../../../../test_utils.dart';
 
 void main() {
   late MockListBookmarks mockList;
+  late MockListLocalBookmarks mockListLocal;
   late MockDeleteBookmark mockDelete;
   late MockBookmarksSyncController mockSync;
   late MockAnalyticsService mockAnalytics;
@@ -20,6 +21,7 @@ void main() {
 
   setUp(() {
     mockList = MockListBookmarks();
+    mockListLocal = MockListLocalBookmarks();
     mockDelete = MockDeleteBookmark();
     mockSync = MockBookmarksSyncController();
     mockAnalytics = MockAnalyticsService();
@@ -34,8 +36,13 @@ void main() {
     statusController.close();
   });
 
-  BookmarksListBloc buildBloc() =>
-      BookmarksListBloc(mockList, mockDelete, mockSync, mockAnalytics);
+  BookmarksListBloc buildBloc() => BookmarksListBloc(
+    mockList,
+    mockListLocal,
+    mockDelete,
+    mockSync,
+    mockAnalytics,
+  );
 
   group('BookmarksListBloc', () {
     test('initial state is empty', () {
@@ -77,6 +84,39 @@ void main() {
           predicate<BookmarksListState>((s) => s.isLoading),
           predicate<BookmarksListState>((s) => s.failure != null),
         ],
+      );
+    });
+
+    group('sync status', () {
+      blocTest<BookmarksListBloc, BookmarksListState>(
+        'syncing → idle reloads via listLocal without re-triggering a sync',
+        setUp: () {
+          when(
+            () => mockListLocal(),
+          ).thenAnswer((_) async => Ok([testBookmark]));
+        },
+        build: buildBloc,
+        act: (bloc) async {
+          statusController.add(BookmarksSyncStatus.syncing);
+          await Future<void>.delayed(Duration.zero);
+          statusController.add(BookmarksSyncStatus.idle);
+        },
+        expect: () => [
+          predicate<BookmarksListState>(
+            (s) => s.syncStatus == BookmarksSyncStatus.syncing,
+          ),
+          predicate<BookmarksListState>(
+            (s) => s.syncStatus == BookmarksSyncStatus.idle,
+          ),
+          predicate<BookmarksListState>((s) => s.items.length == 1),
+        ],
+        verify: (_) {
+          // The silent reload must read local only: a single listLocal() call
+          // and no list() call, otherwise list() would fire another sync and
+          // loop indefinitely.
+          verify(() => mockListLocal()).called(1);
+          verifyNever(() => mockList());
+        },
       );
     });
 

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -13,6 +13,7 @@ import 'package:flutter_starter_template/features/bookmarks/domain/usecases/crea
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/delete_bookmark.dart';
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/get_bookmark.dart';
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_bookmarks.dart';
+import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_local_bookmarks.dart';
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/update_bookmark.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -56,6 +57,8 @@ void stubAnalyticsService(MockAnalyticsService analytics) {
 }
 
 class MockListBookmarks extends Mock implements ListBookmarks {}
+
+class MockListLocalBookmarks extends Mock implements ListLocalBookmarks {}
 
 class MockGetBookmark extends Mock implements GetBookmark {}
 


### PR DESCRIPTION
## Problem

The bookmarks list endpoint was being hammered — hundreds of `GET /api/bookmarks` per second from a single client:

```
2026/05/30 08:53:03 [...i0twLp2iCc-002875] "GET http://localhost:8080/api/bookmarks HTTP/1.1" from 127.0.0.1:54555 - 200 309B in 224.125µs
... (thousands more in the same second)
```

### Root cause: a sync ↔ reload feedback loop

1. `BookmarksListBloc` reloads local data after every sync cycle by calling `_list()`.
2. `BookmarksRepositoryImpl.list()` **always** fires a fire-and-forget `_sync.sync()`.
3. The sync emits `syncing → idle` on its status stream.
4. The bloc listens to that stream and, on the `syncing → idle` transition, schedules **another** silent reload → back to step 1.

Each loop iteration's `_pull()` issues one `GET /api/bookmarks`. Against a local server each cycle takes microseconds, so the endpoint was hit continuously.

## Fix

Give the silent post-sync reload a **non-syncing** read path so refreshing the freshly-pulled data doesn't kick off another sync:

- Add `BookmarksRepository.listLocal()` — reads the local store only, no sync. `list()` now delegates to it and then triggers the background sync, so its documented behavior is unchanged.
- Add `ListLocalBookmarks` use case mirroring `ListBookmarks`.
- `BookmarksListBloc._onReloadSilentlyRequested` now uses `listLocal()`, breaking the loop while preserving `list()`'s background-refresh contract (still relied on by `HomeBloc` and pull-to-refresh).

## Testing

- New regression test: a `syncing → idle` transition reloads via `listLocal()` **exactly once** and **never** calls `list()`.
- `flutter test` bookmarks bloc + repository suites: 29/29 pass.
- `flutter analyze lib test`: no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)