### PR TITLE
fix(bookmarks): make image & camera attachments work on iOS

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -46,8 +46,18 @@ post_install do |installer|
       definitions = config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] ||= [
         '$(inherited)',
       ]
-      unless definitions.include?('PERMISSION_NOTIFICATIONS=1')
-        definitions << 'PERMISSION_NOTIFICATIONS=1'
+      # permission_handler compiles each permission in only when its macro is
+      # defined; without the macro the permission silently resolves to "denied"
+      # and its system dialog never appears (so e.g. the camera never opens).
+      # Keep this list in sync with the NS*UsageDescription keys in
+      # Runner/Info.plist.
+      %w[
+        PERMISSION_NOTIFICATIONS=1
+        PERMISSION_CAMERA=1
+        PERMISSION_MICROPHONE=1
+        PERMISSION_PHOTOS=1
+      ].each do |macro|
+        definitions << macro unless definitions.include?(macro)
       end
     end
   end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -11,6 +11,12 @@ PODS:
   - Firebase/Messaging (12.13.0):
     - Firebase/CoreOnly
     - FirebaseMessaging (~> 12.13.0)
+  - Firebase/Performance (12.13.0):
+    - Firebase/CoreOnly
+    - FirebasePerformance (~> 12.13.0)
+  - Firebase/RemoteConfig (12.13.0):
+    - Firebase/CoreOnly
+    - FirebaseRemoteConfig (~> 12.13.0)
   - firebase_analytics (12.4.1):
     - firebase_core
     - FirebaseAnalytics (= 12.13.0)
@@ -26,6 +32,16 @@ PODS:
     - Firebase/Messaging (= 12.13.0)
     - firebase_core
     - Flutter
+  - firebase_performance (0.11.4-1):
+    - Firebase/Performance (= 12.13.0)
+    - firebase_core
+    - Flutter
+  - firebase_remote_config (6.5.1):
+    - Firebase/RemoteConfig (= 12.13.0)
+    - firebase_core
+    - Flutter
+  - FirebaseABTesting (12.13.0):
+    - FirebaseCore (~> 12.13.0)
   - FirebaseAnalytics (12.13.0):
     - FirebaseAnalytics/Default (= 12.13.0)
     - FirebaseCore (~> 12.13.0)
@@ -75,6 +91,24 @@ PODS:
     - GoogleUtilities/Reachability (~> 8.1)
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
+  - FirebasePerformance (12.13.0):
+    - FirebaseCore (~> 12.13.0)
+    - FirebaseInstallations (~> 12.13.0)
+    - FirebaseRemoteConfig (~> 12.13.0)
+    - FirebaseSessions (~> 12.13.0)
+    - GoogleDataTransport (~> 10.1)
+    - GoogleUtilities/Environment (~> 8.1)
+    - GoogleUtilities/MethodSwizzler (~> 8.1)
+    - GoogleUtilities/UserDefaults (~> 8.1)
+    - nanopb (~> 3.30910.0)
+  - FirebaseRemoteConfig (12.13.0):
+    - FirebaseABTesting (~> 12.13.0)
+    - FirebaseCore (~> 12.13.0)
+    - FirebaseInstallations (~> 12.13.0)
+    - FirebaseRemoteConfigInterop (~> 12.13.0)
+    - FirebaseSharedSwift (~> 12.13.0)
+    - GoogleUtilities/Environment (~> 8.1)
+    - "GoogleUtilities/NSData+zlib (~> 8.1)"
   - FirebaseRemoteConfigInterop (12.13.0)
   - FirebaseSessions (12.13.0):
     - FirebaseCore (~> 12.13.0)
@@ -85,6 +119,7 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
+  - FirebaseSharedSwift (12.13.0)
   - Flutter (1.0.0)
   - flutter_local_notifications (0.0.1):
     - Flutter
@@ -150,6 +185,8 @@ PODS:
     - GoogleUtilities/Privacy
   - image_picker_ios (0.0.1):
     - Flutter
+  - integration_test (0.0.1):
+    - Flutter
   - nanopb (3.30910.0):
     - nanopb/decode (= 3.30910.0)
     - nanopb/encode (= 3.30910.0)
@@ -187,10 +224,13 @@ DEPENDENCIES:
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_crashlytics (from `.symlinks/plugins/firebase_crashlytics/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
+  - firebase_performance (from `.symlinks/plugins/firebase_performance/ios`)
+  - firebase_remote_config (from `.symlinks/plugins/firebase_remote_config/ios`)
   - Flutter (from `Flutter`)
   - flutter_local_notifications (from `.symlinks/plugins/flutter_local_notifications/ios`)
   - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - objectbox_flutter_libs (from `.symlinks/plugins/objectbox_flutter_libs/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
@@ -203,6 +243,7 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Firebase
+    - FirebaseABTesting
     - FirebaseAnalytics
     - FirebaseCore
     - FirebaseCoreExtension
@@ -210,8 +251,11 @@ SPEC REPOS:
     - FirebaseCrashlytics
     - FirebaseInstallations
     - FirebaseMessaging
+    - FirebasePerformance
+    - FirebaseRemoteConfig
     - FirebaseRemoteConfigInterop
     - FirebaseSessions
+    - FirebaseSharedSwift
     - GoogleAdsOnDeviceConversion
     - GoogleAppMeasurement
     - GoogleDataTransport
@@ -234,6 +278,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/firebase_crashlytics/ios"
   firebase_messaging:
     :path: ".symlinks/plugins/firebase_messaging/ios"
+  firebase_performance:
+    :path: ".symlinks/plugins/firebase_performance/ios"
+  firebase_remote_config:
+    :path: ".symlinks/plugins/firebase_remote_config/ios"
   Flutter:
     :path: Flutter
   flutter_local_notifications:
@@ -242,6 +290,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  integration_test:
+    :path: ".symlinks/plugins/integration_test/ios"
   objectbox_flutter_libs:
     :path: ".symlinks/plugins/objectbox_flutter_libs/ios"
   package_info_plus:
@@ -267,6 +317,9 @@ SPEC CHECKSUMS:
   firebase_core: 0013f886fbd0b4950865551eaab47784424bfdb5
   firebase_crashlytics: fae0a58bac6eaaef4cdacc72f9e55fef1e0be0a1
   firebase_messaging: b875e4088ddd9ecd1834f6c89f6e0a1ffc7d98f0
+  firebase_performance: 088348a0d6061bd81240260500d00eea909adddf
+  firebase_remote_config: 5b3ca34efd50bd5562783bee849dad87cf1e15f9
+  FirebaseABTesting: a308446df8bd5fd29d2535ddfb124a7011dadbc2
   FirebaseAnalytics: 853fa849aca9e418f163c2de5ed0a867efa4fddf
   FirebaseCore: 58905958aa00a061397a0fd759ae4b55bddb3576
   FirebaseCoreExtension: 5b94169f1ee96ecc2dbde40bc53690e4d65eb652
@@ -274,8 +327,11 @@ SPEC CHECKSUMS:
   FirebaseCrashlytics: 8bb2d41cb47e8f3ea34200d99361499a59995e0d
   FirebaseInstallations: 134bde50e477628ded76070efdb12d515d53f948
   FirebaseMessaging: 30564b85d2f81a96f9d312bd23acf8186ff092ae
+  FirebasePerformance: 0d1e1fc53c4f6fc62bf8ef42d1a5670f87c51c77
+  FirebaseRemoteConfig: 672634c19a4a5bc329fd85e84cfea51fce514c4b
   FirebaseRemoteConfigInterop: 4801ab93a543ef8fedfb40ae2f66d03e3fdcb864
   FirebaseSessions: 0e5f64cd99400275798fcb5e2b773dd000ca02c1
+  FirebaseSharedSwift: 76bdd9de8ff1da7a601236ee058253e36206978e
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_local_notifications: 643a3eda1ce1c0599413ca31672536d423dee214
   flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
@@ -284,6 +340,7 @@ SPEC CHECKSUMS:
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
+  integration_test: 4a889634ef21a45d28d50d622cf412dc6d9f586e
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   ObjectBox: 2aae8ad350012cb53c6e7848064307cf68617f73
   objectbox_flutter_libs: 42b57158b8c4869b731487f220e07d6edc6616e0
@@ -297,6 +354,6 @@ SPEC CHECKSUMS:
   url_launcher_ios: 7a95fa5b60cc718a708b8f2966718e93db0cef1b
   video_player_avfoundation: 3453f792138786248960ca029747fcd9f318ef52
 
-PODFILE CHECKSUM: 2241e9d363da392799ae87a5474909dd77364bf2
+PODFILE CHECKSUM: 6d8e1bad30b663fd21e0624cb3678888bfd85c12
 
 COCOAPODS: 1.16.2

--- a/lib/features/bookmarks/presentation/bloc/bookmark_form/bookmark_form_bloc.dart
+++ b/lib/features/bookmarks/presentation/bloc/bookmark_form/bookmark_form_bloc.dart
@@ -132,7 +132,11 @@ class BookmarkFormBloc extends Bloc<BookmarkFormEvent, BookmarkFormState> {
     BookmarkFormImagesPicked event,
     Emitter<BookmarkFormState> emit,
   ) async {
-    if (!await _ensureGalleryPermission(emit)) return;
+    // No gallery permission gate: image_picker's gallery flow uses the system
+    // photo picker (PHPicker on iOS, the Android photo picker), which runs
+    // out-of-process and only ever exposes the items the user selects, so it
+    // needs no photo-library permission. Requesting one would add a dialog
+    // that, when denied, wrongly stops the picker from ever opening.
     try {
       final images = await _imagePickerService.pickMultiImage();
       if (images.isNotEmpty) {
@@ -175,7 +179,8 @@ class BookmarkFormBloc extends Bloc<BookmarkFormEvent, BookmarkFormState> {
     BookmarkFormVideoPicked event,
     Emitter<BookmarkFormState> emit,
   ) async {
-    if (!await _ensureGalleryPermission(emit)) return;
+    // No permission gate — the system gallery picker needs none. See the note
+    // in _onImagesPicked.
     try {
       final video = await _imagePickerService.pickVideo(
         source: ImageSource.gallery,
@@ -249,18 +254,6 @@ class BookmarkFormBloc extends Bloc<BookmarkFormEvent, BookmarkFormState> {
           state.copyWith(status: BookmarkFormStatus.idle, failure: failure),
         );
     }
-  }
-
-  Future<bool> _ensureGalleryPermission(Emitter<BookmarkFormState> emit) async {
-    if (await _permissionService.hasGalleryPermission()) return true;
-    if (await _permissionService.requestGalleryPermission()) return true;
-    emit(
-      state.copyWith(
-        status: BookmarkFormStatus.idle,
-        failure: const PermissionFailure(),
-      ),
-    );
-    return false;
   }
 
   Future<bool> _ensureCameraPermission(Emitter<BookmarkFormState> emit) async {

--- a/test/features/bookmarks/presentation/bloc/bookmark_form/bookmark_form_bloc_test.dart
+++ b/test/features/bookmarks/presentation/bloc/bookmark_form/bookmark_form_bloc_test.dart
@@ -260,11 +260,8 @@ void main() {
       final mockFile = XFile('test/path.png');
 
       blocTest<BookmarkFormBloc, BookmarkFormState>(
-        'picks images successfully when gallery permission is already granted',
+        'picks images from the gallery without requesting permission',
         setUp: () {
-          when(
-            () => mockPermission.hasGalleryPermission(),
-          ).thenAnswer((_) async => true);
           when(
             () => mockImagePicker.pickMultiImage(),
           ).thenAnswer((_) async => [mockFile]);
@@ -277,56 +274,17 @@ void main() {
                 s.imageUrls.length == 1 && s.imageUrls.first == 'test/path.png',
           ),
         ],
-      );
-
-      blocTest<BookmarkFormBloc, BookmarkFormState>(
-        'picks images successfully after requesting and getting gallery permission',
-        setUp: () {
-          when(
-            () => mockPermission.hasGalleryPermission(),
-          ).thenAnswer((_) async => false);
-          when(
-            () => mockPermission.requestGalleryPermission(),
-          ).thenAnswer((_) async => true);
-          when(
-            () => mockImagePicker.pickMultiImage(),
-          ).thenAnswer((_) async => [mockFile]);
+        verify: (_) {
+          // The system photo picker needs no permission; gating it would
+          // wrongly block the picker from opening (regression guard).
+          verifyNever(() => mockPermission.hasGalleryPermission());
+          verifyNever(() => mockPermission.requestGalleryPermission());
         },
-        build: buildBloc,
-        act: (bloc) => bloc.add(const BookmarkFormImagesPicked()),
-        expect: () => [
-          predicate<BookmarkFormState>(
-            (s) =>
-                s.imageUrls.length == 1 && s.imageUrls.first == 'test/path.png',
-          ),
-        ],
-      );
-
-      blocTest<BookmarkFormBloc, BookmarkFormState>(
-        'fails to pick images when gallery permission is denied',
-        setUp: () {
-          when(
-            () => mockPermission.hasGalleryPermission(),
-          ).thenAnswer((_) async => false);
-          when(
-            () => mockPermission.requestGalleryPermission(),
-          ).thenAnswer((_) async => false);
-        },
-        build: buildBloc,
-        act: (bloc) => bloc.add(const BookmarkFormImagesPicked()),
-        expect: () => [
-          predicate<BookmarkFormState>(
-            (s) => s.failure is PermissionFailure,
-          ),
-        ],
       );
 
       blocTest<BookmarkFormBloc, BookmarkFormState>(
         'emits MediaPickFailure when image picker throws',
         setUp: () {
-          when(
-            () => mockPermission.hasGalleryPermission(),
-          ).thenAnswer((_) async => true);
           when(
             () => mockImagePicker.pickMultiImage(),
           ).thenThrow(Exception('picker failed'));
@@ -419,11 +377,8 @@ void main() {
       final mockVideo = XFile('test/video.mp4');
 
       blocTest<BookmarkFormBloc, BookmarkFormState>(
-        'picks video successfully when gallery permission is already granted',
+        'picks video from the gallery without requesting permission',
         setUp: () {
-          when(
-            () => mockPermission.hasGalleryPermission(),
-          ).thenAnswer((_) async => true);
           when(
             () => mockImagePicker.pickVideo(source: ImageSource.gallery),
           ).thenAnswer((_) async => mockVideo);
@@ -435,6 +390,9 @@ void main() {
             (s) => s.videoUrl == 'test/video.mp4',
           ),
         ],
+        verify: (_) {
+          verifyNever(() => mockPermission.hasGalleryPermission());
+        },
       );
 
       blocTest<BookmarkFormBloc, BookmarkFormState>(


### PR DESCRIPTION
## Problem
Attaching media to a new bookmark was broken on iOS — neither the gallery pickers nor the camera-capture buttons did anything. Two independent defects in the same feature:

1. **Gallery picks were gated behind a permission they don't need.** `BookmarkFormBloc` ran `_ensureGalleryPermission()` before `pickMultiImage` / `pickVideo(gallery)`. iOS's `PHPickerViewController` (and the Android photo picker) runs out-of-process and needs no photo-library permission, so whenever `Permission.photos` wasn't granted the bloc emitted a `PermissionFailure` and returned **before the picker ever opened**.

2. **`permission_handler` had the camera permission compiled out.** On iOS each permission is included only if its `PERMISSION_*` macro is defined in the Podfile. `ios/Podfile` defined only `PERMISSION_NOTIFICATIONS=1`, so `Permission.camera` / `.photos` / `.microphone` resolved to **"denied" with no system dialog** — "Take Photo" / "Record Video" could never pass the camera gate. Confirmed against the generated Pods build settings (only `PERMISSION_NOTIFICATIONS=1` was present before this change).

## Changes
- `bookmark_form_bloc.dart` — remove the gallery permission gate from `_onImagesPicked` / `_onVideoPicked` (the camera gate is retained); drop the now-unused `_ensureGalleryPermission`.
- `ios/Podfile` — enable `PERMISSION_CAMERA`, `PERMISSION_MICROPHONE`, `PERMISSION_PHOTOS` alongside notifications, kept in sync with the `NS*UsageDescription` keys in `Info.plist`.
- `ios/Podfile.lock` — regenerated via `pod install` (also syncs Firebase/integration_test pods the committed lock was stale on).
- Bloc tests — gallery image/video tests now `verifyNever` the permission methods (regression guard); removed the obsolete "permission denied" case.

## Test plan
- [x] `fvm flutter analyze` → no issues
- [x] `fvm flutter test …/bookmark_form_bloc_test.dart` → 21/21 pass
- [x] `pod install` → generated Pods now define `PERMISSION_CAMERA/MICROPHONE/PHOTOS=1`
- [ ] **Manual (real iOS device):** full rebuild, then Add Images / Add Video open the picker; Take Photo / Record Video prompt for camera permission and open the camera. (Camera can't be tested on the Simulator — no hardware.)

> ⚠️ Native build-settings change — reviewers/testers need a **full rebuild**, not a hot reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
