### PR TITLE
ci: raise coverage floor 55 → 58

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,12 +76,12 @@ jobs:
 
       # Fail the build if line coverage drops below the threshold. Generated
       # files are excluded so the percentage reflects hand-written code only.
-      # Current baseline is ~57%; raise `min_coverage` as coverage improves.
+      # Current baseline is ~59%; raise `min_coverage` as coverage improves.
       - name: Enforce coverage threshold
         uses: VeryGoodOpenSource/very_good_coverage@v3
         with:
           path: coverage/lcov.info
-          min_coverage: 55
+          min_coverage: 58
           exclude: >-
             **/*.g.dart
             **/*.freezed.dart


### PR DESCRIPTION
Follow-up to #35. The offline/sync/retry hardening added 14 tests, lifting line coverage (generated + l10n excluded) to **~58.8%**. This ratchets the CI gate from 55 → 58 so coverage can't silently regress below the new baseline.

Floor left ~0.8% below the measured value as a small safety margin against OS/runner differences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)