### PR TITLE
fix(ci): actually commit the placeholder firebase_options.dart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ Thumbs.db
 # -------------------------------------------------------------------------
 firebase.json
 .firebaserc
-lib/firebase_options.dart
+# lib/firebase_options.dart is intentionally committed as a non-real PLACEHOLDER
+# so the template builds out of the box; run `flutterfire configure` to generate
+# your own (it overwrites the placeholder locally). Native config stays ignored.
 ios/Runner/GoogleService-Info.plist
 macos/Runner/GoogleService-Info.plist

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,87 @@
+// PLACEHOLDER Firebase configuration — committed so the template compiles and
+// runs the test suite out of the box. The values are NOT real.
+//
+// Replace this file with your own project's config by running the FlutterFire
+// CLI before building for a device:
+//
+//     dart pub global activate flutterfire_cli
+//     flutterfire configure
+//
+// That also generates the native config (google-services.json /
+// GoogleService-Info.plist), which remain git-ignored and are required for
+// real device/emulator builds.
+//
+// ignore_for_file: type=lint
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+/// Default [FirebaseOptions] for use with your Firebase apps.
+///
+/// Example:
+/// ```dart
+/// import 'firebase_options.dart';
+/// // ...
+/// await Firebase.initializeApp(
+///   options: DefaultFirebaseOptions.currentPlatform,
+/// );
+/// ```
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions have not been configured for macos - '
+          'you can reconfigure this by running the FlutterFire CLI again.',
+        );
+      case TargetPlatform.windows:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions have not been configured for windows - '
+          'you can reconfigure this by running the FlutterFire CLI again.',
+        );
+      case TargetPlatform.linux:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions have not been configured for linux - '
+          'you can reconfigure this by running the FlutterFire CLI again.',
+        );
+      default:
+        throw UnsupportedError(
+          'DefaultFirebaseOptions are not supported for this platform.',
+        );
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'PLACEHOLDER_WEB_API_KEY',
+    appId: '1:000000000000:web:0000000000000000000000',
+    messagingSenderId: '000000000000',
+    projectId: 'your-firebase-project',
+    authDomain: 'your-firebase-project.firebaseapp.com',
+    storageBucket: 'your-firebase-project.appspot.com',
+    measurementId: 'G-0000000000',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'PLACEHOLDER_ANDROID_API_KEY',
+    appId: '1:000000000000:android:0000000000000000000000',
+    messagingSenderId: '000000000000',
+    projectId: 'your-firebase-project',
+    storageBucket: 'your-firebase-project.appspot.com',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'PLACEHOLDER_IOS_API_KEY',
+    appId: '1:000000000000:ios:0000000000000000000000',
+    messagingSenderId: '000000000000',
+    projectId: 'your-firebase-project',
+    storageBucket: 'your-firebase-project.appspot.com',
+    iosBundleId: 'com.example.flutterStarterTemplate',
+  );
+}


### PR DESCRIPTION
Repairs #38, which removed the CI firebase stub step but did not land the placeholder (the `.gitignore` edit silently no-op'd), leaving `main` unable to compile in CI / on a fresh clone.

This commits the non-real placeholder and un-ignores `lib/firebase_options.dart`, so the project compiles, analyzes, and runs the full suite out of the box. Native config (`google-services.json` / `GoogleService-Info.plist`) stays ignored; run `flutterfire configure` for real device builds.

Verified locally: analyze clean, dart format clean, 289 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)