### PR TITLE
Enforce up-to-date generated code in CI and document the policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      # Generated files (*.g.dart, *.freezed.dart, *.config.dart, etc.) are
+      # committed to the repo. Regenerate them and fail if anything changed,
+      # so a PR can never merge with stale generated code.
+      - name: Verify generated code is up to date
+        run: |
+          dart run build_runner build --delete-conflicting-outputs
+          if ! git diff --quiet --exit-code; then
+            echo "::error::Generated code is out of date. Run 'dart run build_runner build --delete-conflicting-outputs' and commit the result."
+            git diff --stat
+            exit 1
+          fi
+
       - name: Verify formatting
         run: dart format --output=none --set-exit-if-changed .
 

--- a/README.md
+++ b/README.md
@@ -546,7 +546,36 @@ fvm dart run build_runner build --delete-conflicting-outputs   # one-shot
 fvm dart run build_runner watch --delete-conflicting-outputs   # incremental
 ```
 
-Runs Freezed, Retrofit, Injectable, ObjectBox, `go_router_builder`, `flutter_gen`, and `json_serializable`. Generated files are tracked in git — adjust `.gitignore` if your team prefers otherwise.
+Runs Freezed, Retrofit, Injectable, ObjectBox, `go_router_builder`, `flutter_gen`, and `json_serializable`.
+
+### 📦 Generated files are committed (not ignored)
+
+This repo **tracks** generated output (`*.g.dart`, `*.freezed.dart`,
+`*.config.dart`, `*.gen.dart`, `lib/objectbox.g.dart`, `lib/objectbox-model.json`)
+rather than `.gitignore`-ing it. Reasons:
+
+- **ObjectBox requires it.** `lib/objectbox-model.json` holds the stable
+  entity/property UIDs that keep on-device data intact across schema
+  migrations — it is a source-of-truth file and **must** be version-controlled.
+  Committing the matching `objectbox.g.dart` keeps the pair consistent.
+- **Reproducible checkouts.** A fresh clone, a reviewer, or CI compiles
+  immediately without first running `build_runner`, and regenerated code shows
+  up in the PR diff — so "someone forgot to regenerate" is caught at review.
+- **Simpler CI.** No mandatory codegen step before every analyze/test run.
+
+Two safeguards keep the trade-off (diff noise) in check:
+
+- **`.gitattributes`** marks these files `linguist-generated=true`, so GitHub
+  collapses them in diffs and excludes them from language stats.
+- **CI** runs `build_runner` and fails if the working tree changes (the
+  _"Verify generated code is up to date"_ step in
+  [`.github/workflows/ci.yml`](file:///Users/trunglaptieu/development/projects/flutter-starter-template/.github/workflows/ci.yml)),
+  so stale generated code can never merge.
+
+If your team prefers ignoring generated files instead, you'd need to: add the
+patterns to `.gitignore` (but **keep `objectbox-model.json` tracked**), make the
+CI `build_runner` step run before analyze/test on every job, and add a local
+pre-build hook so contributors don't compile stale code.
 
 <br>
 


### PR DESCRIPTION
## Summary

We commit generated code (`*.g.dart`, `*.freezed.dart`, `*.config.dart`, `*.gen.dart`, plus ObjectBox's `objectbox.g.dart` / `objectbox-model.json`) rather than gitignoring it. This PR makes that decision explicit and safe:

- **CI guard** — new *"Verify generated code is up to date"* step in `ci.yml` runs `build_runner` after `pub get` and fails (with an actionable message + `git diff --stat`) if the tree changes. Stale generated code can no longer merge.
- **Docs** — expanded the README *Code Generation* section into a *"Generated files are committed (not ignored)"* subsection covering the policy, the rationale (ObjectBox schema UIDs must be tracked, reproducible checkouts, simpler CI), the two safeguards, and what to change if a team prefers ignoring them instead.

The diff-collapsing half (`linguist-generated=true` in `.gitattributes`) was already present, so no change was needed there.

## Why keep them committed

- `lib/objectbox-model.json` holds stable entity/property UIDs required for safe on-device schema migrations — it **must** be version-controlled, and committing the matching `objectbox.g.dart` keeps the pair consistent.
- Fresh clones / reviewers / CI compile without first running `build_runner`, and regenerated output shows up in PR diffs.

## Test plan

- [ ] CI passes, including the new *Verify generated code is up to date* step.
- [ ] Locally: `dart run build_runner build --delete-conflicting-outputs` produces no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)