### PR TITLE
Add notifications page with activity feed to bottom bar

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -12,6 +12,7 @@ import '../features/bookmarks/presentation/screens/bookmark_detail_screen.dart';
 import '../features/bookmarks/presentation/screens/bookmark_form_screen.dart';
 import '../features/bookmarks/presentation/screens/bookmarks_list_screen.dart';
 import '../features/home/presentation/screens/home_screen.dart';
+import '../features/notifications/presentation/screens/notifications_screen.dart';
 import '../features/profile/presentation/screens/profile_screen.dart';
 import '../features/splash/presentation/screens/splash_screen.dart';
 import 'widgets/app_shell.dart';
@@ -41,6 +42,14 @@ part 'router.g.dart';
               name: 'bookmark_edit',
             ),
           ],
+        ),
+      ],
+    ),
+    TypedStatefulShellBranch<NotificationsBranchData>(
+      routes: <TypedRoute<RouteData>>[
+        TypedGoRoute<NotificationsRoute>(
+          path: '/notifications',
+          name: 'notifications',
         ),
       ],
     ),
@@ -79,6 +88,10 @@ class BookmarksBranchData extends StatefulShellBranchData {
   const BookmarksBranchData();
 }
 
+class NotificationsBranchData extends StatefulShellBranchData {
+  const NotificationsBranchData();
+}
+
 class ProfileBranchData extends StatefulShellBranchData {
   const ProfileBranchData();
 }
@@ -97,6 +110,14 @@ class HomeRoute extends GoRouteData with $HomeRoute {
 
   @override
   Widget build(BuildContext context, GoRouterState state) => const HomeScreen();
+}
+
+class NotificationsRoute extends GoRouteData with $NotificationsRoute {
+  const NotificationsRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const NotificationsScreen();
 }
 
 class ProfileRoute extends GoRouteData with $ProfileRoute {

--- a/lib/app/router.g.dart
+++ b/lib/app/router.g.dart
@@ -54,6 +54,15 @@ RouteBase get $appShellRouteData => StatefulShellRouteData.$route(
     StatefulShellBranchData.$branch(
       routes: [
         GoRouteData.$route(
+          path: '/notifications',
+          name: 'notifications',
+          factory: $NotificationsRoute._fromState,
+        ),
+      ],
+    ),
+    StatefulShellBranchData.$branch(
+      routes: [
+        GoRouteData.$route(
           path: '/profile',
           name: 'profile',
           factory: $ProfileRoute._fromState,
@@ -170,6 +179,27 @@ mixin $BookmarkEditRoute on GoRouteData {
   @override
   String get location =>
       GoRouteData.$location('/bookmarks/${Uri.encodeComponent(_self.id)}/edit');
+
+  @override
+  void go(BuildContext context) => context.go(location);
+
+  @override
+  Future<T?> push<T>(BuildContext context) => context.push<T>(location);
+
+  @override
+  void pushReplacement(BuildContext context) =>
+      context.pushReplacement(location);
+
+  @override
+  void replace(BuildContext context) => context.replace(location);
+}
+
+mixin $NotificationsRoute on GoRouteData {
+  static NotificationsRoute _fromState(GoRouterState state) =>
+      const NotificationsRoute();
+
+  @override
+  String get location => GoRouteData.$location('/notifications');
 
   @override
   void go(BuildContext context) => context.go(location);

--- a/lib/app/widgets/app_shell.dart
+++ b/lib/app/widgets/app_shell.dart
@@ -29,6 +29,11 @@ class AppShell extends StatelessWidget {
         label: l10n.navBookmarks,
       ),
       AppDestination(
+        icon: Icons.notifications_outlined,
+        selectedIcon: Icons.notifications,
+        label: l10n.navNotifications,
+      ),
+      AppDestination(
         icon: Icons.person_outline,
         selectedIcon: Icons.person,
         label: l10n.navProfile,

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -53,7 +53,6 @@ import 'package:flutter_starter_template/core/permissions/permission_service.dar
 import 'package:flutter_starter_template/core/share/share_module.dart' as _i390;
 import 'package:flutter_starter_template/core/share/share_service.dart'
     as _i580;
-import 'package:flutter_starter_template/ui/theme/theme_bloc.dart' as _i652;
 import 'package:flutter_starter_template/features/auth/data/datasources/auth_local_data_source.dart'
     as _i297;
 import 'package:flutter_starter_template/features/auth/data/datasources/auth_remote_data_source.dart'
@@ -122,11 +121,26 @@ import 'package:flutter_starter_template/features/bookmarks/presentation/bloc/bo
     as _i566;
 import 'package:flutter_starter_template/features/home/presentation/bloc/home_bloc.dart'
     as _i423;
+import 'package:flutter_starter_template/features/notifications/data/datasources/notifications_remote_data_source.dart'
+    as _i937;
+import 'package:flutter_starter_template/features/notifications/data/datasources/notifications_remote_module.dart'
+    as _i951;
+import 'package:flutter_starter_template/features/notifications/data/repositories/notifications_repository_impl.dart'
+    as _i879;
+import 'package:flutter_starter_template/features/notifications/domain/repositories/notifications_repository.dart'
+    as _i578;
+import 'package:flutter_starter_template/features/notifications/domain/usecases/get_notifications_feed.dart'
+    as _i41;
+import 'package:flutter_starter_template/features/notifications/domain/usecases/mark_notification_read.dart'
+    as _i854;
+import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_bloc.dart'
+    as _i642;
 import 'package:flutter_starter_template/features/profile/presentation/bloc/profile_bloc.dart'
     as _i1013;
 import 'package:flutter_starter_template/objectbox.g.dart' as _i831;
 import 'package:flutter_starter_template/shared/domain/bookmark_stats.dart'
     as _i189;
+import 'package:flutter_starter_template/ui/theme/theme_bloc.dart' as _i753;
 import 'package:get_it/get_it.dart' as _i174;
 import 'package:image_picker/image_picker.dart' as _i183;
 import 'package:injectable/injectable.dart' as _i526;
@@ -154,11 +168,12 @@ extension GetItInjectableX on _i174.GetIt {
     final networkModule = _$NetworkModule();
     final authNetworkModule = _$AuthNetworkModule();
     final bookmarksRemoteModule = _$BookmarksRemoteModule();
+    final notificationsRemoteModule = _$NotificationsRemoteModule();
+    gh.factory<_i1013.ProfileBloc>(() => _i1013.ProfileBloc());
     await gh.factoryAsync<_i460.SharedPreferences>(
       () => sharedPreferencesModule.provideSharedPreferences(),
       preResolve: true,
     );
-    gh.factory<_i1013.ProfileBloc>(() => _i1013.ProfileBloc());
     gh.singleton<_i689.EnvConfig>(() => const _i689.EnvConfig());
     gh.singleton<_i999.FirebaseService>(() => _i999.FirebaseService());
     await gh.singletonAsync<_i319.ObjectBox>(
@@ -215,8 +230,8 @@ extension GetItInjectableX on _i174.GetIt {
     gh.lazySingleton<_i838.AnalyticsService>(
       () => _i838.FirebaseAnalyticsService(gh<_i398.FirebaseAnalytics>()),
     );
-    gh.lazySingleton<_i652.ThemeBloc>(
-      () => _i652.ThemeBloc(
+    gh.lazySingleton<_i753.ThemeBloc>(
+      () => _i753.ThemeBloc(
         gh<_i460.SharedPreferences>(),
         gh<_i838.AnalyticsService>(),
       ),
@@ -263,6 +278,16 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i361.Dio>(),
       ),
     );
+    gh.lazySingleton<_i937.NotificationsRemoteDataSource>(
+      () => notificationsRemoteModule.provideNotificationsRemoteDataSource(
+        gh<_i361.Dio>(),
+      ),
+    );
+    gh.lazySingleton<_i578.NotificationsRepository>(
+      () => _i879.NotificationsRepositoryImpl(
+        gh<_i937.NotificationsRemoteDataSource>(),
+      ),
+    );
     gh.lazySingleton<_i627.BookmarksSyncController>(
       () => _i539.BookmarksSyncService(
         gh<_i724.BookmarksLocalDataSource>(),
@@ -270,11 +295,23 @@ extension GetItInjectableX on _i174.GetIt {
         gh<_i895.Connectivity>(),
       ),
     );
+    gh.factory<_i41.GetNotificationsFeed>(
+      () => _i41.GetNotificationsFeed(gh<_i578.NotificationsRepository>()),
+    );
+    gh.factory<_i854.MarkNotificationRead>(
+      () => _i854.MarkNotificationRead(gh<_i578.NotificationsRepository>()),
+    );
     gh.lazySingleton<_i987.AuthRepository>(
       () => _i1028.AuthRepositoryImpl(
         gh<_i87.AuthRemoteDataSource>(),
         gh<_i297.AuthLocalDataSource>(),
         gh<_i533.TokenRefresher>(),
+      ),
+    );
+    gh.factory<_i642.NotificationsBloc>(
+      () => _i642.NotificationsBloc(
+        gh<_i41.GetNotificationsFeed>(),
+        gh<_i854.MarkNotificationRead>(),
       ),
     );
     gh.factory<_i780.ChangePassword>(
@@ -370,7 +407,7 @@ extension GetItInjectableX on _i174.GetIt {
   }
 }
 
-class _$SharedPreferencesModule extends _i652.SharedPreferencesModule {}
+class _$SharedPreferencesModule extends _i753.SharedPreferencesModule {}
 
 class _$ObjectBoxModule extends _i319.ObjectBoxModule {}
 
@@ -395,3 +432,5 @@ class _$NetworkModule extends _i173.NetworkModule {}
 class _$AuthNetworkModule extends _i740.AuthNetworkModule {}
 
 class _$BookmarksRemoteModule extends _i235.BookmarksRemoteModule {}
+
+class _$NotificationsRemoteModule extends _i951.NotificationsRemoteModule {}

--- a/lib/features/notifications/data/datasources/notifications_remote_data_source.dart
+++ b/lib/features/notifications/data/datasources/notifications_remote_data_source.dart
@@ -1,0 +1,22 @@
+import 'package:dio/dio.dart';
+import 'package:retrofit/retrofit.dart';
+
+import '../models/notification_dto.dart';
+import '../models/user_activity_dto.dart';
+
+part 'notifications_remote_data_source.g.dart';
+
+@RestApi()
+abstract class NotificationsRemoteDataSource {
+  factory NotificationsRemoteDataSource(Dio dio, {String baseUrl}) =
+      _NotificationsRemoteDataSource;
+
+  @GET('/api/notifications')
+  Future<List<NotificationDto>> listNotifications();
+
+  @GET('/api/activity')
+  Future<List<UserActivityDto>> listActivity();
+
+  @PATCH('/api/notifications/{id}/read')
+  Future<void> markRead(@Path('id') String id);
+}

--- a/lib/features/notifications/data/datasources/notifications_remote_data_source.g.dart
+++ b/lib/features/notifications/data/datasources/notifications_remote_data_source.g.dart
@@ -1,0 +1,131 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notifications_remote_data_source.dart';
+
+// dart format off
+
+// **************************************************************************
+// RetrofitGenerator
+// **************************************************************************
+
+// ignore_for_file: unnecessary_brace_in_string_interps,no_leading_underscores_for_local_identifiers,unused_element,unnecessary_string_interpolations,unused_element_parameter,avoid_unused_constructor_parameters,unreachable_from_main,avoid_redundant_argument_values
+
+class _NotificationsRemoteDataSource implements NotificationsRemoteDataSource {
+  _NotificationsRemoteDataSource(this._dio, {this.baseUrl, this.errorLogger});
+
+  final Dio _dio;
+
+  String? baseUrl;
+
+  final ParseErrorLogger? errorLogger;
+
+  @override
+  Future<List<NotificationDto>> listNotifications() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<NotificationDto>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/notifications',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<NotificationDto> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) => NotificationDto.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<List<UserActivityDto>> listActivity() async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<List<UserActivityDto>>(
+      Options(method: 'GET', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/activity',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    final _result = await _dio.fetch<List<dynamic>>(_options);
+    late List<UserActivityDto> _value;
+    try {
+      _value = _result.data!
+          .map(
+            (dynamic i) => UserActivityDto.fromJson(i as Map<String, dynamic>),
+          )
+          .toList();
+    } on Object catch (e, s) {
+      errorLogger?.logError(e, s, _options, response: _result);
+      rethrow;
+    }
+    return _value;
+  }
+
+  @override
+  Future<void> markRead(String id) async {
+    final _extra = <String, dynamic>{};
+    final queryParameters = <String, dynamic>{};
+    final _headers = <String, dynamic>{};
+    const Map<String, dynamic>? _data = null;
+    final _options = _setStreamType<void>(
+      Options(method: 'PATCH', headers: _headers, extra: _extra)
+          .compose(
+            _dio.options,
+            '/api/notifications/${id}/read',
+            queryParameters: queryParameters,
+            data: _data,
+          )
+          .copyWith(baseUrl: _combineBaseUrls(_dio.options.baseUrl, baseUrl)),
+    );
+    await _dio.fetch<void>(_options);
+  }
+
+  RequestOptions _setStreamType<T>(RequestOptions requestOptions) {
+    if (T != dynamic &&
+        !(requestOptions.responseType == ResponseType.bytes ||
+            requestOptions.responseType == ResponseType.stream)) {
+      if (T == String) {
+        requestOptions.responseType = ResponseType.plain;
+      } else {
+        requestOptions.responseType = ResponseType.json;
+      }
+    }
+    return requestOptions;
+  }
+
+  String _combineBaseUrls(String dioBaseUrl, String? baseUrl) {
+    if (baseUrl == null || baseUrl.trim().isEmpty) {
+      return dioBaseUrl;
+    }
+
+    final url = Uri.parse(baseUrl);
+
+    if (url.isAbsolute) {
+      return url.toString();
+    }
+
+    return Uri.parse(dioBaseUrl).resolveUri(url).toString();
+  }
+}
+
+// dart format on

--- a/lib/features/notifications/data/datasources/notifications_remote_module.dart
+++ b/lib/features/notifications/data/datasources/notifications_remote_module.dart
@@ -1,0 +1,11 @@
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+
+import 'notifications_remote_data_source.dart';
+
+@module
+abstract class NotificationsRemoteModule {
+  @lazySingleton
+  NotificationsRemoteDataSource provideNotificationsRemoteDataSource(Dio dio) =>
+      NotificationsRemoteDataSource(dio);
+}

--- a/lib/features/notifications/data/models/notification_dto.dart
+++ b/lib/features/notifications/data/models/notification_dto.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'notification_dto.freezed.dart';
+part 'notification_dto.g.dart';
+
+@Freezed(copyWith: false, equal: false)
+abstract class NotificationDto with _$NotificationDto {
+  const factory NotificationDto({
+    required String id,
+    required String title,
+    required String body,
+    required String type,
+    @JsonKey(name: 'is_read') @Default(false) bool isRead,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+  }) = _NotificationDto;
+
+  factory NotificationDto.fromJson(Map<String, dynamic> json) =>
+      _$NotificationDtoFromJson(json);
+}

--- a/lib/features/notifications/data/models/notification_dto.freezed.dart
+++ b/lib/features/notifications/data/models/notification_dto.freezed.dart
@@ -1,0 +1,200 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notification_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$NotificationDto {
+
+ String get id; String get title; String get body; String get type;@JsonKey(name: 'is_read') bool get isRead;@JsonKey(name: 'created_at') DateTime get createdAt;
+
+  /// Serializes this NotificationDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+
+
+@override
+String toString() {
+  return 'NotificationDto(id: $id, title: $title, body: $body, type: $type, isRead: $isRead, createdAt: $createdAt)';
+}
+
+
+}
+
+
+
+
+/// Adds pattern-matching-related methods to [NotificationDto].
+extension NotificationDtoPatterns on NotificationDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NotificationDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NotificationDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NotificationDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _NotificationDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NotificationDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NotificationDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String title,  String body,  String type, @JsonKey(name: 'is_read')  bool isRead, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NotificationDto() when $default != null:
+return $default(_that.id,_that.title,_that.body,_that.type,_that.isRead,_that.createdAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String title,  String body,  String type, @JsonKey(name: 'is_read')  bool isRead, @JsonKey(name: 'created_at')  DateTime createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _NotificationDto():
+return $default(_that.id,_that.title,_that.body,_that.type,_that.isRead,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String title,  String body,  String type, @JsonKey(name: 'is_read')  bool isRead, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _NotificationDto() when $default != null:
+return $default(_that.id,_that.title,_that.body,_that.type,_that.isRead,_that.createdAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _NotificationDto implements NotificationDto {
+  const _NotificationDto({required this.id, required this.title, required this.body, required this.type, @JsonKey(name: 'is_read') this.isRead = false, @JsonKey(name: 'created_at') required this.createdAt});
+  factory _NotificationDto.fromJson(Map<String, dynamic> json) => _$NotificationDtoFromJson(json);
+
+@override final  String id;
+@override final  String title;
+@override final  String body;
+@override final  String type;
+@override@JsonKey(name: 'is_read') final  bool isRead;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$NotificationDtoToJson(this, );
+}
+
+
+
+@override
+String toString() {
+  return 'NotificationDto(id: $id, title: $title, body: $body, type: $type, isRead: $isRead, createdAt: $createdAt)';
+}
+
+
+}
+
+
+
+
+// dart format on

--- a/lib/features/notifications/data/models/notification_dto.g.dart
+++ b/lib/features/notifications/data/models/notification_dto.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'notification_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_NotificationDto _$NotificationDtoFromJson(Map<String, dynamic> json) =>
+    _NotificationDto(
+      id: json['id'] as String,
+      title: json['title'] as String,
+      body: json['body'] as String,
+      type: json['type'] as String,
+      isRead: json['is_read'] as bool? ?? false,
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$NotificationDtoToJson(_NotificationDto instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'title': instance.title,
+      'body': instance.body,
+      'type': instance.type,
+      'is_read': instance.isRead,
+      'created_at': instance.createdAt.toIso8601String(),
+    };

--- a/lib/features/notifications/data/models/user_activity_dto.dart
+++ b/lib/features/notifications/data/models/user_activity_dto.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'user_activity_dto.freezed.dart';
+part 'user_activity_dto.g.dart';
+
+@Freezed(copyWith: false, equal: false)
+abstract class UserActivityDto with _$UserActivityDto {
+  const factory UserActivityDto({
+    required String id,
+    required String description,
+    required String type,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+  }) = _UserActivityDto;
+
+  factory UserActivityDto.fromJson(Map<String, dynamic> json) =>
+      _$UserActivityDtoFromJson(json);
+}

--- a/lib/features/notifications/data/models/user_activity_dto.freezed.dart
+++ b/lib/features/notifications/data/models/user_activity_dto.freezed.dart
@@ -1,0 +1,198 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'user_activity_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$UserActivityDto {
+
+ String get id; String get description; String get type;@JsonKey(name: 'created_at') DateTime get createdAt;
+
+  /// Serializes this UserActivityDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+
+
+@override
+String toString() {
+  return 'UserActivityDto(id: $id, description: $description, type: $type, createdAt: $createdAt)';
+}
+
+
+}
+
+
+
+
+/// Adds pattern-matching-related methods to [UserActivityDto].
+extension UserActivityDtoPatterns on UserActivityDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _UserActivityDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _UserActivityDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _UserActivityDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _UserActivityDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _UserActivityDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _UserActivityDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String description,  String type, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _UserActivityDto() when $default != null:
+return $default(_that.id,_that.description,_that.type,_that.createdAt);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String description,  String type, @JsonKey(name: 'created_at')  DateTime createdAt)  $default,) {final _that = this;
+switch (_that) {
+case _UserActivityDto():
+return $default(_that.id,_that.description,_that.type,_that.createdAt);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String description,  String type, @JsonKey(name: 'created_at')  DateTime createdAt)?  $default,) {final _that = this;
+switch (_that) {
+case _UserActivityDto() when $default != null:
+return $default(_that.id,_that.description,_that.type,_that.createdAt);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _UserActivityDto implements UserActivityDto {
+  const _UserActivityDto({required this.id, required this.description, required this.type, @JsonKey(name: 'created_at') required this.createdAt});
+  factory _UserActivityDto.fromJson(Map<String, dynamic> json) => _$UserActivityDtoFromJson(json);
+
+@override final  String id;
+@override final  String description;
+@override final  String type;
+@override@JsonKey(name: 'created_at') final  DateTime createdAt;
+
+
+@override
+Map<String, dynamic> toJson() {
+  return _$UserActivityDtoToJson(this, );
+}
+
+
+
+@override
+String toString() {
+  return 'UserActivityDto(id: $id, description: $description, type: $type, createdAt: $createdAt)';
+}
+
+
+}
+
+
+
+
+// dart format on

--- a/lib/features/notifications/data/models/user_activity_dto.g.dart
+++ b/lib/features/notifications/data/models/user_activity_dto.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user_activity_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_UserActivityDto _$UserActivityDtoFromJson(Map<String, dynamic> json) =>
+    _UserActivityDto(
+      id: json['id'] as String,
+      description: json['description'] as String,
+      type: json['type'] as String,
+      createdAt: DateTime.parse(json['created_at'] as String),
+    );
+
+Map<String, dynamic> _$UserActivityDtoToJson(_UserActivityDto instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'description': instance.description,
+      'type': instance.type,
+      'created_at': instance.createdAt.toIso8601String(),
+    };

--- a/lib/features/notifications/data/repositories/notifications_repository_impl.dart
+++ b/lib/features/notifications/data/repositories/notifications_repository_impl.dart
@@ -1,0 +1,73 @@
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/utils/result.dart';
+import '../../domain/entities/app_notification.dart';
+import '../../domain/entities/notifications_feed.dart';
+import '../../domain/entities/user_activity.dart';
+import '../../domain/repositories/notifications_repository.dart';
+import '../datasources/notifications_remote_data_source.dart';
+import '../models/notification_dto.dart';
+import '../models/user_activity_dto.dart';
+
+@LazySingleton(as: NotificationsRepository)
+class NotificationsRepositoryImpl implements NotificationsRepository {
+  NotificationsRepositoryImpl(this._remote);
+
+  final NotificationsRemoteDataSource _remote;
+
+  @override
+  Future<Result<NotificationsFeed>> getFeed() async {
+    // Fetch both lists concurrently; the record `.wait` propagates the first
+    // failure so the use case's guard can map it to a Failure.
+    final (notificationDtos, activityDtos) = await (
+      _remote.listNotifications(),
+      _remote.listActivity(),
+    ).wait;
+
+    return Ok(
+      NotificationsFeed(
+        notifications: notificationDtos
+            .map(_toNotification)
+            .toList(growable: false),
+        activities: activityDtos.map(_toActivity).toList(growable: false),
+      ),
+    );
+  }
+
+  @override
+  Future<Result<void>> markRead(String id) async {
+    await _remote.markRead(id);
+    return const Ok(null);
+  }
+
+  AppNotification _toNotification(NotificationDto dto) => AppNotification(
+    id: dto.id,
+    title: dto.title,
+    body: dto.body,
+    type: _notificationType(dto.type),
+    isRead: dto.isRead,
+    createdAt: dto.createdAt,
+  );
+
+  UserActivity _toActivity(UserActivityDto dto) => UserActivity(
+    id: dto.id,
+    description: dto.description,
+    type: _activityType(dto.type),
+    createdAt: dto.createdAt,
+  );
+
+  NotificationType _notificationType(String raw) => switch (raw) {
+    'social' => NotificationType.social,
+    'reminder' => NotificationType.reminder,
+    'promotion' => NotificationType.promotion,
+    _ => NotificationType.system,
+  };
+
+  UserActivityType _activityType(String raw) => switch (raw) {
+    'created' => UserActivityType.created,
+    'updated' => UserActivityType.updated,
+    'deleted' => UserActivityType.deleted,
+    'signed_in' => UserActivityType.signedIn,
+    _ => UserActivityType.other,
+  };
+}

--- a/lib/features/notifications/domain/entities/app_notification.dart
+++ b/lib/features/notifications/domain/entities/app_notification.dart
@@ -1,0 +1,30 @@
+/// Category of a notification, used to pick an icon and accent color in the UI.
+enum NotificationType { system, social, reminder, promotion }
+
+/// A notification addressed to the current user.
+class AppNotification {
+  const AppNotification({
+    required this.id,
+    required this.title,
+    required this.body,
+    required this.type,
+    required this.isRead,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String title;
+  final String body;
+  final NotificationType type;
+  final bool isRead;
+  final DateTime createdAt;
+
+  AppNotification copyWith({bool? isRead}) => AppNotification(
+    id: id,
+    title: title,
+    body: body,
+    type: type,
+    isRead: isRead ?? this.isRead,
+    createdAt: createdAt,
+  );
+}

--- a/lib/features/notifications/domain/entities/notifications_feed.dart
+++ b/lib/features/notifications/domain/entities/notifications_feed.dart
@@ -1,0 +1,16 @@
+import 'app_notification.dart';
+import 'user_activity.dart';
+
+/// The combined payload shown on the notifications page: the user's own recent
+/// [activities] alongside [notifications] addressed to them.
+class NotificationsFeed {
+  const NotificationsFeed({
+    required this.notifications,
+    required this.activities,
+  });
+
+  final List<AppNotification> notifications;
+  final List<UserActivity> activities;
+
+  static const empty = NotificationsFeed(notifications: [], activities: []);
+}

--- a/lib/features/notifications/domain/entities/user_activity.dart
+++ b/lib/features/notifications/domain/entities/user_activity.dart
@@ -1,0 +1,17 @@
+/// Kind of action the user performed, used to pick an icon in the UI.
+enum UserActivityType { created, updated, deleted, signedIn, other }
+
+/// A single entry in the current user's recent activity log.
+class UserActivity {
+  const UserActivity({
+    required this.id,
+    required this.description,
+    required this.type,
+    required this.createdAt,
+  });
+
+  final String id;
+  final String description;
+  final UserActivityType type;
+  final DateTime createdAt;
+}

--- a/lib/features/notifications/domain/repositories/notifications_repository.dart
+++ b/lib/features/notifications/domain/repositories/notifications_repository.dart
@@ -1,0 +1,10 @@
+import '../../../../core/utils/result.dart';
+import '../entities/notifications_feed.dart';
+
+abstract interface class NotificationsRepository {
+  /// Loads the user's notifications and recent activity in one shot.
+  Future<Result<NotificationsFeed>> getFeed();
+
+  /// Marks the notification with [id] as read on the server.
+  Future<Result<void>> markRead(String id);
+}

--- a/lib/features/notifications/domain/usecases/get_notifications_feed.dart
+++ b/lib/features/notifications/domain/usecases/get_notifications_feed.dart
@@ -1,0 +1,18 @@
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/usecases/use_case.dart';
+import '../../../../core/utils/result.dart';
+import '../entities/notifications_feed.dart';
+import '../repositories/notifications_repository.dart';
+
+@injectable
+class GetNotificationsFeed extends NoParamUseCase<NotificationsFeed> {
+  const GetNotificationsFeed(this._repository);
+
+  final NotificationsRepository _repository;
+
+  @override
+  Future<Result<NotificationsFeed>> call([NoParams param = noParams]) {
+    return runResultGuarded(_repository.getFeed);
+  }
+}

--- a/lib/features/notifications/domain/usecases/mark_notification_read.dart
+++ b/lib/features/notifications/domain/usecases/mark_notification_read.dart
@@ -1,0 +1,17 @@
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/usecases/use_case.dart';
+import '../../../../core/utils/result.dart';
+import '../repositories/notifications_repository.dart';
+
+@injectable
+class MarkNotificationRead extends UseCase<String, void> {
+  const MarkNotificationRead(this._repository);
+
+  final NotificationsRepository _repository;
+
+  @override
+  Future<Result<void>> call(String id) {
+    return runResultGuarded(() => _repository.markRead(id));
+  }
+}

--- a/lib/features/notifications/presentation/bloc/notifications_bloc.dart
+++ b/lib/features/notifications/presentation/bloc/notifications_bloc.dart
@@ -1,0 +1,74 @@
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../core/utils/result.dart';
+import '../../domain/entities/app_notification.dart';
+import '../../domain/usecases/get_notifications_feed.dart';
+import '../../domain/usecases/mark_notification_read.dart';
+import 'notifications_state.dart';
+
+part 'notifications_event.dart';
+
+@injectable
+class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
+  NotificationsBloc(this._getFeed, this._markRead)
+    : super(const NotificationsState()) {
+    on<NotificationsLoadRequested>(
+      _onLoadRequested,
+      transformer: droppable(),
+    );
+    on<NotificationMarkReadRequested>(
+      _onMarkReadRequested,
+      transformer: sequential(),
+    );
+  }
+
+  final GetNotificationsFeed _getFeed;
+  final MarkNotificationRead _markRead;
+
+  Future<void> _onLoadRequested(
+    NotificationsLoadRequested event,
+    Emitter<NotificationsState> emit,
+  ) async {
+    emit(state.copyWith(isLoading: true, failure: null));
+    final result = await _getFeed();
+    switch (result) {
+      case Ok(value: final feed):
+        emit(
+          state.copyWith(
+            isLoading: false,
+            notifications: feed.notifications,
+            activities: feed.activities,
+          ),
+        );
+      case Err(:final failure):
+        emit(state.copyWith(isLoading: false, failure: failure));
+    }
+  }
+
+  Future<void> _onMarkReadRequested(
+    NotificationMarkReadRequested event,
+    Emitter<NotificationsState> emit,
+  ) async {
+    final id = event.id;
+    final hasUnreadTarget = state.notifications.any(
+      (n) => n.id == id && !n.isRead,
+    );
+    if (!hasUnreadTarget) return;
+
+    // Optimistically flip to read so the UI responds immediately.
+    emit(state.copyWith(notifications: _withRead(id, isRead: true)));
+    final result = await _markRead(id);
+    if (result is Err) {
+      // Roll back if the server rejected the change.
+      emit(state.copyWith(notifications: _withRead(id, isRead: false)));
+    }
+  }
+
+  List<AppNotification> _withRead(String id, {required bool isRead}) {
+    return state.notifications
+        .map((n) => n.id == id ? n.copyWith(isRead: isRead) : n)
+        .toList(growable: false);
+  }
+}

--- a/lib/features/notifications/presentation/bloc/notifications_event.dart
+++ b/lib/features/notifications/presentation/bloc/notifications_event.dart
@@ -1,0 +1,17 @@
+part of 'notifications_bloc.dart';
+
+sealed class NotificationsEvent {
+  const NotificationsEvent();
+}
+
+/// Loads (or refreshes) the notifications and activity feed.
+final class NotificationsLoadRequested extends NotificationsEvent {
+  const NotificationsLoadRequested();
+}
+
+/// Marks a single notification as read.
+final class NotificationMarkReadRequested extends NotificationsEvent {
+  const NotificationMarkReadRequested(this.id);
+
+  final String id;
+}

--- a/lib/features/notifications/presentation/bloc/notifications_state.dart
+++ b/lib/features/notifications/presentation/bloc/notifications_state.dart
@@ -1,0 +1,24 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../../core/error/failure.dart';
+import '../../domain/entities/app_notification.dart';
+import '../../domain/entities/user_activity.dart';
+
+part 'notifications_state.freezed.dart';
+
+@freezed
+abstract class NotificationsState with _$NotificationsState {
+  const factory NotificationsState({
+    @Default(false) bool isLoading,
+    @Default([]) List<AppNotification> notifications,
+    @Default([]) List<UserActivity> activities,
+    Failure? failure,
+  }) = _NotificationsState;
+  const NotificationsState._();
+
+  /// Number of unread notifications, surfaced as a badge in the header.
+  int get unreadCount => notifications.where((n) => !n.isRead).length;
+
+  /// `true` when the feed has neither notifications nor activity to show.
+  bool get hasNoContent => notifications.isEmpty && activities.isEmpty;
+}

--- a/lib/features/notifications/presentation/bloc/notifications_state.freezed.dart
+++ b/lib/features/notifications/presentation/bloc/notifications_state.freezed.dart
@@ -1,0 +1,292 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'notifications_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+/// @nodoc
+mixin _$NotificationsState {
+
+ bool get isLoading; List<AppNotification> get notifications; List<UserActivity> get activities; Failure? get failure;
+/// Create a copy of NotificationsState
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$NotificationsStateCopyWith<NotificationsState> get copyWith => _$NotificationsStateCopyWithImpl<NotificationsState>(this as NotificationsState, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is NotificationsState&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&const DeepCollectionEquality().equals(other.notifications, notifications)&&const DeepCollectionEquality().equals(other.activities, activities)&&(identical(other.failure, failure) || other.failure == failure));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,isLoading,const DeepCollectionEquality().hash(notifications),const DeepCollectionEquality().hash(activities),failure);
+
+@override
+String toString() {
+  return 'NotificationsState(isLoading: $isLoading, notifications: $notifications, activities: $activities, failure: $failure)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $NotificationsStateCopyWith<$Res>  {
+  factory $NotificationsStateCopyWith(NotificationsState value, $Res Function(NotificationsState) _then) = _$NotificationsStateCopyWithImpl;
+@useResult
+$Res call({
+ bool isLoading, List<AppNotification> notifications, List<UserActivity> activities, Failure? failure
+});
+
+
+
+
+}
+/// @nodoc
+class _$NotificationsStateCopyWithImpl<$Res>
+    implements $NotificationsStateCopyWith<$Res> {
+  _$NotificationsStateCopyWithImpl(this._self, this._then);
+
+  final NotificationsState _self;
+  final $Res Function(NotificationsState) _then;
+
+/// Create a copy of NotificationsState
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? isLoading = null,Object? notifications = null,Object? activities = null,Object? failure = freezed,}) {
+  return _then(_self.copyWith(
+isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
+as bool,notifications: null == notifications ? _self.notifications : notifications // ignore: cast_nullable_to_non_nullable
+as List<AppNotification>,activities: null == activities ? _self.activities : activities // ignore: cast_nullable_to_non_nullable
+as List<UserActivity>,failure: freezed == failure ? _self.failure : failure // ignore: cast_nullable_to_non_nullable
+as Failure?,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [NotificationsState].
+extension NotificationsStatePatterns on NotificationsState {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _NotificationsState value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _NotificationsState() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _NotificationsState value)  $default,){
+final _that = this;
+switch (_that) {
+case _NotificationsState():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _NotificationsState value)?  $default,){
+final _that = this;
+switch (_that) {
+case _NotificationsState() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( bool isLoading,  List<AppNotification> notifications,  List<UserActivity> activities,  Failure? failure)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _NotificationsState() when $default != null:
+return $default(_that.isLoading,_that.notifications,_that.activities,_that.failure);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( bool isLoading,  List<AppNotification> notifications,  List<UserActivity> activities,  Failure? failure)  $default,) {final _that = this;
+switch (_that) {
+case _NotificationsState():
+return $default(_that.isLoading,_that.notifications,_that.activities,_that.failure);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( bool isLoading,  List<AppNotification> notifications,  List<UserActivity> activities,  Failure? failure)?  $default,) {final _that = this;
+switch (_that) {
+case _NotificationsState() when $default != null:
+return $default(_that.isLoading,_that.notifications,_that.activities,_that.failure);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+
+
+class _NotificationsState extends NotificationsState {
+  const _NotificationsState({this.isLoading = false, final  List<AppNotification> notifications = const [], final  List<UserActivity> activities = const [], this.failure}): _notifications = notifications,_activities = activities,super._();
+  
+
+@override@JsonKey() final  bool isLoading;
+ final  List<AppNotification> _notifications;
+@override@JsonKey() List<AppNotification> get notifications {
+  if (_notifications is EqualUnmodifiableListView) return _notifications;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_notifications);
+}
+
+ final  List<UserActivity> _activities;
+@override@JsonKey() List<UserActivity> get activities {
+  if (_activities is EqualUnmodifiableListView) return _activities;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_activities);
+}
+
+@override final  Failure? failure;
+
+/// Create a copy of NotificationsState
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$NotificationsStateCopyWith<_NotificationsState> get copyWith => __$NotificationsStateCopyWithImpl<_NotificationsState>(this, _$identity);
+
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _NotificationsState&&(identical(other.isLoading, isLoading) || other.isLoading == isLoading)&&const DeepCollectionEquality().equals(other._notifications, _notifications)&&const DeepCollectionEquality().equals(other._activities, _activities)&&(identical(other.failure, failure) || other.failure == failure));
+}
+
+
+@override
+int get hashCode => Object.hash(runtimeType,isLoading,const DeepCollectionEquality().hash(_notifications),const DeepCollectionEquality().hash(_activities),failure);
+
+@override
+String toString() {
+  return 'NotificationsState(isLoading: $isLoading, notifications: $notifications, activities: $activities, failure: $failure)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$NotificationsStateCopyWith<$Res> implements $NotificationsStateCopyWith<$Res> {
+  factory _$NotificationsStateCopyWith(_NotificationsState value, $Res Function(_NotificationsState) _then) = __$NotificationsStateCopyWithImpl;
+@override @useResult
+$Res call({
+ bool isLoading, List<AppNotification> notifications, List<UserActivity> activities, Failure? failure
+});
+
+
+
+
+}
+/// @nodoc
+class __$NotificationsStateCopyWithImpl<$Res>
+    implements _$NotificationsStateCopyWith<$Res> {
+  __$NotificationsStateCopyWithImpl(this._self, this._then);
+
+  final _NotificationsState _self;
+  final $Res Function(_NotificationsState) _then;
+
+/// Create a copy of NotificationsState
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? isLoading = null,Object? notifications = null,Object? activities = null,Object? failure = freezed,}) {
+  return _then(_NotificationsState(
+isLoading: null == isLoading ? _self.isLoading : isLoading // ignore: cast_nullable_to_non_nullable
+as bool,notifications: null == notifications ? _self._notifications : notifications // ignore: cast_nullable_to_non_nullable
+as List<AppNotification>,activities: null == activities ? _self._activities : activities // ignore: cast_nullable_to_non_nullable
+as List<UserActivity>,failure: freezed == failure ? _self.failure : failure // ignore: cast_nullable_to_non_nullable
+as Failure?,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/features/notifications/presentation/screens/notifications_screen.dart
+++ b/lib/features/notifications/presentation/screens/notifications_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/di/injection.dart';
+import '../bloc/notifications_bloc.dart';
+import '../widgets/notifications_widgets.dart';
+
+class NotificationsScreen extends StatelessWidget {
+  const NotificationsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) =>
+          getIt<NotificationsBloc>()..add(const NotificationsLoadRequested()),
+      child: const NotificationsView(),
+    );
+  }
+}

--- a/lib/features/notifications/presentation/widgets/notifications_widgets.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_widgets.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../../ui/animation/widget_animations.dart';
+import '../../../../ui/theme/app_radius.dart';
+import '../../../../ui/theme/app_spacing.dart';
+import '../../../../ui/widgets/widgets.dart';
+import '../../domain/entities/app_notification.dart';
+import '../../domain/entities/user_activity.dart';
+import '../bloc/notifications_bloc.dart';
+import '../bloc/notifications_state.dart';
+
+class NotificationsView extends StatelessWidget {
+  const NotificationsView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<NotificationsBloc, NotificationsState>(
+      builder: (context, state) {
+        // First load with no cached content yet — defer to the failure / empty
+        // states below once it settles.
+        if (state.failure != null && state.hasNoContent) {
+          return AppScaffold(
+            title: context.l10n.notificationsAppBarTitle,
+            body: AppErrorView(
+              message: context.l10n.notificationsLoadError,
+              onRetry: () => context.read<NotificationsBloc>().add(
+                const NotificationsLoadRequested(),
+              ),
+            ),
+          );
+        }
+
+        return AppScaffold(
+          title: context.l10n.notificationsAppBarTitle,
+          isLoading: state.isLoading && state.hasNoContent,
+          padding: EdgeInsets.zero,
+          body: state.hasNoContent && !state.isLoading
+              ? AppEmptyView(
+                  icon: Icons.notifications_none_outlined,
+                  title: context.l10n.notificationsEmptyTitle,
+                  message: context.l10n.notificationsEmptyMessage,
+                )
+              : const _FeedList(),
+        );
+      },
+    );
+  }
+}
+
+class _FeedList extends StatelessWidget {
+  const _FeedList();
+
+  @override
+  Widget build(BuildContext context) {
+    final state = context.watch<NotificationsBloc>().state;
+    return RefreshIndicator(
+      onRefresh: () {
+        final bloc = context.read<NotificationsBloc>()
+          ..add(const NotificationsLoadRequested());
+        // Keep the spinner visible until the reload settles.
+        return bloc.stream.firstWhere((s) => !s.isLoading);
+      },
+      child: ListView(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        children: [
+          if (state.activities.isNotEmpty) ...[
+            _SectionHeader(title: context.l10n.notificationsActivitySection),
+            const SizedBox(height: AppSpacing.sm),
+            for (final (index, activity) in state.activities.indexed)
+              _ActivityTile(
+                activity: activity,
+              ).animateSlideUp(delay: (50 * index).ms),
+            const SizedBox(height: AppSpacing.xl),
+          ],
+          _SectionHeader(
+            title: context.l10n.notificationsSection,
+            badgeCount: state.unreadCount,
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          if (state.notifications.isEmpty)
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
+              child: Text(
+                context.l10n.notificationsNoNotifications,
+                style: context.textTheme.bodyMedium?.copyWith(
+                  color: context.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            )
+          else
+            for (final (index, notification) in state.notifications.indexed)
+              _NotificationTile(
+                notification: notification,
+                onTap: () => context.read<NotificationsBloc>().add(
+                  NotificationMarkReadRequested(notification.id),
+                ),
+              ).animateSlideUp(delay: (50 * index).ms),
+        ],
+      ),
+    );
+  }
+}
+
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({required this.title, this.badgeCount = 0});
+
+  final String title;
+  final int badgeCount;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Text(
+          title,
+          style: context.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        if (badgeCount > 0) ...[
+          const SizedBox(width: AppSpacing.sm),
+          Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.sm,
+              vertical: AppSpacing.xxs,
+            ),
+            decoration: BoxDecoration(
+              color: context.colorScheme.primary,
+              borderRadius: BorderRadius.circular(AppRadius.xl),
+            ),
+            child: Text(
+              context.l10n.notificationsUnreadCount(badgeCount),
+              style: context.textTheme.labelSmall?.copyWith(
+                color: context.colorScheme.onPrimary,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}
+
+class _ActivityTile extends StatelessWidget {
+  const _ActivityTile({required this.activity});
+
+  final UserActivity activity;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      color: context.colorScheme.surfaceContainerHighest.withValues(
+        alpha: 0.4,
+      ),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: context.colorScheme.secondaryContainer,
+          child: Icon(
+            _activityIcon(activity.type),
+            color: context.colorScheme.onSecondaryContainer,
+          ),
+        ),
+        title: Text(activity.description),
+        subtitle: Text(formatRelativeTime(context, activity.createdAt)),
+      ),
+    );
+  }
+}
+
+class _NotificationTile extends StatelessWidget {
+  const _NotificationTile({required this.notification, required this.onTap});
+
+  final AppNotification notification;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = _notificationColor(context, notification.type);
+    return Card(
+      elevation: notification.isRead ? 0 : 1,
+      color: notification.isRead
+          ? context.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4)
+          : context.colorScheme.surface,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: ListTile(
+        onTap: notification.isRead ? null : onTap,
+        leading: CircleAvatar(
+          backgroundColor: accent.withValues(alpha: 0.15),
+          child: Icon(_notificationIcon(notification.type), color: accent),
+        ),
+        title: Text(
+          notification.title,
+          style: TextStyle(
+            fontWeight: notification.isRead
+                ? FontWeight.w400
+                : FontWeight.w600,
+          ),
+        ),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(notification.body),
+            const SizedBox(height: AppSpacing.xxs),
+            Text(
+              formatRelativeTime(context, notification.createdAt),
+              style: context.textTheme.labelSmall?.copyWith(
+                color: context.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+        trailing: notification.isRead
+            ? null
+            : Container(
+                width: 10,
+                height: 10,
+                decoration: BoxDecoration(
+                  color: accent,
+                  shape: BoxShape.circle,
+                ),
+              ),
+      ),
+    );
+  }
+}
+
+IconData _activityIcon(UserActivityType type) => switch (type) {
+  UserActivityType.created => Icons.add_circle_outline,
+  UserActivityType.updated => Icons.edit_outlined,
+  UserActivityType.deleted => Icons.delete_outline,
+  UserActivityType.signedIn => Icons.login_outlined,
+  UserActivityType.other => Icons.history,
+};
+
+IconData _notificationIcon(NotificationType type) => switch (type) {
+  NotificationType.system => Icons.info_outline,
+  NotificationType.social => Icons.people_outline,
+  NotificationType.reminder => Icons.alarm_outlined,
+  NotificationType.promotion => Icons.local_offer_outlined,
+};
+
+Color _notificationColor(BuildContext context, NotificationType type) =>
+    switch (type) {
+      NotificationType.system => context.colorScheme.primary,
+      NotificationType.social => context.semanticColors.info,
+      NotificationType.reminder => context.semanticColors.warning,
+      NotificationType.promotion => context.semanticColors.success,
+    };
+
+/// Formats [timestamp] as a compact, localized relative time
+/// (e.g. "Just now", "5m ago", "3h ago", "2d ago", or an absolute date).
+String formatRelativeTime(BuildContext context, DateTime timestamp) {
+  final l10n = context.l10n;
+  final diff = DateTime.now().difference(timestamp);
+  if (diff.inMinutes < 1) return l10n.timeJustNow;
+  if (diff.inMinutes < 60) return l10n.timeMinutesAgo(diff.inMinutes);
+  if (diff.inHours < 24) return l10n.timeHoursAgo(diff.inHours);
+  if (diff.inDays < 7) return l10n.timeDaysAgo(diff.inDays);
+  final local = timestamp.toLocal();
+  return '${local.year}-${local.month.toString().padLeft(2, '0')}-'
+      '${local.day.toString().padLeft(2, '0')}';
+}

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -152,5 +152,50 @@
     }
   },
   "bookmarkAttachedImageLabel": "Attached image",
-  "bookmarkRemoveImageLabel": "Remove image"
+  "bookmarkRemoveImageLabel": "Remove image",
+  "navNotifications": "Notifications",
+  "notificationsAppBarTitle": "Notifications",
+  "notificationsActivitySection": "Your activity",
+  "notificationsSection": "Notifications",
+  "notificationsEmptyTitle": "Nothing here yet",
+  "notificationsEmptyMessage": "Your notifications and recent activity will appear here.",
+  "notificationsNoNotifications": "No notifications yet.",
+  "notificationsLoadError": "Couldn't load your notifications. Pull to refresh or try again.",
+  "notificationsUnreadCount": "{count} unread",
+  "@notificationsUnreadCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "timeJustNow": "Just now",
+  "timeMinutesAgo": "{minutes}m ago",
+  "@timeMinutesAgo": {
+    "placeholders": {
+      "minutes": {
+        "type": "int",
+        "example": "5"
+      }
+    }
+  },
+  "timeHoursAgo": "{hours}h ago",
+  "@timeHoursAgo": {
+    "placeholders": {
+      "hours": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "timeDaysAgo": "{days}d ago",
+  "@timeDaysAgo": {
+    "placeholders": {
+      "days": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  }
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -751,6 +751,84 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Remove image'**
   String get bookmarkRemoveImageLabel;
+
+  /// No description provided for @navNotifications.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get navNotifications;
+
+  /// No description provided for @notificationsAppBarTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get notificationsAppBarTitle;
+
+  /// No description provided for @notificationsActivitySection.
+  ///
+  /// In en, this message translates to:
+  /// **'Your activity'**
+  String get notificationsActivitySection;
+
+  /// No description provided for @notificationsSection.
+  ///
+  /// In en, this message translates to:
+  /// **'Notifications'**
+  String get notificationsSection;
+
+  /// No description provided for @notificationsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Nothing here yet'**
+  String get notificationsEmptyTitle;
+
+  /// No description provided for @notificationsEmptyMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Your notifications and recent activity will appear here.'**
+  String get notificationsEmptyMessage;
+
+  /// No description provided for @notificationsNoNotifications.
+  ///
+  /// In en, this message translates to:
+  /// **'No notifications yet.'**
+  String get notificationsNoNotifications;
+
+  /// No description provided for @notificationsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load your notifications. Pull to refresh or try again.'**
+  String get notificationsLoadError;
+
+  /// No description provided for @notificationsUnreadCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count} unread'**
+  String notificationsUnreadCount(int count);
+
+  /// No description provided for @timeJustNow.
+  ///
+  /// In en, this message translates to:
+  /// **'Just now'**
+  String get timeJustNow;
+
+  /// No description provided for @timeMinutesAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{minutes}m ago'**
+  String timeMinutesAgo(int minutes);
+
+  /// No description provided for @timeHoursAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{hours}h ago'**
+  String timeHoursAgo(int hours);
+
+  /// No description provided for @timeDaysAgo.
+  ///
+  /// In en, this message translates to:
+  /// **'{days}d ago'**
+  String timeDaysAgo(int days);
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -350,4 +350,53 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get bookmarkRemoveImageLabel => 'Remove image';
+
+  @override
+  String get navNotifications => 'Notifications';
+
+  @override
+  String get notificationsAppBarTitle => 'Notifications';
+
+  @override
+  String get notificationsActivitySection => 'Your activity';
+
+  @override
+  String get notificationsSection => 'Notifications';
+
+  @override
+  String get notificationsEmptyTitle => 'Nothing here yet';
+
+  @override
+  String get notificationsEmptyMessage =>
+      'Your notifications and recent activity will appear here.';
+
+  @override
+  String get notificationsNoNotifications => 'No notifications yet.';
+
+  @override
+  String get notificationsLoadError =>
+      'Couldn\'t load your notifications. Pull to refresh or try again.';
+
+  @override
+  String notificationsUnreadCount(int count) {
+    return '$count unread';
+  }
+
+  @override
+  String get timeJustNow => 'Just now';
+
+  @override
+  String timeMinutesAgo(int minutes) {
+    return '${minutes}m ago';
+  }
+
+  @override
+  String timeHoursAgo(int hours) {
+    return '${hours}h ago';
+  }
+
+  @override
+  String timeDaysAgo(int days) {
+    return '${days}d ago';
+  }
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -352,4 +352,53 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get bookmarkRemoveImageLabel => 'Xóa hình ảnh';
+
+  @override
+  String get navNotifications => 'Thông báo';
+
+  @override
+  String get notificationsAppBarTitle => 'Thông báo';
+
+  @override
+  String get notificationsActivitySection => 'Hoạt động của bạn';
+
+  @override
+  String get notificationsSection => 'Thông báo';
+
+  @override
+  String get notificationsEmptyTitle => 'Chưa có gì ở đây';
+
+  @override
+  String get notificationsEmptyMessage =>
+      'Thông báo và hoạt động gần đây của bạn sẽ hiển thị ở đây.';
+
+  @override
+  String get notificationsNoNotifications => 'Chưa có thông báo nào.';
+
+  @override
+  String get notificationsLoadError =>
+      'Không tải được thông báo. Hãy kéo để làm mới hoặc thử lại.';
+
+  @override
+  String notificationsUnreadCount(int count) {
+    return '$count chưa đọc';
+  }
+
+  @override
+  String get timeJustNow => 'Vừa xong';
+
+  @override
+  String timeMinutesAgo(int minutes) {
+    return '$minutes phút trước';
+  }
+
+  @override
+  String timeHoursAgo(int hours) {
+    return '$hours giờ trước';
+  }
+
+  @override
+  String timeDaysAgo(int days) {
+    return '$days ngày trước';
+  }
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -116,5 +116,50 @@
   "bookmarksDetailPlaceholder": "Chọn một bookmark để xem chi tiết",
   "bookmarkImageLabel": "Hình ảnh của {title}",
   "bookmarkAttachedImageLabel": "Hình ảnh đính kèm",
-  "bookmarkRemoveImageLabel": "Xóa hình ảnh"
+  "bookmarkRemoveImageLabel": "Xóa hình ảnh",
+  "navNotifications": "Thông báo",
+  "notificationsAppBarTitle": "Thông báo",
+  "notificationsActivitySection": "Hoạt động của bạn",
+  "notificationsSection": "Thông báo",
+  "notificationsEmptyTitle": "Chưa có gì ở đây",
+  "notificationsEmptyMessage": "Thông báo và hoạt động gần đây của bạn sẽ hiển thị ở đây.",
+  "notificationsNoNotifications": "Chưa có thông báo nào.",
+  "notificationsLoadError": "Không tải được thông báo. Hãy kéo để làm mới hoặc thử lại.",
+  "notificationsUnreadCount": "{count} chưa đọc",
+  "@notificationsUnreadCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "timeJustNow": "Vừa xong",
+  "timeMinutesAgo": "{minutes} phút trước",
+  "@timeMinutesAgo": {
+    "placeholders": {
+      "minutes": {
+        "type": "int",
+        "example": "5"
+      }
+    }
+  },
+  "timeHoursAgo": "{hours} giờ trước",
+  "@timeHoursAgo": {
+    "placeholders": {
+      "hours": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "timeDaysAgo": "{days} ngày trước",
+  "@timeDaysAgo": {
+    "placeholders": {
+      "days": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Adds a **Notifications** page to the app and surfaces it as a new bottom-bar destination. The page shows a single combined feed: the user's recent **activity** on top, **notifications** below.

Built as a self-contained `lib/features/notifications/` slice that mirrors the `bookmarks` clean-architecture pattern (data → domain → presentation), with dependency direction `features → shared → ui → core` preserved.

## What's included

**Domain**
- `AppNotification`, `UserActivity`, `NotificationsFeed` entities (+ `NotificationType` / `UserActivityType` enums)
- `NotificationsRepository` interface
- `GetNotificationsFeed` and `MarkNotificationRead` use cases

**Data**
- `NotificationDto` / `UserActivityDto` (freezed + json_serializable)
- Retrofit `NotificationsRemoteDataSource` — `GET /api/notifications`, `GET /api/activity`, `PATCH /api/notifications/{id}/read`
- `@module` provider (uses the authenticated `Dio`, so the feed is user-scoped)
- `NotificationsRepositoryImpl` — fetches both lists concurrently via record `.wait`, maps DTO type strings to enums with safe fallbacks

**Presentation**
- `NotificationsBloc` — load via `droppable`, optimistic mark-as-read with rollback via `sequential`
- freezed `NotificationsState` with `unreadCount` / `hasNoContent`
- `NotificationsScreen` + combined-feed widgets: pull-to-refresh, unread badge, per-type icons/accent colors (from `SemanticColors`), staggered animations, shared `AppScaffold` / `AppEmptyView` / `AppErrorView` states

**Wiring**
- `/notifications` go_router branch + bottom-bar destination in `AppShell` (inserted between Bookmarks and Profile; branch order kept in sync with destination order)
- en/vi ARB strings (nav label, page strings, relative-time formatting)

## Notes

- The endpoints are assumed REST contracts. Until a backend serves them, the page shows the retry error state — adjust paths/DTO field names in the data layer if your API differs.
- Per the repo's committed-generated-code policy, `gen-l10n` and `build_runner` were run; regenerated `.freezed.dart` / `.g.dart` / `router.g.dart` / `injection.config.dart` / localizations are included.

## Testing

- `fvm flutter analyze` — no issues
- `fvm flutter test` — all 293 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)