### PR TITLE
Update README architecture documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    # Skip analyze/test when a push touches only docs. Any change outside
+    # these paths (lib/, test/, packages/, pubspec.*, etc.) still triggers CI.
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
 
 # Cancel superseded runs on the same ref to save CI minutes.
 concurrency:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,9 @@ name: CodeQL
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.md'
+      - 'LICENSE'
   pull_request:
     branches: [main]
     paths:

--- a/README.md
+++ b/README.md
@@ -60,44 +60,58 @@ To enable seamless local development and testing, this template is paired with a
 ## 🧬 Architecture
 
 ```
-lib/
-├── main.dart                         # Entry: DI → Firebase → runApp
-├── app/
-│   ├── app.dart                      # MaterialApp.router + providers
-│   ├── router.dart                   # TypedGoRoute + auth redirect
-│   └── widgets/                      # App-level shell widgets
-├── core/
-│   ├── analytics/                    # Firebase Analytics wrapper + route observer
-│   ├── config/                       # EnvConfig — typed --dart-define values
-│   ├── di/                           # get_it + injectable
-│   ├── domain/                       # Failure, Result, UseCase primitives
-│   ├── extensions/                   # BuildContext and Future helpers
-│   ├── firebase/                     # Firebase initialization & global Crashlytics/Messaging setup
-│   ├── layout/                       # Responsive breakpoints (AppBreakpoints)
-│   ├── media/                        # Camera, Image Picker, and Video Player wrapper services
-│   ├── network/                      # Dio clients, auth interceptor, token refresh
-│   ├── notifications/                # flutter_local_notifications
-│   ├── permissions/                  # Runtime permission request handling
-│   └── share/                        # share_plus wrapper
-├── features/
-│   ├── auth/                         # Sign-in, sign-out, session restore
-│   ├── bookmarks/                    # CRUD, offline sync, list/detail/form
-│   ├── home/                         # Welcome screen
-│   ├── notifications/                # Notification and activity feed
-│   ├── profile/                      # User info + notification controls
-│   └── splash/                       # Session restoration gate
-├── gen/                              # flutter_gen asset references
-├── l10n/                             # ARB translation files
-├── shared/                           # Cross-feature domain contracts
-└── ui/                               # Theme, animation, reusable widgets
+.
+├── lib/                              # Root Flutter app package
+│   ├── main.dart                     # Entry: DI → Firebase → runApp
+│   ├── app/
+│   │   ├── app.dart                  # MaterialApp.router + providers
+│   │   ├── router.dart               # TypedGoRoute + auth redirect
+│   │   └── widgets/                  # App-level shell widgets
+│   ├── core/
+│   │   ├── data/database/            # ObjectBox wrapper and generated store binding
+│   │   ├── di/                       # get_it + injectable app graph
+│   │   ├── extensions/               # App-specific convenience extensions
+│   │   └── platform/firebase/        # App bootstrap for Firebase services
+│   ├── features/
+│   │   ├── auth/                     # Sign-in, sign-out, session restore
+│   │   ├── bookmarks/                # CRUD, offline sync, list/detail/form
+│   │   ├── home/                     # Home dashboard
+│   │   ├── notifications/            # Notification and activity feed
+│   │   ├── profile/                  # User info + account actions
+│   │   └── splash/                   # Session restoration gate
+│   ├── gen/                          # flutter_gen asset references
+│   ├── l10n/                         # ARB files + generated localizations
+│   ├── shared/                       # App-level shared domain/presentation contracts
+│   └── ui/                           # Compatibility exports for app_ui
+├── packages/                         # Dart Pub Workspace members
+│   ├── app_ui/                       # Design system, theme, layout, reusable widgets
+│   ├── core_analytics/               # Analytics service + route observer
+│   ├── core_config/                  # EnvConfig + Remote Config wrapper
+│   ├── core_domain/                  # Failure, Result, UseCase primitives
+│   ├── core_network/                 # Dio, Retrofit, retry/performance interceptors
+│   ├── core_platform/                # Camera, picker, permissions, notifications, share
+│   ├── core_storage/                 # SharedPreferences and secure storage helpers
+│   ├── core_theme/                   # ThemeBloc and persisted theme state
+│   └── test_utils/                   # Shared mocks, images, and mocktail export
+├── test/                             # Root app tests only
+└── integration_test/                 # Device/emulator integration tests
 ```
 
-The repository uses Dart Pub Workspaces. The root package remains the Flutter
-app, and `packages/app_ui` contains shared, pure UI design tokens such as
-spacing, radii, icon sizes, and motion durations. `packages/core_domain`
-contains pure-Dart domain primitives such as `Failure`, `Result`, and `UseCase`.
-Existing `lib/ui/...` token files and `lib/core/domain/...` files re-export the
-workspace packages for compatibility with current app imports.
+The repository uses Dart Pub Workspaces. The root package is the assembled
+Flutter app: routing, DI composition, app-only features, ObjectBox entities, and
+Firebase bootstrap stay there. Reusable infrastructure lives in `packages/` and
+is consumed through package entry points such as `package:core_network/core_network.dart`.
+
+Workspace packages own their third-party implementation details. For example,
+the root app depends on `core_network`, not directly on `dio` or `retrofit`;
+`core_network` exports those APIs when the app needs the types. The same pattern
+keeps platform, storage, analytics, theme, and UI dependencies versioned in one
+place and avoids root-package dependency conflicts.
+
+Compatibility exports remain under `lib/ui/...` for existing app imports, but
+new shared UI should be added to `packages/app_ui`. Package-owned tests live
+beside their package in `packages/<name>/test`, while root app tests stay under
+`test/`.
 
 <details>
 <summary><b>📁 Feature Slice (Clean Architecture)</b></summary>
@@ -202,20 +216,34 @@ This template includes a robust set of automated tests and static analysis confi
 
 ### 🏃 Running Tests
 
-Unit and widget tests mirror the `lib/` directory structure. Run them using:
+Root app tests mirror the `lib/` feature structure. Package-owned tests live
+beside the package they cover under `packages/<name>/test`.
 
 ```bash
-# Run all unit and widget tests
-fvm flutter test
+# Run root app unit and widget tests
+fvm flutter test --exclude-tags golden
 
 # Run a specific test file
 fvm flutter test test/widget_test.dart
 
 # Run tests by name match
 fvm flutter test --name "signs in"
+
+# Run a package's own tests
+(cd packages/core_network && fvm flutter test)
 ```
 
-Refer to the [test/README.md](test/README.md) file for detailed testing guidelines and patterns.
+Shared mocks and test fixtures live in `packages/test_utils` and are exported
+through `package:test_utils/test_utils.dart`; root-only fixtures remain in
+`test/test_utils/`.
+
+CI runs root tests with coverage, then runs each package test suite with
+coverage and merges the LCOV reports before enforcing the workspace coverage
+threshold. Golden tests are excluded in CI because baselines are generated on
+macOS while CI runs on Ubuntu.
+
+Refer to the [test/README.md](test/README.md) file for detailed testing
+guidelines and patterns.
 
 ### 🔍 Static Analysis & Linting
 
@@ -249,7 +277,13 @@ Before pushing your branch, run local checks to ensure the CI will pass:
 ```bash
 fvm dart format .
 fvm flutter analyze
-fvm flutter test
+fvm flutter test --exclude-tags golden
+
+for package in packages/*; do
+  if [ -d "$package/test" ]; then
+    (cd "$package" && fvm flutter test --exclude-tags golden)
+  fi
+done
 ```
 
 ### 3. Open a Pull Request
@@ -306,7 +340,8 @@ fvm flutter run --flavor staging --dart-define-from-file=env/staging.json
 fvm flutter run --flavor prod    --dart-define-from-file=env/prod.json
 ```
 
-`EnvConfig` (`lib/core/config/env_config.dart`) surfaces API base URL, Firebase project IDs, and flavor name from `String.fromEnvironment` at startup.
+`EnvConfig` (`packages/core_config/lib/core_config.dart`) surfaces API base URL,
+Firebase project IDs, and flavor name from `String.fromEnvironment` at startup.
 
 <br>
 
@@ -365,23 +400,31 @@ Replace `yourdomain.com` with your actual domain, then host these on your server
 
 ## 🧩 UI Widgets
 
-All shared components in `lib/ui/widgets/`:
+Shared app components live in `packages/app_ui` and are exported through
+`package:app_ui/app_ui.dart`. The root `lib/ui/...` files remain compatibility
+exports for existing app imports.
 
 | Widget              | Purpose                                                          |
 |---------------------|------------------------------------------------------------------|
+| `AppAdaptiveScaffold` | Responsive navigation shell with bottom bar / rail behavior    |
 | `AppAnimatedText`   | Typewriter + fade text animations                                |
 | `AppButton`         | Loading state, expand‑to‑fill, leading icon                      |
 | `AppCarousel`       | Auto‑play slider with dot indicators                             |
 | `AppEmptyView`      | Empty‑state placeholder — icon + message                         |
 | `AppErrorView`      | Error state — icon + message + retry                             |
 | `AppLinkPreview`    | Rich card — image, title, description                            |
+| `AppListDetailPane` | Responsive master/detail layout primitive                        |
 | `AppLoading`        | Centered spinner                                                 |
 | `AppNetworkImage`   | Cached network image with loading placeholder and error widgets  |
 | `AppPhotoView`      | Interactive image viewer with zoom, rotation, and fullscreen gallery |
 | `AppScaffold`       | Themed shell — app bar, connectivity banner                      |
+| `AppSkeleton`       | Lightweight loading skeleton                                     |
 | `AppSlidable`       | Swipe‑to‑reveal actions wrapper for list items                    |
 | `AppTextField`      | Label, prefix icon, validation, autofill hints                   |
-| `AppVideoPlayer`    | Customizable video player with progress controls and audio controls |
+
+Feature-specific widgets stay inside their feature slice. For example, bookmark
+video playback widgets live under `lib/features/bookmarks/presentation/widgets/`
+because they are tied to bookmark attachment behavior.
 
 <br>
 
@@ -396,32 +439,32 @@ All shared components in `lib/ui/widgets/`:
 | **State**          | `flutter_bloc` (Bloc) · `bloc_concurrency`                                                         |
 | **Routing**        | `go_router` · `go_router_builder`                                                                  |
 | **DI**             | `get_it` · `injectable`                                                                            |
-| **Networking**     | `Dio` · `Retrofit`                                                                                 |
+| **Networking**     | `core_network` (`Dio` · `Retrofit`)                                                                |
 | **Code Gen**       | `build_runner` · `freezed` · `json_serializable` · `retrofit_generator` · `injectable_generator` · `go_router_builder` · `flutter_gen_runner` · `objectbox_generator` |
 | **Local DB**       | `ObjectBox` (`objectbox` · `objectbox_flutter_libs`)                                               |
-| **Secure Storage** | `flutter_secure_storage`                                                                           |
+| **Secure Storage** | `core_storage` (`flutter_secure_storage` · `shared_preferences`)                                    |
 | **Auth**           | JWT — access + refresh tokens                                                                      |
-| **Theming**        | Material 3 · `flex_color_scheme` · `google_fonts` (Inter)                                          |
+| **Theming**        | `core_theme` · Material 3 · `flex_color_scheme` · `google_fonts` (Inter)                           |
 | **i18n**           | `flutter_localizations` · `intl`                                                                   |
 | **Icons**          | `cupertino_icons`                                                                                  |
 | **Assets**         | `flutter_svg` · `flutter_gen_runner`                                                               |
-| **Image / Media**  | `photo_view` · `image_picker` · `camera` · `video_player` · `cached_network_image` · `vector_graphics` |
+| **Image / Media**  | `app_ui` · `core_platform` (`photo_view` · `image_picker` · `camera` · `video_player` · `cached_network_image` · `vector_graphics`) |
 | **Carousel**       | `carousel_slider`                                                                                  |
 | **List Slidables** | `flutter_slidable`                                                                                 |
-| **Permissions**    | `permission_handler`                                                                               |
-| **Notifications**  | `flutter_local_notifications`                                                                      |
-| **Firebase**       | `firebase_core` · `firebase_crashlytics` · `firebase_analytics` · `firebase_messaging`             |
+| **Permissions**    | `core_platform` (`permission_handler`)                                                             |
+| **Notifications**  | `core_platform` (`flutter_local_notifications` · `firebase_messaging`)                             |
+| **Firebase**       | `firebase_core` · `core_analytics` · `core_platform`                                                |
 | **Animations**     | `flutter_animate` · `animated_text_kit`                                                            |
 | **Haptics**        | `HapticFeedback` (Flutter Services)                                                                |
 | **Connectivity**   | `connectivity_plus`                                                                                |
 | **Storage**        | `path_provider` · `shared_preferences`                                                             |
 | **Device Info**    | `package_info_plus`                                                                                |
 | **URL**            | `url_launcher`                                                                                     |
-| **Share**          | `share_plus`                                                                                       |
+| **Share**          | `core_platform` (`share_plus`)                                                                     |
 | **Link Preview**   | `flutter_link_previewer`                                                                           |
 | **UUID**           | `uuid`                                                                                             |
 | **Splash**         | Custom session-restore bootstrapper (no package)                                                   |
-| **Testing & Lints**| `mocktail` · `bloc_test` · `very_good_analysis` · `build_verify`                                        |
+| **Testing & Lints**| `test_utils` (`mocktail`) · `bloc_test` · `very_good_analysis` · `build_verify`                    |
 | **Backend**        | Go — `chi/v5` · `golang-jwt/v5` · `cors`                                                          |
 
 <br>

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ To enable seamless local development and testing, this template is paired with a
 │   │   └── splash/                   # Session restoration gate
 │   ├── gen/                          # flutter_gen asset references
 │   ├── l10n/                         # ARB files + generated localizations
-│   ├── shared/                       # App-level shared domain/presentation contracts
-│   └── ui/                           # Compatibility exports for app_ui
+│   └── shared/                       # App-level shared domain/presentation contracts
 ├── packages/                         # Dart Pub Workspace members
 │   ├── app_ui/                       # Design system, theme, layout, reusable widgets
 │   ├── core_analytics/               # Analytics service + route observer
@@ -108,10 +107,10 @@ the root app depends on `core_network`, not directly on `dio` or `retrofit`;
 keeps platform, storage, analytics, theme, and UI dependencies versioned in one
 place and avoids root-package dependency conflicts.
 
-Compatibility exports remain under `lib/ui/...` for existing app imports, but
-new shared UI should be added to `packages/app_ui`. Package-owned tests live
-beside their package in `packages/<name>/test`, while root app tests stay under
-`test/`.
+All shared UI lives in `packages/app_ui` and is consumed through
+`package:app_ui/app_ui.dart`; add new generic widgets there. Package-owned tests
+live beside their package in `packages/<name>/test`, while root app tests stay
+under `test/`.
 
 <details>
 <summary><b>📁 Feature Slice (Clean Architecture)</b></summary>
@@ -401,8 +400,7 @@ Replace `yourdomain.com` with your actual domain, then host these on your server
 ## 🧩 UI Widgets
 
 Shared app components live in `packages/app_ui` and are exported through
-`package:app_ui/app_ui.dart`. The root `lib/ui/...` files remain compatibility
-exports for existing app imports.
+`package:app_ui/app_ui.dart`.
 
 | Widget              | Purpose                                                          |
 |---------------------|------------------------------------------------------------------|
@@ -638,7 +636,10 @@ Since `generate: true` is enabled in [pubspec.yaml](file:///Users/trunglaptieu/d
 fvm flutter gen-l10n
 ```
 
-Import `package:flutter_gen/gen_l10n/app_localizations.dart` and use `AppLocalizations.of(context)` to access localized strings.
+Generated localizations are emitted into `lib/l10n/`. Import
+`package:flutter_starter_template/l10n/app_localizations.dart` and use
+`AppLocalizations.of(context)` (or the `context.l10n` extension) to access
+localized strings.
 
 <br>
 

--- a/android/README.md
+++ b/android/README.md
@@ -10,9 +10,9 @@ While Flutter generates this directory and manages most of its configurations au
   - **`app/src/main/AndroidManifest.xml`**: The central configuration file for the Android app. Modify this file to add native Android permissions (e.g., camera, internet), register deep linking intent filters, or update the application name and icon.
   - **`app/src/main/kotlin/`** (or `java/`): Contains the `MainActivity` class (usually inheriting from `FlutterActivity`). You edit this if you need to write custom native Kotlin/Java code or integrate Android-specific plugins that require activity changes.
   - **`app/src/main/res/`**: Native Android resources, such as launcher icons (`mipmap` folders) and splash screens.
-  - **`app/build.gradle`**: The module-level Gradle build file. Use this to change the application ID (package name), version code/name, minimum/target SDK versions, and to add Android-specific dependencies (like Firebase BOM).
-- **`build.gradle`** (Root): The project-level Gradle configuration. It defines the Gradle plugins and repositories used across all modules.
-- **`settings.gradle`**: Configures the Gradle project and includes the `app` module.
+  - **`app/build.gradle.kts`**: The module-level Gradle build file (Kotlin DSL). Use this to change the application ID (package name), version code/name, minimum/target SDK versions, and to add Android-specific dependencies (like Firebase BOM).
+- **`build.gradle.kts`** (Root): The project-level Gradle configuration. It defines the Gradle plugins and repositories used across all modules.
+- **`settings.gradle.kts`**: Configures the Gradle project and includes the `app` module.
 - **`gradle.properties`**: Contains project-wide Gradle properties (e.g., enabling AndroidX, allocating memory for the Gradle daemon).
 - **`gradlew` / `gradlew.bat`**: The Gradle wrapper executable used to build the Android project from the command line without requiring a global Gradle installation.
 
@@ -30,10 +30,10 @@ To request access to device hardware or data (like the internet or location), ad
 ```
 
 ### 2. Updating the SDK Version
-To change the `minSdkVersion`, `compileSdkVersion`, or `targetSdkVersion`, modify the `app/build.gradle` file (or sometimes the `local.properties` depending on how the Flutter template is structured).
+To change the `minSdkVersion`, `compileSdkVersion`, or `targetSdkVersion`, modify the `app/build.gradle.kts` file (or sometimes the `local.properties` depending on how the Flutter template is structured).
 
 ### 3. Signing the App for Release
-To build a release APK or AAB, you need to configure app signing. This typically involves creating a `keystore` file and referencing it in `app/build.gradle`. Refer to the [official Flutter documentation on Android deployment](https://docs.flutter.dev/deployment/android) for details.
+To build a release APK or AAB, you need to configure app signing. This typically involves creating a `keystore` file and referencing it in `app/build.gradle.kts`. Refer to the [official Flutter documentation on Android deployment](https://docs.flutter.dev/deployment/android) for details.
 
 ## Important Note
 

--- a/env/README.md
+++ b/env/README.md
@@ -36,7 +36,7 @@ The `.vscode/launch.json` file is already configured to use these environments. 
 Inside the application, these variables are mapped to strongly-typed properties through the `EnvConfig` class using `String.fromEnvironment`. 
 
 ```dart
-// Example of how it's defined in lib/core/config/env_config.dart
+// Example of how it's defined in packages/core_config/lib/src/env_config.dart
 String get apiBaseUrl => const String.fromEnvironment(
   'API_BASE_URL', 
   defaultValue: 'http://localhost:8080'

--- a/lib/core/README.md
+++ b/lib/core/README.md
@@ -2,25 +2,42 @@
 
 This directory contains reusable, cross-feature code that is shared across the entire application. 
 
-In our feature-first Clean Architecture approach, the `core` directory holds the foundational layers and utilities that any feature can depend on. However, **code inside `core/` must never depend on code inside `features/`**.
+In our feature-first Clean Architecture approach, the `core` directory holds the foundational, app-owned infrastructure that any feature can depend on. However, **code inside `core/` must never depend on code inside `features/`**.
+
+Most reusable, third-party-backed infrastructure has been extracted into
+workspace packages under `packages/` (see the table below). What remains in
+`lib/core/` is infrastructure that stays coupled to the assembled app —
+the DI composition root, the ObjectBox store, and Firebase bootstrap.
 
 ## Directory Structure
 
-Here is a breakdown of the typical subdirectories found in `core/`:
+Here is a breakdown of the subdirectories found in `core/`:
 
-- **`analytics/`**: Centralized services for logging events, screen views, and user properties (e.g., Firebase Analytics wrapper).
-- **`config/`**: App-wide configurations, environment variables, feature flags, and constants.
-- **`di/`**: Dependency Injection setup (e.g., `get_it` or `injectable` configurations) for registering all core services, repositories, and BLoCs.
-- **`domain/`**: Architecture-level domain primitives shared by feature domains, such as `Failure`, `Result<T>`, and `UseCase`.
-- **`data/`**: Reusable data-layer infrastructure, such as database wrappers, networking clients, interceptors, API configuration, and data-source helpers.
-- **`extensions/`**: Generic extensions used across the app (e.g., `build_context_extensions.dart`, `future_extensions.dart`).
-- **`layout/`**: Responsive layout primitives such as breakpoints.
-- **`platform/`**: App-wide platform and plugin integrations, such as Firebase initialization, media picking/playback, push/local notifications, OS permissions, and sharing.
+- **`data/database/`**: The app's ObjectBox wrapper and its generated store binding (`object_box.dart`).
+- **`di/`**: Dependency Injection setup (`get_it` + `injectable`) that composes the app graph, wiring together services from the workspace packages and the feature modules.
+- **`extensions/`**: App-specific convenience extensions used across features.
+- **`platform/firebase/`**: App bootstrap for Firebase services (`FirebaseService` — initialization, Crashlytics handlers, background messaging).
+
+## Where the rest of `core` went
+
+Reusable, non-visual infrastructure now lives in versioned workspace packages,
+consumed through their entry points (e.g. `package:core_network/core_network.dart`):
+
+| Concern | Package |
+|---|---|
+| Architecture primitives (`Failure`, `Result`, `UseCase`) | `core_domain` |
+| Networking (`Dio`, `Retrofit`, interceptors) | `core_network` |
+| Analytics + route observer | `core_analytics` |
+| Env + Remote Config | `core_config` |
+| Secure storage + preferences | `core_storage` |
+| Media, picker, permissions, notifications, share | `core_platform` |
+| Theme state (`ThemeBloc`) | `core_theme` |
+| Design system — theming, widgets, layout, animation | `app_ui` |
 
 > [!NOTE]
-> The design system — global theming (`theme/`), reusable generic widgets
-> (`widgets/`), and animation primitives (`animation/`) — lives in `lib/ui/`,
-> not here. `core/` is for non-visual infrastructure.
+> The design system (theming, reusable generic widgets, layout primitives, and
+> animations) lives in the `app_ui` package, not here. `core/` is for non-visual,
+> app-coupled infrastructure.
 
 ## Golden Rule
 

--- a/lib/features/README.md
+++ b/lib/features/README.md
@@ -28,7 +28,10 @@ The UI layer responsible for displaying information to the user and capturing us
 
 ## Best Practices
 
-- **Feature Independence:** Features should be as isolated as possible. A feature should not directly import `data`, `domain`, or `presentation` files from another feature.
-- **Shared Code:** If code needs to be shared across multiple features, it belongs in the `lib/core/` directory.
+- **Feature Independence:** Features should be as isolated as possible. As a default, a feature must **not** import another feature's `presentation` layer — shared *state* is read through a contract in `lib/shared/` instead. The one deliberate exception is a *capability* (a self-contained presentation object one feature surfaces inside another); while only a single consumer exists, importing it directly is allowed.
+- **Shared Code:** Pick the destination by what kind of thing it is:
+  - *Business* vocabulary used by 2+ features (e.g. the session, shared entities) → `lib/shared/`, on the **rule of three** (promote only when ≥2 features depend on it today).
+  - *Cross-cutting, non-visual* infrastructure → `lib/core/` (app-coupled) or a `packages/core_*` workspace package (reusable).
+  - *Generic visual* building blocks → the `app_ui` package.
 - **Immutability:** Use immutable models and `Freezed` unions for state management and domain entities.
-- **Dependency Injection:** Dependencies are injected using `get_it` (configured in `lib/core/di/`).
+- **Dependency Injection:** Dependencies are injected using `get_it` + `injectable` (composition root in `lib/core/di/`).

--- a/lib/l10n/README.md
+++ b/lib/l10n/README.md
@@ -34,13 +34,13 @@ To add a new localized string or update an existing one:
 
 ## Usage in Code
 
-To use the generated localizations in your UI code, use `AppLocalizations.of(context)`:
+To use the generated localizations in your UI code, use `AppLocalizations.of(context)`. Because `nullable-getter: false` is set in `l10n.yaml`, the getter returns a non-null `AppLocalizations`, so no `!` is needed:
 
 ```dart
 import 'package:flutter_starter_template/l10n/app_localizations.dart';
 
 // ... inside a widget's build method
-Text(AppLocalizations.of(context)!.helloWorld);
+Text(AppLocalizations.of(context).helloWorld);
 ```
 
 Alternatively, you can use the `BuildContext` extension if one is provided in the project:

--- a/lib/shared/README.md
+++ b/lib/shared/README.md
@@ -1,0 +1,44 @@
+# Shared (`shared`)
+
+App-level *business* vocabulary genuinely used by **2+ features**. This is the
+seam that lets features collaborate without importing each other's
+presentation layers.
+
+It mirrors the feature layer layout (`domain/`, `presentation/`, and `data/`
+when needed) and sits between features and the lower layers: the dependency
+direction is `features → shared → ui → core`.
+
+## What lives here
+
+- **`domain/`** — shared contracts and lightweight projections:
+  - `session.dart` — `Session`, the app-wide "who is logged in" contract
+    (current user + `restore`/`signOut`/`clearSession` lifecycle). It is
+    `Listenable` so widgets rebuild on change.
+  - `entities/auth_user.dart` — the authenticated user identity.
+  - `bookmark_stats.dart` — `BookmarkSummary`, a slim cross-feature projection
+    of a bookmark so consumers (e.g. the home dashboard) don't depend on the
+    bookmarks feature's full `Bookmark` aggregate.
+- **`presentation/`** — `session_scope.dart` exposes the `Session` to the widget
+  tree via an `InheritedWidget`; read it with `SessionScope.of(context)` and
+  rebuild with a `ListenableBuilder`.
+
+## Worked example — the session
+
+"Who is logged in" is read by `home`, `profile`, and `splash`. Instead of those
+features importing the auth feature's `AuthBloc` (a presentation-layer type),
+they depend on the `Session` contract here. The auth feature provides the
+implementation (`AuthSession`, an adapter over `AuthBloc`); the composition root
+(`lib/app/app.dart`) wires it and exposes it through `SessionScope`.
+
+## The rule of three
+
+Promote a type into `shared` only when **≥2 features actually depend on it
+today** (not "might someday") and its contract is stable. Until then it stays in
+its owning feature. Keep `shared` a small, deliberate set of contracts — never a
+catch-all dumping ground. A feature-specific *capability* (a presentation object
+one feature surfaces inside another) stays in its owning feature while a single
+consumer exists, and graduates here only when a second consumer appears.
+
+Reusable *non-visual infrastructure* belongs in `lib/core/` or a `core_*`
+package; generic *visual* building blocks belong in `app_ui`. `shared` is only
+for shared **business** state and contracts.

--- a/packages/README.md
+++ b/packages/README.md
@@ -1,0 +1,51 @@
+# Workspace packages
+
+Reusable infrastructure for the Flutter starter template, split out of
+`lib/core/` into [Dart pub workspace](https://dart.dev/tools/pub/workspaces)
+members. The root app depends on these through their entry points (e.g.
+`package:core_network/core_network.dart`) rather than on the third-party
+packages directly, so implementation details and versions stay owned in one
+place.
+
+| Package | Responsibility |
+|---|---|
+| `app_ui` | Design system — theming, generic widgets, layout, animation |
+| `core_domain` | Pure-Dart architecture primitives (`Failure`, `Result`, `UseCase`) |
+| `core_network` | `Dio`/`Retrofit` client + retry/performance interceptors |
+| `core_analytics` | Firebase-backed analytics service + route observer |
+| `core_config` | Environment config + Firebase Remote Config |
+| `core_storage` | `SharedPreferences` provisioning + iOS Keychain reinstall reset |
+| `core_platform` | Device integrations — media, notifications, permissions, share |
+| `core_theme` | `ThemeBloc` + persisted theme state |
+| `test_utils` | Shared `mocktail` export, cross-package mocks/fakes, test images |
+
+Dependency direction is `features → shared → ui → core`. A package must not
+depend on the root app or on `lib/features/`.
+
+## Dependency injection — the micro-package pattern
+
+Each package that registers `@injectable`/`@module` types carries its own DI
+wiring so the app doesn't have to know its internals:
+
+- `lib/src/di.dart` holds an empty top-level function annotated with
+  `@InjectableInit.microPackage()` — the codegen anchor.
+- Running `build_runner` **inside the package** generates `lib/src/di.module.dart`
+  containing a `class <PackageName>PackageModule extends MicroPackageModule`
+  (e.g. `core_analytics` → `CoreAnalyticsPackageModule`).
+- The barrel exports that module class.
+
+The app composes them in `lib/core/di/injection.dart` via
+`@InjectableInit(externalPackageModulesBefore: [ExternalModule(...), ...])`.
+**Order matters**: a package whose types depend on another's must be listed
+after it (e.g. `core_network` after `core_config` because `NetworkModule` reads
+`EnvConfig`). Build-time "depends on unregistered type" warnings for
+cross-package dependencies are expected and resolve at runtime.
+
+After changing injectable types in a package, rerun `build_runner` in that
+package, then at the repo root to regenerate `injection.config.dart`.
+
+## Conventions
+
+- Package-owned tests live beside each package under `packages/<name>/test`.
+- A type graduates from a feature into a `core_*` / `shared` location only on
+  the **rule of three** — when ≥2 consumers actually depend on it today.

--- a/packages/app_ui/README.md
+++ b/packages/app_ui/README.md
@@ -1,7 +1,16 @@
 # app_ui
 
-Shared UI design tokens for the Flutter starter template.
+The design system for the Flutter starter template — generic, app-agnostic
+visual building blocks exported through `package:app_ui/app_ui.dart`.
 
-This package intentionally contains only app-agnostic UI primitives for now:
-spacing, radii, icon sizes, and motion durations. Keep app services, DI,
-analytics, session state, and platform integrations in the root app package.
+Contents (`lib/src/`):
+
+- `theme/` — Material 3 theming and design tokens (spacing, radii, sizes, motion durations).
+- `widgets/` — reusable generic widgets (`AppButton`, `AppScaffold`, `AppAdaptiveScaffold`, `AppNetworkImage`, …).
+- `layout/` — responsive primitives such as `AppBreakpoints`.
+- `animation/` — animation helpers.
+- `extensions/` — UI-related `BuildContext`/widget extensions.
+
+These widgets carry **no business meaning**. Keep app services, DI, analytics,
+session state, platform integrations, and feature-specific widgets out of this
+package — those belong in the root app or the relevant `core_*` package.

--- a/packages/core_analytics/README.md
+++ b/packages/core_analytics/README.md
@@ -1,0 +1,24 @@
+# core_analytics
+
+Firebase-backed analytics for the Flutter starter template.
+
+Wraps Firebase Analytics behind an app-facing service so feature code logs
+events without depending on the SDK directly. Exported through
+`package:core_analytics/core_analytics.dart`.
+
+## Public API
+
+- `AnalyticsService` — logs events, screen views, and user properties.
+- `AnalyticsEvents` — the catalog of named events the app emits.
+- `analytics_extensions.dart` — convenience helpers for logging.
+- `AnalyticsRouteObserver` — a `NavigatorObserver` that auto-logs screen views;
+  wire it into `MaterialApp.router`'s `observers`.
+- `CoreAnalyticsPackageModule` — the injectable micro-package module the app
+  registers via `externalPackageModulesBefore`.
+
+## Notes
+
+`AnalyticsService` is consumed by other packages (e.g. `core_theme`'s
+`ThemeBloc` and `core_platform`'s messaging service), so this module must be
+registered **before** them in the app's DI composition. See
+[`packages/README.md`](../README.md) for the micro-package DI pattern.

--- a/packages/core_config/README.md
+++ b/packages/core_config/README.md
@@ -1,0 +1,22 @@
+# core_config
+
+App configuration — environment values + Firebase Remote Config — for the
+Flutter starter template. Exported through
+`package:core_config/core_config.dart`.
+
+## Public API
+
+- `EnvConfig` — typed runtime configuration read from `--dart-define`
+  (`String.fromEnvironment`): API base URL, timeouts, flavor name, and
+  `isDev`/`isStaging`/`isProd`. Values come from the `env/*.json` files (see
+  [`env/README.md`](../../env/README.md)).
+- `RemoteConfigService` — a wrapper over Firebase Remote Config for
+  server-driven feature flags and values.
+- `CoreConfigPackageModule` — the injectable micro-package module the app
+  registers via `externalPackageModulesBefore`.
+
+## Notes
+
+`EnvConfig` is a dependency of `core_network` (`NetworkModule` reads the API
+base URL and timeout), so this module must be registered **before**
+`core_network` in the app's DI composition.

--- a/packages/core_network/README.md
+++ b/packages/core_network/README.md
@@ -1,0 +1,26 @@
+# core_network
+
+`Dio` HTTP client building blocks for the Flutter starter template. Exported
+through `package:core_network/core_network.dart`.
+
+Because the barrel re-exports `dio`, `retrofit`, and `firebase_performance`,
+the app and features get their HTTP types from `core_network` and never depend
+on those packages directly.
+
+## Public API
+
+- `NetworkModule` — provides the configured `Dio` instance (base URL and
+  timeouts sourced from `EnvConfig`) with the interceptors attached.
+- `RetryInterceptor` — retries transient failures with backoff.
+- `PerformanceInterceptor` — records request timing via Firebase Performance.
+- `CoreNetworkPackageModule` — the injectable micro-package module the app
+  registers via `externalPackageModulesBefore`.
+- Re-exports: `package:dio/dio.dart`, `package:retrofit/retrofit.dart`
+  (hiding `Headers`/`HttpMethod`), `package:firebase_performance/...`.
+
+## Notes
+
+`NetworkModule` reads `EnvConfig`, so `core_config` must be registered
+**before** `core_network` in the app's DI composition. Auth concerns (token
+attach/refresh interceptors) stay in the auth feature, which adds them to the
+`Dio` instance this package provides.

--- a/packages/core_platform/README.md
+++ b/packages/core_platform/README.md
@@ -1,0 +1,31 @@
+# core_platform
+
+Device and platform integrations for the Flutter starter template, grouped
+behind app-facing services. Exported through
+`package:core_platform/core_platform.dart`.
+
+The barrel re-exports the underlying plugins (`camera`, `image_picker`,
+`video_player`, `permission_handler`, `share_plus`, `flutter_local_notifications`,
+`firebase_messaging`, `firebase_crashlytics`), so the app consumes their types
+through this single package.
+
+## Public API
+
+Organized by capability under `lib/src/`:
+
+- **`media/`** — `CameraService`, `ImagePickerService`, `VideoPlayerService`.
+- **`notifications/`** — `NotificationsService` (on-device scheduling +
+  tap-to-navigate) and `FirebaseMessagingService` (FCM).
+- **`permissions/`** — `PermissionService`, a thin wrapper over
+  `permission_handler`.
+- **`share/`** — `ShareService`, a wrapper over `share_plus`.
+- `CorePlatformPackageModule` — the injectable micro-package module the app
+  registers via `externalPackageModulesBefore`.
+
+## Notes
+
+`FirebaseMessagingService` depends on `AnalyticsService`, so `core_analytics`
+must be registered **before** `core_platform` in the app's DI composition. The
+Firebase *bootstrap* (`Firebase.initializeApp`, the `@pragma('vm:entry-point')`
+background handler) stays in the app under `lib/core/platform/firebase/` because
+it is coupled to the app-generated `firebase_options.dart`.

--- a/packages/core_storage/README.md
+++ b/packages/core_storage/README.md
@@ -1,0 +1,31 @@
+# core_storage
+
+App storage primitives for the Flutter starter template. Exported through
+`package:core_storage/core_storage.dart`.
+
+The barrel re-exports `shared_preferences` and `flutter_secure_storage`, so the
+app gets those types through this package.
+
+## Public API
+
+- `SharedPreferencesModule` — provides the app-wide `SharedPreferences`
+  instance through DI (registered as `CoreStoragePackageModule`).
+- `KeychainResetOnReinstall` — clears stale secure storage on the first launch
+  after an install (see below).
+- `CoreStoragePackageModule` — the injectable micro-package module the app
+  registers via `externalPackageModulesBefore`.
+
+## The iOS Keychain reinstall reset
+
+iOS keeps Keychain data (where `flutter_secure_storage` lives) across app
+uninstalls, so a reinstall would inherit stale auth tokens.
+`KeychainResetOnReinstall.run()` — called in `main()` right after
+`configureDependencies()`, before session restore reads secure storage — wipes
+all secure storage on the first launch after install. It detects "first launch"
+via a flag in `SharedPreferences` (NSUserDefaults *is* cleared on uninstall).
+
+## Notes
+
+`SharedPreferences` provisioning lives here because two consumers need it
+(`core_theme`'s `ThemeBloc` and the reinstall reset), so `core_storage` must be
+registered **before** `core_theme` in the app's DI composition.

--- a/packages/core_theme/README.md
+++ b/packages/core_theme/README.md
@@ -1,0 +1,26 @@
+# core_theme
+
+Theme state management (mode + color scheme) for the Flutter starter template.
+Exported through `package:core_theme/core_theme.dart`.
+
+The barrel re-exports `flex_color_scheme`, so the app builds its themes from
+this package's types.
+
+## Public API
+
+- `ThemeBloc` — manages the active `ThemeMode` and color scheme, persisting the
+  user's choice to `SharedPreferences` and restoring it on launch.
+- `ThemeState` — the persisted theme state.
+- `CoreThemePackageModule` — the injectable micro-package module the app
+  registers via `externalPackageModulesBefore`.
+
+## Notes
+
+`ThemeBloc` is a separate package from `app_ui` on purpose: keeping it here
+avoids dragging `flutter_bloc`, `injectable`, and `shared_preferences` into the
+pure design-system package. The theme *data* (`app_theme.dart`) still lives in
+`app_ui`.
+
+`ThemeBloc` depends on `AnalyticsService` and reads the `SharedPreferences`
+provided by `core_storage`, so in the app's DI composition `core_theme` is
+registered **after** both `core_analytics` and `core_storage`.

--- a/test/README.md
+++ b/test/README.md
@@ -6,26 +6,31 @@ The testing strategy emphasizes unit tests for logic and widget tests for UI com
 
 ## Directory Structure
 
-The `test/` directory mirrors the `lib/` directory structure:
+This `test/` directory holds **root app tests only** and mirrors the app's
+`lib/` structure. Reusable infrastructure now lives in workspace packages, and
+each package owns its tests under `packages/<name>/test` — so there is no
+`test/core/` here; those suites moved into the relevant `core_*` / `app_ui`
+packages.
 
-- `core/`: Tests for reusable cross-feature code (e.g., core utilities, networking, local storage, theming).
-- `features/`: Tests for specific features, organized by data, domain, and presentation layers.
-- `test_utils/`: Contains shared test utilities, generated mocks, and reusable test fixtures.
-  - `mocks.dart`: Generated `mocktail` mocks for repositories, services, and other dependencies.
-  - `fixtures.dart`: Reusable test data and mock objects used across multiple tests.
-- `test_utils.dart`: Barrel file exporting mocks and fixtures for easy importing in your tests.
+- `features/`: Tests for the app's features, organized by data, domain, and presentation layers.
+- `test_utils/`: Root-only test helpers.
+  - `mocks.dart`: Hand-written `mocktail` mocks/fakes for the app's repositories, use cases, and services (e.g. `MockSignIn`, `FakeSession`).
+  - `fixtures.dart`: Reusable test data used across multiple tests.
+- `test_utils.dart`: Barrel file. Re-exports `package:test_utils/test_utils.dart` (the shared `mocktail` export plus cross-package mocks/fakes) alongside the local `mocks.dart` and `fixtures.dart`.
 - `widget_test.dart`: An integration-style widget test that exercises the full app startup and sign-in flow.
 
 ## Mocking Dependencies
 
-This project uses [`mocktail`](https://pub.dev/packages/mocktail) for mocking dependencies. 
+This project uses [`mocktail`](https://pub.dev/packages/mocktail) for mocking
+dependencies. `mocktail` is runtime-based, so mocks are **written by hand** and
+require **no code generation** — declare them directly:
 
-To generate or update mocks (if using code generation for mocks), run the build runner:
-```bash
-fvm dart run build_runner build --delete-conflicting-outputs
+```dart
+class MockAuthRepository extends Mock implements AuthRepository {}
 ```
 
-*(Note: If you write mocks manually using `class MockMyClass extends Mock implements MyClass {}`, no code generation is required.)*
+The `Mock`/`Fake` base classes come from `package:test_utils/test_utils.dart`,
+re-exported through the `test_utils.dart` barrel.
 
 ## Running Tests
 


### PR DESCRIPTION
Summary:
- Document the current root app and Dart workspace package structure.
- Clarify package ownership for network/platform/storage/theme/UI/test utilities.
- Update testing guidance for root tests, package-owned tests, shared test_utils, and CI coverage merging.

Tests:
- git diff --check HEAD~1..HEAD