### PR TITLE
Add architecture boundary guardrails + lint hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 </h1>
 
 <p align="center">
-  <i>A production‑ready Flutter foundation with Clean Architecture,<br>offline‑first sync, JWT auth, Firebase, and a companion Go backend.</i>
+  <i>A production‑ready Flutter foundation: modular Clean Architecture,<br>offline‑first sync, JWT auth, Firebase, and a companion Go reference backend.</i>
 </p>
 
 <p align="center">
@@ -25,7 +25,7 @@
 
 **Flutter Starter Template**, built by [Luci Studio](https://luci-studio.com), is an enterprise-grade mobile boilerplate engineered for building scalable, high-performance cross-platform applications. It solves the complex challenges of bootstrapping new projects by providing a production-ready structure out of the box. This template features strict Clean Architecture layers, robust offline-first synchronization, secure JWT credential lifecycle management, and pre-configured Firebase integrations.
 
-To enable seamless local development and testing, this template is paired with a companion in-memory backend server written in Go, allowing you to test authentication flows, CRUD operations, and sync conflict resolution under real network conditions.
+To enable seamless local development and testing, this template is paired with a companion SQLite-backed backend server written in Go, allowing you to test authentication flows, CRUD operations, and sync conflict resolution under real network conditions.
 
 <br>
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,9 +28,12 @@ analyzer:
     strict-raw-types: true
   exclude:
     - build/**
-    - lib/**/*.freezed.dart
-    - lib/**/*.g.dart
-    - lib/objectbox.g.dart
+    # Match generated files anywhere in the workspace (app and packages/*),
+    # not just the root lib/. Globs are relative to this file, so lib/** would
+    # miss codegen that lands inside a package (e.g. retrofit/injectable).
+    - "**/*.freezed.dart"
+    - "**/*.g.dart"
+    - "**/*.config.dart"
     - lib/firebase_options.dart
 
 

--- a/test/architecture/feature_boundaries_test.dart
+++ b/test/architecture/feature_boundaries_test.dart
@@ -1,0 +1,254 @@
+// Architecture guardrail: enforces the cross-feature import boundary
+// documented in CLAUDE.md ("a feature must not import another feature").
+//
+// A file under `lib/features/<A>/` may not import code from another feature
+// `lib/features/<B>/` (whether through a `package:` or a relative import).
+// Shared state must be read through a `shared/` contract, and shared infra
+// through the `core_*` / `app_ui` / `ui` packages instead.
+//
+// The one documented escape hatch is the "capability" exception: a
+// presentation object that one feature deliberately surfaces inside another
+// while it has a single consumer. Those exact imports are whitelisted in
+// [_allowedCrossFeatureImports]. When you intentionally add such a capability,
+// add its import here with a comment; when a second consumer appears, promote
+// the contract to `shared/` and remove the entry (the staleness test below
+// will remind you if a whitelisted import disappears).
+//
+// This is a pure file-scan test on purpose: it has no third-party dependency,
+// runs inside the normal `fvm flutter test` / CI flow, and can't break when
+// the analyzer or pinned SDK is upgraded.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// The package name from `pubspec.yaml`, used to detect absolute
+/// `package:flutter_starter_template/features/...` imports.
+const _packageName = 'flutter_starter_template';
+
+/// Documented capability exceptions, keyed by the importing feature.
+///
+/// Each value is the set of import targets (paths relative to `lib/features/`)
+/// that feature is allowed to reach into. Keep this list minimal and
+/// commented — every entry is a deliberate exception to the boundary rule.
+const _allowedCrossFeatureImports = <String, Set<String>>{
+  // `profile` surfaces auth's account-deletion capability (single consumer).
+  // See CLAUDE.md "Feature-specific capabilities" / the DeleteAccountCubit
+  // worked example.
+  'profile': {
+    'auth/presentation/bloc/delete_account_cubit.dart',
+    'auth/presentation/bloc/delete_account_state.dart',
+  },
+};
+
+void main() {
+  final featuresDir = Directory('lib/features');
+
+  test('lib/features exists (run from the package root)', () {
+    expect(
+      featuresDir.existsSync(),
+      isTrue,
+      reason: 'Expected to find lib/features relative to the current '
+          'directory. Run this test from the package root.',
+    );
+  });
+
+  final featureNames = featuresDir
+      .listSync()
+      .whereType<Directory>()
+      .map((dir) => _posix(dir.path).split('/').last)
+      .toSet();
+
+  final crossFeatureImports = _collectCrossFeatureImports(
+    featuresDir,
+    featureNames,
+  );
+
+  test('no feature imports another feature outside the documented allowlist',
+      () {
+    final violations = crossFeatureImports
+        .where(
+          (i) =>
+              !(_allowedCrossFeatureImports[i.sourceFeature]?.contains(
+                    i.targetPath,
+                  ) ??
+                  false),
+        )
+        .toList();
+
+    expect(
+      violations,
+      isEmpty,
+      reason: 'Cross-feature imports break the feature boundary documented in '
+          'CLAUDE.md. Read shared state through a shared/ contract, or — if '
+          'this is a deliberate single-consumer capability — add it to '
+          '_allowedCrossFeatureImports in this test.\n\n'
+          '${violations.map((v) => '  $v').join('\n')}',
+    );
+  });
+
+  test('every allowlisted capability import still exists (no stale entries)',
+      () {
+    final actual = crossFeatureImports
+        .map((i) => '${i.sourceFeature} -> ${i.targetPath}')
+        .toSet();
+
+    final stale = <String>[];
+    _allowedCrossFeatureImports.forEach((feature, targets) {
+      for (final target in targets) {
+        if (!actual.contains('$feature -> $target')) {
+          stale.add('$feature -> $target');
+        }
+      }
+    });
+
+    expect(
+      stale,
+      isEmpty,
+      reason: 'These whitelisted capability imports no longer exist. Remove '
+          'them from _allowedCrossFeatureImports — a stale allowlist hides '
+          'real boundary violations:\n\n${stale.map((s) => '  $s').join('\n')}',
+    );
+  });
+}
+
+/// A single import that crosses from one feature into another.
+class _CrossFeatureImport {
+  _CrossFeatureImport({
+    required this.file,
+    required this.line,
+    required this.sourceFeature,
+    required this.targetFeature,
+    required this.targetPath,
+    required this.uri,
+  });
+
+  /// Path of the importing file, relative to the package root.
+  final String file;
+
+  /// 1-based line number of the import directive.
+  final int line;
+
+  /// Feature that owns [file].
+  final String sourceFeature;
+
+  /// Feature being imported.
+  final String targetFeature;
+
+  /// Import target relative to `lib/features/`
+  /// (e.g. `auth/presentation/bloc/delete_account_cubit.dart`).
+  final String targetPath;
+
+  /// The raw import URI as written in source.
+  final String uri;
+
+  @override
+  String toString() => '$file:$line imports $sourceFeature -> $uri '
+      '(resolves to features/$targetPath)';
+}
+
+/// Matches `import '...'` / `export '...'` and captures the URI.
+final _importDirective =
+    RegExp(r'''^\s*(?:import|export)\s+['"]([^'"]+)['"]''');
+
+List<_CrossFeatureImport> _collectCrossFeatureImports(
+  Directory featuresDir,
+  Set<String> featureNames,
+) {
+  final results = <_CrossFeatureImport>[];
+
+  final dartFiles = featuresDir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.dart'));
+
+  for (final file in dartFiles) {
+    final relPath = _posix(file.path);
+    final sourceFeature = _featureOf(relPath, featureNames);
+    if (sourceFeature == null) continue;
+
+    final lines = file.readAsLinesSync();
+    for (var i = 0; i < lines.length; i++) {
+      final match = _importDirective.firstMatch(lines[i]);
+      if (match == null) continue;
+
+      final uri = match.group(1)!;
+      final targetPath = _resolveFeatureTarget(uri, relPath);
+      if (targetPath == null) continue;
+
+      final targetFeature = targetPath.split('/').first;
+      if (targetFeature == sourceFeature) continue;
+
+      results.add(
+        _CrossFeatureImport(
+          file: relPath,
+          line: i + 1,
+          sourceFeature: sourceFeature,
+          targetFeature: targetFeature,
+          targetPath: targetPath,
+          uri: uri,
+        ),
+      );
+    }
+  }
+
+  return results;
+}
+
+/// Returns the feature segment that owns [relPath], or `null` if the path is
+/// not directly under a known feature.
+String? _featureOf(String relPath, Set<String> featureNames) {
+  const prefix = 'lib/features/';
+  if (!relPath.startsWith(prefix)) return null;
+  final rest = relPath.substring(prefix.length);
+  final feature = rest.split('/').first;
+  return featureNames.contains(feature) ? feature : null;
+}
+
+/// Resolves an import [uri] (from a file at [fromRelPath]) to its target path
+/// relative to `lib/features/`, or `null` if it doesn't point into a feature.
+String? _resolveFeatureTarget(String uri, String fromRelPath) {
+  const featuresPrefix = 'lib/features/';
+
+  // Absolute package import into this package's features.
+  const packageFeatures = 'package:$_packageName/features/';
+  if (uri.startsWith(packageFeatures)) {
+    return uri.substring(packageFeatures.length);
+  }
+
+  // Any other package: import (flutter, core_*, app_ui, ...) is fine.
+  if (uri.startsWith('package:') || uri.startsWith('dart:')) return null;
+
+  // Relative import: resolve against the importing file's directory.
+  final fromDir = _posix(_dirname(fromRelPath));
+  final resolved = _normalize('$fromDir/$uri');
+  if (!resolved.startsWith(featuresPrefix)) return null;
+  return resolved.substring(featuresPrefix.length);
+}
+
+String _dirname(String path) {
+  final i = path.lastIndexOf('/');
+  return i < 0 ? '.' : path.substring(0, i);
+}
+
+/// Normalizes a POSIX-style path, collapsing `.` and `..` segments.
+String _normalize(String path) {
+  final out = <String>[];
+  for (final part in path.split('/')) {
+    if (part.isEmpty || part == '.') continue;
+    if (part == '..') {
+      if (out.isNotEmpty && out.last != '..') {
+        out.removeLast();
+      } else {
+        out.add(part);
+      }
+    } else {
+      out.add(part);
+    }
+  }
+  return out.join('/');
+}
+
+/// Converts a filesystem path to POSIX separators so the test behaves the same
+/// on Windows CI runners.
+String _posix(String path) => path.replaceAll(r'\', '/');

--- a/test/architecture/feature_boundaries_test.dart
+++ b/test/architecture/feature_boundaries_test.dart
@@ -48,7 +48,8 @@ void main() {
     expect(
       featuresDir.existsSync(),
       isTrue,
-      reason: 'Expected to find lib/features relative to the current '
+      reason:
+          'Expected to find lib/features relative to the current '
           'directory. Run this test from the package root.',
     );
   });
@@ -64,31 +65,33 @@ void main() {
     featureNames,
   );
 
-  test('no feature imports another feature outside the documented allowlist',
-      () {
-    final violations = crossFeatureImports
-        .where(
-          (i) =>
-              !(_allowedCrossFeatureImports[i.sourceFeature]?.contains(
-                    i.targetPath,
-                  ) ??
-                  false),
-        )
-        .toList();
+  test(
+    'no feature imports another feature outside the documented allowlist',
+    () {
+      final violations = crossFeatureImports
+          .where(
+            (i) =>
+                !(_allowedCrossFeatureImports[i.sourceFeature]?.contains(
+                      i.targetPath,
+                    ) ??
+                    false),
+          )
+          .toList();
 
-    expect(
-      violations,
-      isEmpty,
-      reason: 'Cross-feature imports break the feature boundary documented in '
-          'CLAUDE.md. Read shared state through a shared/ contract, or — if '
-          'this is a deliberate single-consumer capability — add it to '
-          '_allowedCrossFeatureImports in this test.\n\n'
-          '${violations.map((v) => '  $v').join('\n')}',
-    );
-  });
+      expect(
+        violations,
+        isEmpty,
+        reason:
+            'Cross-feature imports break the feature boundary documented in '
+            'CLAUDE.md. Read shared state through a shared/ contract, or — if '
+            'this is a deliberate single-consumer capability — add it to '
+            '_allowedCrossFeatureImports in this test.\n\n'
+            '${violations.map((v) => '  $v').join('\n')}',
+      );
+    },
+  );
 
-  test('every allowlisted capability import still exists (no stale entries)',
-      () {
+  test('every allowlisted capability import still exists (no stale entries)', () {
     final actual = crossFeatureImports
         .map((i) => '${i.sourceFeature} -> ${i.targetPath}')
         .toSet();
@@ -105,7 +108,8 @@ void main() {
     expect(
       stale,
       isEmpty,
-      reason: 'These whitelisted capability imports no longer exist. Remove '
+      reason:
+          'These whitelisted capability imports no longer exist. Remove '
           'them from _allowedCrossFeatureImports — a stale allowlist hides '
           'real boundary violations:\n\n${stale.map((s) => '  $s').join('\n')}',
     );
@@ -143,13 +147,15 @@ class _CrossFeatureImport {
   final String uri;
 
   @override
-  String toString() => '$file:$line imports $sourceFeature -> $uri '
+  String toString() =>
+      '$file:$line imports $sourceFeature -> $uri '
       '(resolves to features/$targetPath)';
 }
 
 /// Matches `import '...'` / `export '...'` and captures the URI.
-final _importDirective =
-    RegExp(r'''^\s*(?:import|export)\s+['"]([^'"]+)['"]''');
+final _importDirective = RegExp(
+  r'''^\s*(?:import|export)\s+['"]([^'"]+)['"]''',
+);
 
 List<_CrossFeatureImport> _collectCrossFeatureImports(
   Directory featuresDir,

--- a/test/architecture/package_layering_test.dart
+++ b/test/architecture/package_layering_test.dart
@@ -36,12 +36,10 @@ const _layers = <String, int>{
   'core_storage': 1, // shared_preferences / secure storage
   'core_analytics': 1, // -> core_domain
   'app_ui': 1, // design tokens; no core_* deps
-
   // 2 — composed infra built on the primitives.
   'core_network': 2, // -> core_config
   'core_platform': 2, // -> core_analytics, core_domain
   'core_theme': 2, // -> core_analytics, core_domain
-
   // 3 — shared test harness, sits on top of what it provides fakes for.
   'test_utils': 3, // -> core_analytics, core_platform, core_storage
 };
@@ -53,7 +51,8 @@ void main() {
     expect(
       packagesDir.existsSync(),
       isTrue,
-      reason: 'Expected to find packages/ relative to the current directory. '
+      reason:
+          'Expected to find packages/ relative to the current directory. '
           'Run this test from the repository root.',
     );
   });
@@ -67,7 +66,8 @@ void main() {
     expect(
       unranked,
       isEmpty,
-      reason: 'These workspace packages have no entry in _layers. Assign each '
+      reason:
+          'These workspace packages have no entry in _layers. Assign each '
           'a layer rank so its dependency direction is enforced:\n\n'
           '${unranked.map((p) => '  $p').join('\n')}',
     );
@@ -98,7 +98,8 @@ void main() {
     expect(
       violations,
       isEmpty,
-      reason: 'These runtime dependencies violate the package layering '
+      reason:
+          'These runtime dependencies violate the package layering '
           '(a package may only depend on strictly lower layers). Fix the '
           'dependency, or rethink the ranks in _layers if the intended '
           'architecture changed:\n\n${violations.map((v) => '  $v').join('\n')}',

--- a/test/architecture/package_layering_test.dart
+++ b/test/architecture/package_layering_test.dart
@@ -1,0 +1,155 @@
+// Architecture guardrail: enforces the layering between the workspace
+// packages under `packages/` (the `core_*` / `app_ui` / `test_utils` set).
+//
+// Pub already forbids true dependency *cycles*, but it does not enforce a
+// *direction*. This test does: every package is assigned a layer rank, and a
+// package may only depend (at runtime) on packages in a strictly lower layer.
+// That keeps the dependency graph a DAG flowing one way — e.g. core_domain
+// stays a pure leaf nothing reaches up into, and core_network can't quietly
+// start depending on core_theme.
+//
+// Only runtime `dependencies:` are checked. `dev_dependencies:` are excluded
+// on purpose: `test_utils` (the shared test harness, the top layer) is a dev
+// dependency of almost every package, and that back-edge is intentional and
+// test-only — it isn't a runtime layering violation.
+//
+// When you add a new workspace package, give it a layer in [_layers] (the
+// coverage test below fails until you do). When you add a dependency that
+// points the wrong way, either it's a mistake, or the layering is wrong and
+// the ranks need rethinking — don't just bump a number to silence it.
+//
+// Pure file-scan, no third-party dependency, runs in the normal
+// `fvm flutter test` / CI flow.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Layer rank per workspace package. A package may depend only on packages
+/// with a strictly smaller rank.
+const _layers = <String, int>{
+  // 0 — pure-Dart foundation; depends on nothing in the workspace.
+  'core_domain': 0,
+
+  // 1 — primitives: no workspace deps, or only on core_domain.
+  'core_config': 1, // firebase_remote_config wrapper
+  'core_storage': 1, // shared_preferences / secure storage
+  'core_analytics': 1, // -> core_domain
+  'app_ui': 1, // design tokens; no core_* deps
+
+  // 2 — composed infra built on the primitives.
+  'core_network': 2, // -> core_config
+  'core_platform': 2, // -> core_analytics, core_domain
+  'core_theme': 2, // -> core_analytics, core_domain
+
+  // 3 — shared test harness, sits on top of what it provides fakes for.
+  'test_utils': 3, // -> core_analytics, core_platform, core_storage
+};
+
+void main() {
+  final packagesDir = Directory('packages');
+
+  test('packages/ exists (run from the package root)', () {
+    expect(
+      packagesDir.existsSync(),
+      isTrue,
+      reason: 'Expected to find packages/ relative to the current directory. '
+          'Run this test from the repository root.',
+    );
+  });
+
+  final packages = _discoverPackages(packagesDir);
+
+  test('every workspace package has a layer assigned', () {
+    final unranked =
+        packages.keys.where((name) => !_layers.containsKey(name)).toList()
+          ..sort();
+    expect(
+      unranked,
+      isEmpty,
+      reason: 'These workspace packages have no entry in _layers. Assign each '
+          'a layer rank so its dependency direction is enforced:\n\n'
+          '${unranked.map((p) => '  $p').join('\n')}',
+    );
+  });
+
+  test('packages only depend on strictly lower layers', () {
+    final workspaceNames = packages.keys.toSet();
+    final violations = <String>[];
+
+    packages.forEach((name, pubspec) {
+      final fromRank = _layers[name];
+      if (fromRank == null) return; // reported by the coverage test above
+
+      for (final dep in _runtimeDependencies(pubspec)) {
+        if (!workspaceNames.contains(dep)) continue; // third-party dep
+        final toRank = _layers[dep];
+        if (toRank == null) continue; // reported by the coverage test above
+
+        if (toRank >= fromRank) {
+          final kind = toRank == fromRank ? 'same-layer' : 'upward';
+          violations.add(
+            '$name (layer $fromRank) -> $dep (layer $toRank)  [$kind]',
+          );
+        }
+      }
+    });
+
+    expect(
+      violations,
+      isEmpty,
+      reason: 'These runtime dependencies violate the package layering '
+          '(a package may only depend on strictly lower layers). Fix the '
+          'dependency, or rethink the ranks in _layers if the intended '
+          'architecture changed:\n\n${violations.map((v) => '  $v').join('\n')}',
+    );
+  });
+}
+
+/// Maps each workspace package name to the lines of its `pubspec.yaml`.
+Map<String, List<String>> _discoverPackages(Directory packagesDir) {
+  final result = <String, List<String>>{};
+  for (final entity in packagesDir.listSync()) {
+    if (entity is! Directory) continue;
+    final pubspec = File('${entity.path}/pubspec.yaml');
+    if (!pubspec.existsSync()) continue;
+    final lines = pubspec.readAsLinesSync();
+    final name = _packageName(lines);
+    if (name != null) result[name] = lines;
+  }
+  return result;
+}
+
+String? _packageName(List<String> lines) {
+  for (final line in lines) {
+    final match = RegExp(r'^name:\s*(\S+)').firstMatch(line);
+    if (match != null) return match.group(1);
+  }
+  return null;
+}
+
+/// Names listed under the top-level `dependencies:` block of a pubspec.
+///
+/// Intentionally ignores `dev_dependencies:` and nested keys (e.g. the
+/// `sdk: flutter` under `flutter:`).
+Set<String> _runtimeDependencies(List<String> lines) {
+  final deps = <String>{};
+  final entry = RegExp('^  ([a-zA-Z0-9_]+):');
+  var inDependencies = false;
+
+  for (final line in lines) {
+    if (line.trimRight() == 'dependencies:') {
+      inDependencies = true;
+      continue;
+    }
+    // A new top-level key (no leading whitespace) ends the block.
+    if (inDependencies && line.isNotEmpty && !line.startsWith(' ')) {
+      inDependencies = false;
+    }
+    if (!inDependencies) continue;
+
+    final match = entry.firstMatch(line);
+    if (match != null) deps.add(match.group(1)!);
+  }
+  return deps;
+}


### PR DESCRIPTION
## Summary

Adds dependency-free architecture guardrails and hardens the analyzer config so the documented layering in `CLAUDE.md` is actually enforced (not just convention), runnable in the normal `flutter test` / CI flow with no third-party analyzer plugin.

## Changes

**`test/architecture/feature_boundaries_test.dart`** — fails if a feature imports another feature (`package:` or relative import).
- Allowlist for the one documented single-consumer capability exception (`profile` → auth's `DeleteAccountCubit` / `DeleteAccountState`).
- Staleness check so the allowlist can't rot and hide real violations.

**`test/architecture/package_layering_test.dart`** — enforces a one-way dependency DAG among the `packages/` workspace packages.
- Each package gets a layer rank; runtime deps must point to a strictly lower layer (catches upward *and* same-layer edges). This enforces *direction*, which pub's cycle check alone does not.
- Only runtime `dependencies:` are checked — `dev_dependencies:` are excluded so the shared `test_utils` harness back-edge isn't falsely flagged.
- A coverage test forces every new workspace package to be assigned a layer.

**`analysis_options.yaml`** — switched generated-file excludes from root-relative (`lib/**/*.g.dart`) to workspace-wide (`**/*.g.dart`, `**/*.freezed.dart`, `**/*.config.dart`), so codegen landing inside a package (e.g. retrofit in `core_network`) doesn't break `flutter analyze`.

**`README.md`** — sharpened the intro tagline (calls out the modular workspace-package architecture, labels the Go backend a reference implementation) and fixed a factual error: the companion Go server is SQLite-backed, not in-memory.

## Verification

- `flutter analyze` → No issues found across the whole workspace.
- `flutter test test/architecture/` → 6/6 pass on the clean tree.
- Both guardrails verified to **fail** on an injected violation (a `home → bookmarks` import; a `core_domain → core_network` upward dep), then pass again after reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)