### PR TITLE
refactor(ui): replace Material icons with Font Awesome icons

### DIFF
--- a/lib/app/bootstrap_error_app.dart
+++ b/lib/app/bootstrap_error_app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 /// Minimal, dependency-free app shown when bootstrap fails before the real
 /// `App` (and its theming/localization) can start.
@@ -24,7 +25,7 @@ class BootstrapErrorApp extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  const Icon(Icons.error_outline, size: 56),
+                  const FaIcon(FontAwesomeIcons.circleExclamation, size: 56),
                   const SizedBox(height: 16),
                   Text(
                     'Something went wrong',

--- a/lib/app/widgets/app_shell.dart
+++ b/lib/app/widgets/app_shell.dart
@@ -1,6 +1,7 @@
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../core/di/injection.dart';
@@ -40,24 +41,24 @@ class _AppShellState extends State<AppShell> {
           final l10n = context.l10n;
           final destinations = [
             AppDestination(
-              icon: Icons.home_outlined,
-              selectedIcon: Icons.home,
+              icon: FontAwesomeIcons.house,
+              selectedIcon: FontAwesomeIcons.house,
               label: l10n.navHome,
             ),
             AppDestination(
-              icon: Icons.bookmark_outline,
-              selectedIcon: Icons.bookmark,
+              icon: FontAwesomeIcons.bookmark,
+              selectedIcon: FontAwesomeIcons.solidBookmark,
               label: l10n.navBookmarks,
             ),
             AppDestination(
-              icon: Icons.notifications_outlined,
-              selectedIcon: Icons.notifications,
+              icon: FontAwesomeIcons.bell,
+              selectedIcon: FontAwesomeIcons.solidBell,
               label: l10n.navNotifications,
               hasBadge: state.unreadCount > 0,
             ),
             AppDestination(
-              icon: Icons.person_outline,
-              selectedIcon: Icons.person,
+              icon: FontAwesomeIcons.user,
+              selectedIcon: FontAwesomeIcons.solidUser,
               label: l10n.navProfile,
             ),
           ];

--- a/lib/features/auth/presentation/screens/change_password_screen.dart
+++ b/lib/features/auth/presentation/screens/change_password_screen.dart
@@ -2,6 +2,7 @@ import 'package:app_ui/app_ui.dart';
 import 'package:architecture/architecture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/di/injection.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
@@ -95,7 +96,7 @@ class _ChangePasswordViewState extends State<_ChangePasswordView> {
                         AppTextField(
                           controller: _currentPasswordController,
                           label: context.l10n.changePasswordCurrentLabel,
-                          prefixIcon: Icons.lock_outline,
+                          prefixIcon: FontAwesomeIcons.lock,
                           obscureText: true,
                           textInputAction: TextInputAction.next,
                           validator: (value) => (value == null || value.isEmpty)
@@ -106,7 +107,7 @@ class _ChangePasswordViewState extends State<_ChangePasswordView> {
                         AppTextField(
                           controller: _newPasswordController,
                           label: context.l10n.changePasswordNewLabel,
-                          prefixIcon: Icons.lock_reset,
+                          prefixIcon: FontAwesomeIcons.arrowRotateRight,
                           obscureText: true,
                           textInputAction: TextInputAction.next,
                           validator: (value) => (value == null || value.isEmpty)
@@ -117,7 +118,7 @@ class _ChangePasswordViewState extends State<_ChangePasswordView> {
                         AppTextField(
                           controller: _confirmPasswordController,
                           label: context.l10n.changePasswordConfirmLabel,
-                          prefixIcon: Icons.lock_reset,
+                          prefixIcon: FontAwesomeIcons.arrowRotateRight,
                           obscureText: true,
                           textInputAction: TextInputAction.done,
                           onSubmitted: _submitText,

--- a/lib/features/auth/presentation/screens/login_screen.dart
+++ b/lib/features/auth/presentation/screens/login_screen.dart
@@ -2,6 +2,7 @@ import 'package:app_ui/app_ui.dart';
 import 'package:architecture/architecture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../app/router.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
@@ -72,7 +73,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       AppTextField(
                         controller: _usernameController,
                         label: context.l10n.loginUsernameLabel,
-                        prefixIcon: Icons.person_outline,
+                        prefixIcon: FontAwesomeIcons.user,
                         textInputAction: TextInputAction.next,
                         autofillHints: const [AutofillHints.username],
                         validator: (value) =>
@@ -84,7 +85,7 @@ class _LoginScreenState extends State<LoginScreen> {
                       AppTextField(
                         controller: _passwordController,
                         label: context.l10n.loginPasswordLabel,
-                        prefixIcon: Icons.lock_outline,
+                        prefixIcon: FontAwesomeIcons.lock,
                         obscureText: true,
                         autofillHints: const [AutofillHints.password],
                         onSubmitted: (_) => _submit(),

--- a/lib/features/auth/presentation/screens/register_screen.dart
+++ b/lib/features/auth/presentation/screens/register_screen.dart
@@ -2,6 +2,7 @@ import 'package:app_ui/app_ui.dart';
 import 'package:architecture/architecture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/extensions/build_context_extensions.dart';
 import '../bloc/auth_bloc.dart';
@@ -78,7 +79,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       AppTextField(
                         controller: _usernameController,
                         label: context.l10n.registerUsernameLabel,
-                        prefixIcon: Icons.person_outline,
+                        prefixIcon: FontAwesomeIcons.user,
                         textInputAction: TextInputAction.next,
                         autofillHints: const [AutofillHints.newUsername],
                         validator: (value) =>
@@ -90,7 +91,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       AppTextField(
                         controller: _passwordController,
                         label: context.l10n.registerPasswordLabel,
-                        prefixIcon: Icons.lock_outline,
+                        prefixIcon: FontAwesomeIcons.lock,
                         obscureText: true,
                         textInputAction: TextInputAction.next,
                         autofillHints: const [AutofillHints.newPassword],
@@ -102,7 +103,7 @@ class _RegisterScreenState extends State<RegisterScreen> {
                       AppTextField(
                         controller: _confirmPasswordController,
                         label: context.l10n.registerConfirmPasswordLabel,
-                        prefixIcon: Icons.lock_outline,
+                        prefixIcon: FontAwesomeIcons.lock,
                         obscureText: true,
                         textInputAction: TextInputAction.done,
                         onSubmitted: (_) => _submit(),

--- a/lib/features/bookmarks/presentation/widgets/app_video_player.dart
+++ b/lib/features/bookmarks/presentation/widgets/app_video_player.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:app_platform/app_platform.dart';
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'app_video_player_controls.dart';
 import 'app_video_player_fullscreen.dart';
@@ -135,7 +136,7 @@ class _AppVideoPlayerState extends State<AppVideoPlayer> {
           child: const Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(Icons.video_library, color: Colors.white70, size: 48),
+              FaIcon(FontAwesomeIcons.video, color: Colors.white70, size: 48),
               SizedBox(height: AppSpacing.sm),
               Text(
                 'Mock Video Player View',
@@ -209,8 +210,7 @@ class _AppVideoPlayerState extends State<AppVideoPlayer> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        const Icon(
-          Icons.error_outline_rounded,
+        const FaIcon(FontAwesomeIcons.circleExclamation,
           color: Colors.redAccent,
           size: AppIconSize.xxxl,
         ),

--- a/lib/features/bookmarks/presentation/widgets/app_video_player.dart
+++ b/lib/features/bookmarks/presentation/widgets/app_video_player.dart
@@ -210,7 +210,8 @@ class _AppVideoPlayerState extends State<AppVideoPlayer> {
     return Column(
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        const FaIcon(FontAwesomeIcons.circleExclamation,
+        const FaIcon(
+          FontAwesomeIcons.circleExclamation,
           color: Colors.redAccent,
           size: AppIconSize.xxxl,
         ),

--- a/lib/features/bookmarks/presentation/widgets/app_video_player_controls.dart
+++ b/lib/features/bookmarks/presentation/widgets/app_video_player_controls.dart
@@ -1,6 +1,7 @@
 import 'package:app_platform/app_platform.dart';
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import 'app_video_player_controls_bar.dart';
 
@@ -75,7 +76,7 @@ class _FullscreenBackButton extends StatelessWidget {
         child: CircleAvatar(
           backgroundColor: Colors.black45,
           child: IconButton(
-            icon: const Icon(Icons.arrow_back_rounded, color: Colors.white),
+            icon: const FaIcon(FontAwesomeIcons.arrowLeft, color: Colors.white),
             tooltip: MaterialLocalizations.of(context).backButtonTooltip,
             onPressed: () => Navigator.of(context).pop(),
           ),
@@ -110,10 +111,10 @@ class _CenterPlayButton extends StatelessWidget {
                         color: Colors.black.withValues(alpha: 0.5),
                         shape: BoxShape.circle,
                       ),
-                      child: Icon(
+                      child: FaIcon(
                         controller.value.isPlaying
-                            ? Icons.pause_rounded
-                            : Icons.play_arrow_rounded,
+                            ? FontAwesomeIcons.pause
+                            : FontAwesomeIcons.play,
                         color: Colors.white,
                         size: 48,
                       ),

--- a/lib/features/bookmarks/presentation/widgets/app_video_player_controls_bar.dart
+++ b/lib/features/bookmarks/presentation/widgets/app_video_player_controls_bar.dart
@@ -148,9 +148,7 @@ class _ControlsRow extends StatelessWidget {
         const SizedBox(width: AppSpacing.sm),
         IconButton(
           icon: FaIcon(
-            isFullscreen
-                ? FontAwesomeIcons.compress
-                : FontAwesomeIcons.expand,
+            isFullscreen ? FontAwesomeIcons.compress : FontAwesomeIcons.expand,
             color: Colors.white,
             size: 28,
           ),

--- a/lib/features/bookmarks/presentation/widgets/app_video_player_controls_bar.dart
+++ b/lib/features/bookmarks/presentation/widgets/app_video_player_controls_bar.dart
@@ -1,6 +1,7 @@
 import 'package:app_platform/app_platform.dart';
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 class AppVideoPlayerControlsBar extends StatelessWidget {
   const AppVideoPlayerControlsBar({
@@ -113,22 +114,22 @@ class _ControlsRow extends StatelessWidget {
     return Row(
       children: [
         IconButton(
-          icon: Icon(
+          icon: FaIcon(
             controller.value.isPlaying
-                ? Icons.pause_rounded
-                : Icons.play_arrow_rounded,
+                ? FontAwesomeIcons.pause
+                : FontAwesomeIcons.play,
             color: Colors.white,
           ),
           tooltip: controller.value.isPlaying ? 'Pause' : 'Play',
           onPressed: onTogglePlay,
         ),
         IconButton(
-          icon: Icon(
+          icon: FaIcon(
             isMuted
-                ? Icons.volume_off_rounded
+                ? FontAwesomeIcons.volumeXmark
                 : controller.value.volume < 0.5
-                ? Icons.volume_down_rounded
-                : Icons.volume_up_rounded,
+                ? FontAwesomeIcons.volumeLow
+                : FontAwesomeIcons.volumeHigh,
             color: Colors.white,
           ),
           tooltip: isMuted ? 'Unmute' : 'Mute',
@@ -146,10 +147,10 @@ class _ControlsRow extends StatelessWidget {
         ),
         const SizedBox(width: AppSpacing.sm),
         IconButton(
-          icon: Icon(
+          icon: FaIcon(
             isFullscreen
-                ? Icons.fullscreen_exit_rounded
-                : Icons.fullscreen_rounded,
+                ? FontAwesomeIcons.compress
+                : FontAwesomeIcons.expand,
             color: Colors.white,
             size: 28,
           ),

--- a/lib/features/bookmarks/presentation/widgets/bookmark_attachments_section.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmark_attachments_section.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/extensions/build_context_extensions.dart';
 import '../bloc/bookmark_form/bookmark_form_bloc.dart';
@@ -104,8 +105,7 @@ class _ImageAttachmentTile extends StatelessWidget {
                   color: Colors.black54,
                   shape: BoxShape.circle,
                 ),
-                child: const Icon(
-                  Icons.close,
+                child: const FaIcon(FontAwesomeIcons.xmark,
                   size: AppIconSize.sm,
                   color: Colors.white,
                 ),
@@ -132,7 +132,7 @@ class _AttachmentActionButtons extends StatelessWidget {
                 onPressed: () => context.read<BookmarkFormBloc>().add(
                   const BookmarkFormImagesPicked(),
                 ),
-                icon: const Icon(Icons.add_photo_alternate),
+                icon: const FaIcon(FontAwesomeIcons.image),
                 label: const Text('Add Images'),
               ),
             ),
@@ -142,7 +142,7 @@ class _AttachmentActionButtons extends StatelessWidget {
                 onPressed: () => context.read<BookmarkFormBloc>().add(
                   const BookmarkFormCameraImageTaken(),
                 ),
-                icon: const Icon(Icons.camera_alt),
+                icon: const FaIcon(FontAwesomeIcons.camera),
                 label: const Text('Take Photo'),
               ),
             ),
@@ -156,7 +156,7 @@ class _AttachmentActionButtons extends StatelessWidget {
                 onPressed: () => context.read<BookmarkFormBloc>().add(
                   const BookmarkFormVideoPicked(),
                 ),
-                icon: const Icon(Icons.video_library),
+                icon: const FaIcon(FontAwesomeIcons.video),
                 label: const Text('Add Video'),
               ),
             ),
@@ -166,7 +166,7 @@ class _AttachmentActionButtons extends StatelessWidget {
                 onPressed: () => context.read<BookmarkFormBloc>().add(
                   const BookmarkFormCameraVideoTaken(),
                 ),
-                icon: const Icon(Icons.videocam),
+                icon: const FaIcon(FontAwesomeIcons.video),
                 label: const Text('Record Video'),
               ),
             ),

--- a/lib/features/bookmarks/presentation/widgets/bookmark_attachments_section.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmark_attachments_section.dart
@@ -105,7 +105,8 @@ class _ImageAttachmentTile extends StatelessWidget {
                   color: Colors.black54,
                   shape: BoxShape.circle,
                 ),
-                child: const FaIcon(FontAwesomeIcons.xmark,
+                child: const FaIcon(
+                  FontAwesomeIcons.xmark,
                   size: AppIconSize.sm,
                   color: Colors.white,
                 ),

--- a/lib/features/bookmarks/presentation/widgets/bookmark_detail_widgets.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmark_detail_widgets.dart
@@ -6,6 +6,7 @@ import 'package:app_ui/app_ui.dart';
 import 'package:architecture/architecture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -107,17 +108,17 @@ class BookmarkDetailView extends StatelessWidget {
                 children: [
                   IconButton(
                     tooltip: context.l10n.commonShare,
-                    icon: const Icon(Icons.share),
+                    icon: const FaIcon(FontAwesomeIcons.shareNodes),
                     onPressed: () => _shareBookmark(state.bookmark),
                   ),
                   IconButton(
                     tooltip: context.l10n.commonEdit,
-                    icon: const Icon(Icons.edit),
+                    icon: const FaIcon(FontAwesomeIcons.pen),
                     onPressed: () => _openEditor(context),
                   ),
                   IconButton(
                     tooltip: context.l10n.commonDelete,
-                    icon: const Icon(Icons.delete_outline),
+                    icon: const FaIcon(FontAwesomeIcons.trashCan),
                     onPressed: () => _confirmAndDelete(context, state.bookmark),
                   ),
                 ],
@@ -206,8 +207,7 @@ class _DetailBody extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Icon(
-                  Icons.link,
+                FaIcon(FontAwesomeIcons.link,
                   size: 16,
                   color: context.colorScheme.primary,
                 ),
@@ -292,7 +292,7 @@ class _DetailBody extends StatelessWidget {
           const SizedBox(height: AppSpacing.xxl),
           AppButton(
             label: context.l10n.bookmarkOpenUrl,
-            icon: Icons.open_in_new,
+            icon: FontAwesomeIcons.arrowUpRightFromSquare,
             expand: true,
             onPressed: () => _openUrl(context, bookmark),
           ).animateSlideUp(delay: 300.ms),

--- a/lib/features/bookmarks/presentation/widgets/bookmark_detail_widgets.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmark_detail_widgets.dart
@@ -207,7 +207,8 @@ class _DetailBody extends StatelessWidget {
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                FaIcon(FontAwesomeIcons.link,
+                FaIcon(
+                  FontAwesomeIcons.link,
                   size: 16,
                   color: context.colorScheme.primary,
                 ),

--- a/lib/features/bookmarks/presentation/widgets/bookmark_video_attachment_preview.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmark_video_attachment_preview.dart
@@ -102,7 +102,8 @@ class _BookmarkVideoAttachmentPreviewState
                     color: Colors.black54,
                     shape: BoxShape.circle,
                   ),
-                  child: const FaIcon(FontAwesomeIcons.xmark,
+                  child: const FaIcon(
+                    FontAwesomeIcons.xmark,
                     size: AppIconSize.md,
                     color: Colors.white,
                   ),

--- a/lib/features/bookmarks/presentation/widgets/bookmark_video_attachment_preview.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmark_video_attachment_preview.dart
@@ -4,6 +4,7 @@ import 'package:app_platform/app_platform.dart';
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/di/injection.dart';
 import '../bloc/bookmark_form/bookmark_form_bloc.dart';
@@ -101,8 +102,7 @@ class _BookmarkVideoAttachmentPreviewState
                     color: Colors.black54,
                     shape: BoxShape.circle,
                   ),
-                  child: const Icon(
-                    Icons.close,
+                  child: const FaIcon(FontAwesomeIcons.xmark,
                     size: AppIconSize.md,
                     color: Colors.white,
                   ),

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_master.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_master.dart
@@ -136,7 +136,9 @@ class _BookmarksEmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     final isFiltered = query.trim().isNotEmpty;
     return AppEmptyView(
-      icon: isFiltered ? FontAwesomeIcons.magnifyingGlassMinus : FontAwesomeIcons.bookmark,
+      icon: isFiltered
+          ? FontAwesomeIcons.magnifyingGlassMinus
+          : FontAwesomeIcons.bookmark,
       title: isFiltered
           ? context.l10n.bookmarksNoMatchesTitle
           : context.l10n.bookmarksEmptyTitle,

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_master.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_master.dart
@@ -1,6 +1,7 @@
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/extensions/build_context_extensions.dart';
 import '../../domain/entities/bookmark.dart';
@@ -108,14 +109,14 @@ class _BookmarksSearchField extends StatelessWidget {
       child: AppTextField(
         controller: controller,
         hint: context.l10n.bookmarksSearchHint,
-        prefixIcon: Icons.search,
+        prefixIcon: FontAwesomeIcons.magnifyingGlass,
         onChanged: onChanged,
         suffix: ValueListenableBuilder<TextEditingValue>(
           valueListenable: controller,
           builder: (context, value, _) {
             if (value.text.isEmpty) return const SizedBox.shrink();
             return IconButton(
-              icon: const Icon(Icons.clear),
+              icon: const FaIcon(FontAwesomeIcons.xmark),
               tooltip: context.l10n.bookmarksSearchClear,
               onPressed: onClear,
             );
@@ -135,7 +136,7 @@ class _BookmarksEmptyState extends StatelessWidget {
   Widget build(BuildContext context) {
     final isFiltered = query.trim().isNotEmpty;
     return AppEmptyView(
-      icon: isFiltered ? Icons.search_off : Icons.bookmark_outline,
+      icon: isFiltered ? FontAwesomeIcons.magnifyingGlassMinus : FontAwesomeIcons.bookmark,
       title: isFiltered
           ? context.l10n.bookmarksNoMatchesTitle
           : context.l10n.bookmarksEmptyTitle,

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_tile.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_tile.dart
@@ -4,6 +4,7 @@ import 'package:app_ui/app_ui.dart';
 import 'package:architecture/architecture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/di/injection.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
@@ -56,7 +57,7 @@ class BookmarksListTile extends StatelessWidget {
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
-        trailing: const Icon(Icons.chevron_right),
+        trailing: const FaIcon(FontAwesomeIcons.chevronRight),
         onTap: onTap,
         onLongPress: () => _showItemMenu(context, bookmark),
       ),
@@ -95,8 +96,7 @@ class _BookmarkAvatar extends StatelessWidget {
                 color: theme.colorScheme.surface,
                 shape: BoxShape.circle,
               ),
-              child: Icon(
-                Icons.cloud_off,
+              child: FaIcon(FontAwesomeIcons.cloudArrowUp,
                 size: 14,
                 color: theme.colorScheme.outline,
               ),
@@ -141,7 +141,7 @@ Future<void> _showItemMenu(BuildContext context, Bookmark bookmark) async {
         mainAxisSize: MainAxisSize.min,
         children: [
           ListTile(
-            leading: const Icon(Icons.share),
+            leading: const FaIcon(FontAwesomeIcons.shareNodes),
             title: Text(l10n.commonShare),
             onTap: () => Navigator.pop(sheetContext, 'share'),
           ),

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_tile.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_tile.dart
@@ -96,7 +96,8 @@ class _BookmarkAvatar extends StatelessWidget {
                 color: theme.colorScheme.surface,
                 shape: BoxShape.circle,
               ),
-              child: FaIcon(FontAwesomeIcons.cloudArrowUp,
+              child: FaIcon(
+                FontAwesomeIcons.cloudArrowUp,
                 size: 14,
                 color: theme.colorScheme.outline,
               ),

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_widgets.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_widgets.dart
@@ -142,7 +142,8 @@ class _DetailPlaceholder extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          FaIcon(FontAwesomeIcons.bookmark,
+          FaIcon(
+            FontAwesomeIcons.bookmark,
             size: AppIconSize.xxxl,
             color: context.colorScheme.outline,
           ),

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_widgets.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_widgets.dart
@@ -4,6 +4,7 @@ import 'package:app_ui/app_ui.dart';
 import 'package:architecture/architecture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../app/router.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
@@ -96,7 +97,7 @@ class _BookmarksListViewState extends State<BookmarksListView> {
       floatingActionButton: FloatingActionButton(
         onPressed: _openNew,
         tooltip: context.l10n.bookmarksAddTooltip,
-        child: const Icon(Icons.add),
+        child: const FaIcon(FontAwesomeIcons.plus),
       ).animateScale(delay: 300.ms),
       body: LayoutBuilder(
         builder: (context, constraints) {
@@ -141,8 +142,7 @@ class _DetailPlaceholder extends StatelessWidget {
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          Icon(
-            Icons.bookmark_outline,
+          FaIcon(FontAwesomeIcons.bookmark,
             size: AppIconSize.xxxl,
             color: context.colorScheme.outline,
           ),
@@ -173,7 +173,7 @@ class _SortMenuButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return PopupMenuButton<BookmarkSort>(
-      icon: const Icon(Icons.sort),
+      icon: const FaIcon(FontAwesomeIcons.sort),
       tooltip: context.l10n.bookmarksSortTooltip,
       initialValue: sort,
       onSelected: (value) => context.read<BookmarksListBloc>().add(
@@ -218,7 +218,7 @@ class _SyncStatusIcon extends StatelessWidget {
       ),
       BookmarksSyncStatus.error => IconButton(
         tooltip: context.l10n.bookmarksSyncFailedRetryTooltip,
-        icon: const Icon(Icons.cloud_off),
+        icon: const FaIcon(FontAwesomeIcons.cloudArrowUp),
         onPressed: () => context.read<BookmarksListBloc>().add(
           const BookmarksListSyncRetried(),
         ),

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../app/router.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
@@ -30,7 +31,7 @@ class HomeBody extends StatelessWidget {
                 const SizedBox(height: AppSpacing.xxxl),
                 AppButton(
                   label: context.l10n.homeMyBookmarks,
-                  icon: Icons.bookmark_outline,
+                  icon: FontAwesomeIcons.bookmark,
                   onPressed: () =>
                       const BookmarksListRoute().push<void>(context),
                 ).animateSlideUp(delay: 400.ms),
@@ -65,8 +66,7 @@ class _WelcomeSection extends StatelessWidget {
             CircleAvatar(
               radius: AppIconSize.xxl,
               backgroundColor: context.colorScheme.primaryContainer,
-              child: Icon(
-                Icons.person,
+              child: FaIcon(FontAwesomeIcons.solidUser,
                 size: AppIconSize.xxl,
                 color: context.colorScheme.onPrimaryContainer,
               ),
@@ -103,7 +103,7 @@ class _StatsDashboard extends StatelessWidget {
       children: [
         Expanded(
           child: _StatCard(
-            icon: Icons.bookmark,
+            icon: FontAwesomeIcons.solidBookmark,
             value: state.totalBookmarks.toString(),
             label: context.l10n.homeStatsTotal,
           ).animateSlideLeft(delay: 200.ms),
@@ -111,7 +111,7 @@ class _StatsDashboard extends StatelessWidget {
         const SizedBox(width: AppSpacing.md),
         Expanded(
           child: _StatCard(
-            icon: Icons.schedule,
+            icon: FontAwesomeIcons.clock,
             value: state.recentBookmarks.toString(),
             label: context.l10n.homeStatsRecent,
           ).animateSlideUp(delay: 300.ms),
@@ -119,7 +119,7 @@ class _StatsDashboard extends StatelessWidget {
         const SizedBox(width: AppSpacing.md),
         Expanded(
           child: _StatCard(
-            icon: Icons.label_outline,
+            icon: FontAwesomeIcons.tag,
             value: state.uniqueTags.toString(),
             label: context.l10n.homeStatsTags,
           ).animateSlideRight(delay: 400.ms),
@@ -136,7 +136,7 @@ class _StatCard extends StatelessWidget {
     required this.label,
   });
 
-  final IconData icon;
+  final FaIconData icon;
   final String value;
   final String label;
 
@@ -155,7 +155,7 @@ class _StatCard extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
+            FaIcon(
               icon,
               size: AppIconSize.xl,
               color: context.colorScheme.primary,

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -66,7 +66,8 @@ class _WelcomeSection extends StatelessWidget {
             CircleAvatar(
               radius: AppIconSize.xxl,
               backgroundColor: context.colorScheme.primaryContainer,
-              child: FaIcon(FontAwesomeIcons.solidUser,
+              child: FaIcon(
+                FontAwesomeIcons.solidUser,
                 size: AppIconSize.xxl,
                 color: context.colorScheme.onPrimaryContainer,
               ),

--- a/lib/features/notifications/presentation/widgets/notifications_widgets.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/extensions/build_context_extensions.dart';
 import '../../domain/entities/app_notification.dart';
@@ -35,7 +36,7 @@ class NotificationsView extends StatelessWidget {
           padding: EdgeInsets.zero,
           body: state.hasNoContent && !state.isLoading
               ? AppEmptyView(
-                  icon: Icons.notifications_none_outlined,
+                  icon: FontAwesomeIcons.bell,
                   title: context.l10n.notificationsEmptyTitle,
                   message: context.l10n.notificationsEmptyMessage,
                 )
@@ -159,7 +160,7 @@ class _ActivityTile extends StatelessWidget {
       child: ListTile(
         leading: CircleAvatar(
           backgroundColor: context.colorScheme.secondaryContainer,
-          child: Icon(
+          child: FaIcon(
             _activityIcon(activity.type),
             color: context.colorScheme.onSecondaryContainer,
           ),
@@ -192,7 +193,7 @@ class _NotificationTile extends StatelessWidget {
         onTap: notification.isRead ? null : onTap,
         leading: CircleAvatar(
           backgroundColor: accent.withValues(alpha: 0.15),
-          child: Icon(_notificationIcon(notification.type), color: accent),
+          child: FaIcon(_notificationIcon(notification.type), color: accent),
         ),
         title: Text(
           notification.title,
@@ -228,19 +229,19 @@ class _NotificationTile extends StatelessWidget {
   }
 }
 
-IconData _activityIcon(UserActivityType type) => switch (type) {
-  UserActivityType.created => Icons.add_circle_outline,
-  UserActivityType.updated => Icons.edit_outlined,
-  UserActivityType.deleted => Icons.delete_outline,
-  UserActivityType.signedIn => Icons.login_outlined,
-  UserActivityType.other => Icons.history,
+FaIconData _activityIcon(UserActivityType type) => switch (type) {
+  UserActivityType.created => FontAwesomeIcons.circlePlus,
+  UserActivityType.updated => FontAwesomeIcons.penToSquare,
+  UserActivityType.deleted => FontAwesomeIcons.trashCan,
+  UserActivityType.signedIn => FontAwesomeIcons.arrowRightToBracket,
+  UserActivityType.other => FontAwesomeIcons.clockRotateLeft,
 };
 
-IconData _notificationIcon(NotificationType type) => switch (type) {
-  NotificationType.system => Icons.info_outline,
-  NotificationType.social => Icons.people_outline,
-  NotificationType.reminder => Icons.alarm_outlined,
-  NotificationType.promotion => Icons.local_offer_outlined,
+FaIconData _notificationIcon(NotificationType type) => switch (type) {
+  NotificationType.system => FontAwesomeIcons.circleInfo,
+  NotificationType.social => FontAwesomeIcons.users,
+  NotificationType.reminder => FontAwesomeIcons.clock,
+  NotificationType.promotion => FontAwesomeIcons.tag,
 };
 
 Color _notificationColor(BuildContext context, NotificationType type) =>

--- a/lib/features/profile/presentation/widgets/profile_widgets.dart
+++ b/lib/features/profile/presentation/widgets/profile_widgets.dart
@@ -4,6 +4,7 @@ import 'package:architecture/architecture.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:theme/theme.dart';
 
 import '../../../../app/router.dart';
@@ -146,8 +147,7 @@ class _CopyableId extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.xs),
-            Icon(
-              Icons.copy,
+            FaIcon(FontAwesomeIcons.copy,
               size: 14,
               color: theme.colorScheme.onSurfaceVariant,
             ),
@@ -190,9 +190,9 @@ class _ChangePasswordTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      leading: const Icon(Icons.password),
+      leading: const FaIcon(FontAwesomeIcons.key),
       title: Text(context.l10n.profileChangePassword),
-      trailing: const Icon(Icons.chevron_right),
+      trailing: const FaIcon(FontAwesomeIcons.chevronRight),
       onTap: () {
         const ChangePasswordRoute().push<void>(context);
       },
@@ -210,7 +210,7 @@ class _DeleteAccountTile extends StatelessWidget {
       builder: (context, state) {
         final isSubmitting = state is DeleteAccountSubmitting;
         return ListTile(
-          leading: Icon(Icons.delete_forever, color: error),
+          leading: FaIcon(FontAwesomeIcons.trash, color: error),
           title: Text(
             context.l10n.profileDeleteAccount,
             style: TextStyle(color: error),
@@ -316,7 +316,7 @@ class _ThemeModeSelector extends StatelessWidget {
               return RadioListTile<ThemeMode>(
                 value: option,
                 title: Text(_labelFor(context, option)),
-                secondary: Icon(_iconFor(option)),
+                secondary: FaIcon(_iconFor(option)),
               );
             }).toList(),
           ),
@@ -331,10 +331,10 @@ class _ThemeModeSelector extends StatelessWidget {
     ThemeMode.dark => context.l10n.profileThemeDark,
   };
 
-  IconData _iconFor(ThemeMode mode) => switch (mode) {
-    ThemeMode.system => Icons.brightness_auto,
-    ThemeMode.light => Icons.light_mode,
-    ThemeMode.dark => Icons.dark_mode,
+  FaIconData _iconFor(ThemeMode mode) => switch (mode) {
+    ThemeMode.system => FontAwesomeIcons.circleHalfStroke,
+    ThemeMode.light => FontAwesomeIcons.sun,
+    ThemeMode.dark => FontAwesomeIcons.moon,
   };
 }
 
@@ -435,7 +435,7 @@ class _AppInfoTile extends StatelessWidget {
       builder: (context, state) {
         final info = state.packageInfo;
         return ListTile(
-          leading: const Icon(Icons.info_outline),
+          leading: const FaIcon(FontAwesomeIcons.circleInfo),
           title: Text(info?.appName ?? '—'),
           subtitle: info == null
               ? Text(context.l10n.commonLoading)
@@ -465,7 +465,7 @@ class _SignOutButton extends StatelessWidget {
           padding: const EdgeInsets.symmetric(horizontal: AppSpacing.xl),
           child: AppButton(
             label: context.l10n.commonSignOut,
-            icon: Icons.logout,
+            icon: FontAwesomeIcons.arrowRightFromBracket,
             variant: AppButtonVariant.tonal,
             expand: true,
             isLoading: isLoading,

--- a/lib/features/profile/presentation/widgets/profile_widgets.dart
+++ b/lib/features/profile/presentation/widgets/profile_widgets.dart
@@ -147,7 +147,8 @@ class _CopyableId extends StatelessWidget {
               ),
             ),
             const SizedBox(width: AppSpacing.xs),
-            FaIcon(FontAwesomeIcons.copy,
+            FaIcon(
+              FontAwesomeIcons.copy,
               size: 14,
               color: theme.colorScheme.onSurfaceVariant,
             ),

--- a/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
+++ b/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../layout/app_breakpoints.dart';
 
@@ -8,15 +9,15 @@ class AppDestination {
   const AppDestination({
     required this.icon,
     required this.label,
-    IconData? selectedIcon,
+    FaIconData? selectedIcon,
     this.hasBadge = false,
   }) : selectedIcon = selectedIcon ?? icon;
 
   /// Icon shown when the destination is not selected.
-  final IconData icon;
+  final FaIconData icon;
 
   /// Icon shown when the destination is selected.
-  final IconData selectedIcon;
+  final FaIconData selectedIcon;
 
   /// Label shown beside or under the icon.
   final String label;
@@ -81,11 +82,11 @@ class AppAdaptiveScaffold extends StatelessWidget {
                     NavigationRailDestination(
                       icon: Badge(
                         isLabelVisible: d.hasBadge,
-                        child: Icon(d.icon),
+                        child: FaIcon(d.icon),
                       ),
                       selectedIcon: Badge(
                         isLabelVisible: d.hasBadge,
-                        child: Icon(d.selectedIcon),
+                        child: FaIcon(d.selectedIcon),
                       ),
                       label: Text(d.label),
                     ),
@@ -207,7 +208,7 @@ class _BottomBarItem extends StatelessWidget {
                 duration: _duration,
                 child: Badge(
                   isLabelVisible: destination.hasBadge,
-                  child: Icon(
+                  child: FaIcon(
                     selected ? destination.selectedIcon : destination.icon,
                     key: ValueKey<bool>(selected),
                     color: foreground,

--- a/packages/app_ui/lib/src/widgets/app_button.dart
+++ b/packages/app_ui/lib/src/widgets/app_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../app_ui.dart';
 
@@ -27,7 +28,7 @@ class AppButton extends StatelessWidget {
   final VoidCallback? onPressed;
   final AppButtonVariant variant;
   final AppButtonSize size;
-  final IconData? icon;
+  final FaIconData? icon;
   final bool isLoading;
   final bool expand;
 
@@ -63,7 +64,7 @@ class AppButton extends StatelessWidget {
             : FilledButton.icon(
                 onPressed: effectiveOnPressed,
                 style: _style(),
-                icon: Icon(icon),
+                icon: FaIcon(icon),
                 label: Text(label),
               ),
       AppButtonVariant.tonal =>
@@ -76,7 +77,7 @@ class AppButton extends StatelessWidget {
             : FilledButton.tonalIcon(
                 onPressed: effectiveOnPressed,
                 style: _style(),
-                icon: Icon(icon),
+                icon: FaIcon(icon),
                 label: Text(label),
               ),
       AppButtonVariant.outlined =>
@@ -89,7 +90,7 @@ class AppButton extends StatelessWidget {
             : OutlinedButton.icon(
                 onPressed: effectiveOnPressed,
                 style: _style(),
-                icon: Icon(icon),
+                icon: FaIcon(icon),
                 label: Text(label),
               ),
       AppButtonVariant.text =>
@@ -102,7 +103,7 @@ class AppButton extends StatelessWidget {
             : TextButton.icon(
                 onPressed: effectiveOnPressed,
                 style: _style(),
-                icon: Icon(icon),
+                icon: FaIcon(icon),
                 label: Text(label),
               ),
     };

--- a/packages/app_ui/lib/src/widgets/app_empty_view.dart
+++ b/packages/app_ui/lib/src/widgets/app_empty_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../app_ui.dart';
 
@@ -8,13 +9,13 @@ class AppEmptyView extends StatelessWidget {
     super.key,
     required this.message,
     this.title,
-    this.icon = Icons.inbox_outlined,
+    this.icon = FontAwesomeIcons.inbox,
     this.action,
   });
 
   final String message;
   final String? title;
-  final IconData icon;
+  final FaIconData icon;
   final Widget? action;
 
   @override
@@ -25,7 +26,7 @@ class AppEmptyView extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 56, color: context.colorScheme.onSurfaceVariant),
+            FaIcon(icon, size: 56, color: context.colorScheme.onSurfaceVariant),
             const SizedBox(height: AppSpacing.lg),
             if (title != null) ...[
               Text(

--- a/packages/app_ui/lib/src/widgets/app_error_view.dart
+++ b/packages/app_ui/lib/src/widgets/app_error_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../app_ui.dart';
 
@@ -11,14 +12,14 @@ class AppErrorView extends StatelessWidget {
     this.title,
     this.onRetry,
     this.retryLabel,
-    this.icon = Icons.error_outline,
+    this.icon = FontAwesomeIcons.circleExclamation,
   });
 
   final String message;
   final String? title;
   final VoidCallback? onRetry;
   final String? retryLabel;
-  final IconData icon;
+  final FaIconData icon;
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +35,7 @@ class AppErrorView extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(icon, size: 56, color: context.colorScheme.error),
+            FaIcon(icon, size: 56, color: context.colorScheme.error),
             const SizedBox(height: AppSpacing.lg),
             if (title != null) ...[
               Text(
@@ -53,7 +54,7 @@ class AppErrorView extends StatelessWidget {
               const SizedBox(height: AppSpacing.xxl),
               FilledButton.tonalIcon(
                 onPressed: effectiveOnRetry,
-                icon: const Icon(Icons.refresh),
+                icon: const FaIcon(FontAwesomeIcons.rotateRight),
                 label: Text(retryLabel ?? 'Retry'),
               ),
             ],

--- a/packages/app_ui/lib/src/widgets/app_network_image.dart
+++ b/packages/app_ui/lib/src/widgets/app_network_image.dart
@@ -107,7 +107,8 @@ class AppNetworkImage extends StatelessWidget {
       height: height,
       color: context.colorScheme.surfaceContainerHighest,
       alignment: Alignment.center,
-      child: FaIcon(FontAwesomeIcons.image,
+      child: FaIcon(
+        FontAwesomeIcons.image,
         size: errorIconSize,
         color: context.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
       ),

--- a/packages/app_ui/lib/src/widgets/app_network_image.dart
+++ b/packages/app_ui/lib/src/widgets/app_network_image.dart
@@ -1,7 +1,8 @@
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
-import '../theme/app_theme.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
+import '../theme/app_theme.dart';
 import 'app_loading.dart';
 
 /// A wrapper around [CachedNetworkImage] that provides consistent loading
@@ -106,8 +107,7 @@ class AppNetworkImage extends StatelessWidget {
       height: height,
       color: context.colorScheme.surfaceContainerHighest,
       alignment: Alignment.center,
-      child: Icon(
-        Icons.broken_image_rounded,
+      child: FaIcon(FontAwesomeIcons.image,
         size: errorIconSize,
         color: context.colorScheme.onSurfaceVariant.withValues(alpha: 0.5),
       ),

--- a/packages/app_ui/lib/src/widgets/app_photo_view.dart
+++ b/packages/app_ui/lib/src/widgets/app_photo_view.dart
@@ -1,5 +1,7 @@
 import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:photo_view/photo_view.dart';
 
 import '../../app_ui.dart';
@@ -258,8 +260,7 @@ class _AppPhotoViewState extends State<AppPhotoView> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Icon(
-                  Icons.broken_image_rounded,
+                FaIcon(FontAwesomeIcons.image,
                   color: Theme.of(context).colorScheme.error,
                   size: AppIconSize.xxl,
                 ),

--- a/packages/app_ui/lib/src/widgets/app_photo_view.dart
+++ b/packages/app_ui/lib/src/widgets/app_photo_view.dart
@@ -260,7 +260,8 @@ class _AppPhotoViewState extends State<AppPhotoView> {
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                FaIcon(FontAwesomeIcons.image,
+                FaIcon(
+                  FontAwesomeIcons.image,
                   color: Theme.of(context).colorScheme.error,
                   size: AppIconSize.xxl,
                 ),

--- a/packages/app_ui/lib/src/widgets/app_photo_view_fullscreen.dart
+++ b/packages/app_ui/lib/src/widgets/app_photo_view_fullscreen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:photo_view/photo_view_gallery.dart';
 
@@ -258,8 +259,7 @@ class _FullscreenTopBar extends StatelessWidget {
             child: Row(
               children: [
                 IconButton(
-                  icon: const Icon(
-                    Icons.close_rounded,
+                  icon: const FaIcon(FontAwesomeIcons.xmark,
                     color: Colors.white,
                     size: AppIconSize.xl,
                   ),

--- a/packages/app_ui/lib/src/widgets/app_photo_view_fullscreen.dart
+++ b/packages/app_ui/lib/src/widgets/app_photo_view_fullscreen.dart
@@ -259,7 +259,8 @@ class _FullscreenTopBar extends StatelessWidget {
             child: Row(
               children: [
                 IconButton(
-                  icon: const FaIcon(FontAwesomeIcons.xmark,
+                  icon: const FaIcon(
+                    FontAwesomeIcons.xmark,
                     color: Colors.white,
                     size: AppIconSize.xl,
                   ),

--- a/packages/app_ui/lib/src/widgets/app_scaffold.dart
+++ b/packages/app_ui/lib/src/widgets/app_scaffold.dart
@@ -65,7 +65,8 @@ class AppScaffold extends StatelessWidget {
                       leading ??
                       (Navigator.of(context).canPop()
                           ? IconButton(
-                              icon: const FaIcon(FontAwesomeIcons.chevronLeft,
+                              icon: const FaIcon(
+                                FontAwesomeIcons.chevronLeft,
                               ),
                               iconSize: AppIconSize.md,
                               onPressed: () => Navigator.of(context).maybePop(),

--- a/packages/app_ui/lib/src/widgets/app_scaffold.dart
+++ b/packages/app_ui/lib/src/widgets/app_scaffold.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../app_ui.dart';
 
@@ -64,8 +65,7 @@ class AppScaffold extends StatelessWidget {
                       leading ??
                       (Navigator.of(context).canPop()
                           ? IconButton(
-                              icon: const Icon(
-                                Icons.arrow_back_ios_new_rounded,
+                              icon: const FaIcon(FontAwesomeIcons.chevronLeft,
                               ),
                               iconSize: AppIconSize.md,
                               onPressed: () => Navigator.of(context).maybePop(),

--- a/packages/app_ui/lib/src/widgets/app_slidable.dart
+++ b/packages/app_ui/lib/src/widgets/app_slidable.dart
@@ -4,6 +4,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_slidable/flutter_slidable.dart' as slidable;
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../app_ui.dart';
 
@@ -43,7 +44,7 @@ class AppSlidableAction {
   const AppSlidableAction.delete({
     required this.onPressed,
     this.label,
-    this.icon = Icons.delete_outline,
+    this.icon = FontAwesomeIcons.trashCan,
     this.backgroundColor,
     this.foregroundColor,
     this.flex = 1,
@@ -53,7 +54,7 @@ class AppSlidableAction {
   }) : tone = AppSlidableActionTone.destructive;
 
   final String? label;
-  final IconData icon;
+  final FaIconData icon;
   final AppSlidableActionPressed? onPressed;
   final AppSlidableActionTone tone;
   final Color? backgroundColor;
@@ -64,7 +65,7 @@ class AppSlidableAction {
   final EdgeInsets? padding;
 
   Widget _build(BuildContext context) {
-    return slidable.SlidableAction(
+    return slidable.CustomSlidableAction(
       flex: flex,
       autoClose: autoClose,
       onPressed: onPressed == null
@@ -75,10 +76,16 @@ class AppSlidableAction {
             },
       backgroundColor: backgroundColor ?? _backgroundColor(context),
       foregroundColor: foregroundColor ?? _foregroundColor(context),
-      icon: icon,
-      label: label ?? 'Delete',
       borderRadius: borderRadius,
       padding: padding,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          FaIcon(icon),
+          const SizedBox(height: 4),
+          Text(label ?? 'Delete'),
+        ],
+      ),
     );
   }
 

--- a/packages/app_ui/lib/src/widgets/app_text_field.dart
+++ b/packages/app_ui/lib/src/widgets/app_text_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../app_ui.dart';
 
@@ -45,7 +46,7 @@ class AppTextField extends StatelessWidget {
   final String? hint;
   final String? helperText;
   final String? errorText;
-  final IconData? prefixIcon;
+  final FaIconData? prefixIcon;
   final Widget? suffix;
   final bool obscureText;
   final bool enabled;
@@ -97,7 +98,7 @@ class AppTextField extends StatelessWidget {
         hintText: hint,
         helperText: helperText,
         errorText: errorText,
-        prefixIcon: prefixIcon != null ? Icon(prefixIcon) : null,
+        prefixIcon: prefixIcon != null ? FaIcon(prefixIcon) : null,
         suffixIcon: suffix,
         filled: true,
         fillColor: Theme.of(

--- a/packages/app_ui/pubspec.yaml
+++ b/packages/app_ui/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   cached_network_image: ^3.4.1
   carousel_slider: ^5.1.2
   google_fonts: ^8.1.0
+  font_awesome_flutter: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/app_ui/test/widgets/app_adaptive_scaffold_test.dart
+++ b/packages/app_ui/test/widgets/app_adaptive_scaffold_test.dart
@@ -1,11 +1,12 @@
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 void main() {
   const destinations = [
-    AppDestination(icon: Icons.home, label: 'Home'),
-    AppDestination(icon: Icons.settings, label: 'Settings'),
+    AppDestination(icon: FontAwesomeIcons.house, label: 'Home'),
+    AppDestination(icon: FontAwesomeIcons.circle, label: 'Settings'),
   ];
 
   Future<void> pumpAt(
@@ -40,7 +41,7 @@ void main() {
       expect(find.text('Home'), findsOneWidget);
 
       // Tapping another destination reports its index.
-      await tester.tap(find.byIcon(Icons.settings));
+      await tester.tap(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circle.codePoint));
       expect(selected, 1);
     });
 

--- a/packages/app_ui/test/widgets/app_adaptive_scaffold_test.dart
+++ b/packages/app_ui/test/widgets/app_adaptive_scaffold_test.dart
@@ -41,7 +41,13 @@ void main() {
       expect(find.text('Home'), findsOneWidget);
 
       // Tapping another destination reports its index.
-      await tester.tap(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circle.codePoint));
+      await tester.tap(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.circle.codePoint,
+        ),
+      );
       expect(selected, 1);
     });
 

--- a/packages/app_ui/test/widgets/app_photo_view_test.dart
+++ b/packages/app_ui/test/widgets/app_photo_view_test.dart
@@ -61,7 +61,14 @@ void main() {
 
       // Verify the error text is displayed
       expect(find.text('Image Load Failed'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.image.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.image.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('shows fullscreen viewer and close button dismisses it', (
@@ -96,7 +103,11 @@ void main() {
       expect(find.byType(PhotoView), findsOneWidget);
 
       // Close button should be present
-      final closeButton = find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.xmark.codePoint);
+      final closeButton = find.byWidgetPredicate(
+        (w) =>
+            w is FaIcon &&
+            w.icon?.codePoint == FontAwesomeIcons.xmark.codePoint,
+      );
       expect(closeButton, findsOneWidget);
 
       // Tap close to dismiss

--- a/packages/app_ui/test/widgets/app_photo_view_test.dart
+++ b/packages/app_ui/test/widgets/app_photo_view_test.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:photo_view/photo_view.dart';
 import 'package:test_utils/test_utils.dart';
 
@@ -60,7 +61,7 @@ void main() {
 
       // Verify the error text is displayed
       expect(find.text('Image Load Failed'), findsOneWidget);
-      expect(find.byIcon(Icons.broken_image_rounded), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.image.codePoint), findsOneWidget);
     });
 
     testWidgets('shows fullscreen viewer and close button dismisses it', (
@@ -95,7 +96,7 @@ void main() {
       expect(find.byType(PhotoView), findsOneWidget);
 
       // Close button should be present
-      final closeButton = find.byIcon(Icons.close_rounded);
+      final closeButton = find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.xmark.codePoint);
       expect(closeButton, findsOneWidget);
 
       // Tap close to dismiss

--- a/packages/app_ui/test/widgets/core_widgets_test.dart
+++ b/packages/app_ui/test/widgets/core_widgets_test.dart
@@ -44,7 +44,14 @@ void main() {
       );
 
       expect(find.text('Nothing here'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.inbox.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.inbox.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders title when provided', (tester) async {
@@ -59,11 +66,22 @@ void main() {
     testWidgets('renders custom icon', (tester) async {
       await tester.pumpWidget(
         materialApp(
-          const AppEmptyView(message: 'Empty', icon: FontAwesomeIcons.magnifyingGlassMinus),
+          const AppEmptyView(
+            message: 'Empty',
+            icon: FontAwesomeIcons.magnifyingGlassMinus,
+          ),
         ),
       );
 
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.magnifyingGlassMinus.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint ==
+                  FontAwesomeIcons.magnifyingGlassMinus.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders action widget when provided', (tester) async {
@@ -85,7 +103,14 @@ void main() {
       await tester.pumpWidget(materialApp(const AppErrorView(message: 'Oops')));
 
       expect(find.text('Oops'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circleExclamation.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.circleExclamation.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders title when provided', (tester) async {
@@ -105,7 +130,14 @@ void main() {
       );
 
       expect(find.text('Retry'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.rotateRight.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.rotateRight.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('retry callback fires on tap', (tester) async {
@@ -214,7 +246,14 @@ void main() {
 
       expect(find.byType(CustomSlidableAction), findsOneWidget);
       expect(find.text('Delete'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.trashCan.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.trashCan.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('fires action callback', (tester) async {
@@ -259,11 +298,21 @@ void main() {
     testWidgets('renders prefix icon', (tester) async {
       await tester.pumpWidget(
         materialApp(
-          const AppTextField(label: 'Email', prefixIcon: FontAwesomeIcons.circle),
+          const AppTextField(
+            label: 'Email',
+            prefixIcon: FontAwesomeIcons.circle,
+          ),
         ),
       );
 
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circle.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.circle.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('accepts text input', (tester) async {
@@ -335,11 +384,22 @@ void main() {
       testWidgets('renders icon button when icon provided', (tester) async {
         await tester.pumpWidget(
           materialApp(
-            AppButton(label: 'Save', onPressed: () {}, icon: FontAwesomeIcons.circle),
+            AppButton(
+              label: 'Save',
+              onPressed: () {},
+              icon: FontAwesomeIcons.circle,
+            ),
           ),
         );
 
-        expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circle.codePoint), findsOneWidget);
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is FaIcon &&
+                w.icon?.codePoint == FontAwesomeIcons.circle.codePoint,
+          ),
+          findsOneWidget,
+        );
         expect(find.text('Save'), findsOneWidget);
       });
 
@@ -383,7 +443,14 @@ void main() {
           ),
         );
 
-        expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.xmark.codePoint), findsOneWidget);
+        expect(
+          find.byWidgetPredicate(
+            (w) =>
+                w is FaIcon &&
+                w.icon?.codePoint == FontAwesomeIcons.xmark.codePoint,
+          ),
+          findsOneWidget,
+        );
       });
     });
 

--- a/packages/app_ui/test/widgets/core_widgets_test.dart
+++ b/packages/app_ui/test/widgets/core_widgets_test.dart
@@ -2,6 +2,7 @@ import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 Widget materialApp(Widget child) {
   return MaterialApp(
@@ -43,7 +44,7 @@ void main() {
       );
 
       expect(find.text('Nothing here'), findsOneWidget);
-      expect(find.byIcon(Icons.inbox_outlined), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.inbox.codePoint), findsOneWidget);
     });
 
     testWidgets('renders title when provided', (tester) async {
@@ -58,11 +59,11 @@ void main() {
     testWidgets('renders custom icon', (tester) async {
       await tester.pumpWidget(
         materialApp(
-          const AppEmptyView(message: 'Empty', icon: Icons.search_off),
+          const AppEmptyView(message: 'Empty', icon: FontAwesomeIcons.magnifyingGlassMinus),
         ),
       );
 
-      expect(find.byIcon(Icons.search_off), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.magnifyingGlassMinus.codePoint), findsOneWidget);
     });
 
     testWidgets('renders action widget when provided', (tester) async {
@@ -84,7 +85,7 @@ void main() {
       await tester.pumpWidget(materialApp(const AppErrorView(message: 'Oops')));
 
       expect(find.text('Oops'), findsOneWidget);
-      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circleExclamation.codePoint), findsOneWidget);
     });
 
     testWidgets('renders title when provided', (tester) async {
@@ -104,7 +105,7 @@ void main() {
       );
 
       expect(find.text('Retry'), findsOneWidget);
-      expect(find.byIcon(Icons.refresh), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.rotateRight.codePoint), findsOneWidget);
     });
 
     testWidgets('retry callback fires on tap', (tester) async {
@@ -184,7 +185,7 @@ void main() {
             body: const Text('Content'),
             floatingActionButton: FloatingActionButton(
               onPressed: () {},
-              child: const Icon(Icons.add),
+              child: const FaIcon(FontAwesomeIcons.plus),
             ),
           ),
         ),
@@ -211,9 +212,9 @@ void main() {
       await tester.drag(find.text('Bookmark'), const Offset(-300, 0));
       await tester.pumpAndSettle();
 
-      final action = tester.widget<SlidableAction>(find.byType(SlidableAction));
-      expect(action.label, 'Delete');
-      expect(action.icon, Icons.delete_outline);
+      expect(find.byType(CustomSlidableAction), findsOneWidget);
+      expect(find.text('Delete'), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.trashCan.codePoint), findsOneWidget);
     });
 
     testWidgets('fires action callback', (tester) async {
@@ -231,7 +232,7 @@ void main() {
 
       await tester.drag(find.text('Bookmark'), const Offset(-300, 0));
       await tester.pumpAndSettle();
-      await tester.tap(find.byType(SlidableAction));
+      await tester.tap(find.byType(CustomSlidableAction));
 
       expect(tapped, isTrue);
     });
@@ -258,11 +259,11 @@ void main() {
     testWidgets('renders prefix icon', (tester) async {
       await tester.pumpWidget(
         materialApp(
-          const AppTextField(label: 'Email', prefixIcon: Icons.email_outlined),
+          const AppTextField(label: 'Email', prefixIcon: FontAwesomeIcons.circle),
         ),
       );
 
-      expect(find.byIcon(Icons.email_outlined), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circle.codePoint), findsOneWidget);
     });
 
     testWidgets('accepts text input', (tester) async {
@@ -334,11 +335,11 @@ void main() {
       testWidgets('renders icon button when icon provided', (tester) async {
         await tester.pumpWidget(
           materialApp(
-            AppButton(label: 'Save', onPressed: () {}, icon: Icons.save),
+            AppButton(label: 'Save', onPressed: () {}, icon: FontAwesomeIcons.circle),
           ),
         );
 
-        expect(find.byIcon(Icons.save), findsOneWidget);
+        expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circle.codePoint), findsOneWidget);
         expect(find.text('Save'), findsOneWidget);
       });
 
@@ -377,12 +378,12 @@ void main() {
               label: 'Close',
               onPressed: () {},
               variant: AppButtonVariant.tonal,
-              icon: Icons.close,
+              icon: FontAwesomeIcons.xmark,
             ),
           ),
         );
 
-        expect(find.byIcon(Icons.close), findsOneWidget);
+        expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.xmark.codePoint), findsOneWidget);
       });
     });
 

--- a/packages/app_ui/test/widgets/golden/core_widgets_golden_test.dart
+++ b/packages/app_ui/test/widgets/golden/core_widgets_golden_test.dart
@@ -4,6 +4,7 @@ library;
 import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 /// Pumps [child] inside a deterministic MaterialApp (a plain
 /// `ColorScheme.fromSeed` theme, no `google_fonts` network fetch) and captures
@@ -58,7 +59,7 @@ void main() {
         AppButton(
           label: 'Primary',
           onPressed: _noop,
-          icon: Icons.check,
+          icon: FontAwesomeIcons.check,
         ),
         AppButton(
           label: 'Tonal',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -850,6 +850,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: "direct main"
+    description:
+      name: font_awesome_flutter
+      sha256: "09dcde8ab90ffae1a7d65ff2ef96fc62a17ad9d0ce7c127b317ded676b0d5935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.0.0"
   freezed:
     dependency: "direct dev"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -122,6 +122,7 @@ dependencies:
   firebase_core: ^4.9.0
 
   vector_graphics: ^1.2.2
+  font_awesome_flutter: ^11.0.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/test/features/bookmarks/presentation/widgets/app_video_player_test.dart
+++ b/test/features/bookmarks/presentation/widgets/app_video_player_test.dart
@@ -2,6 +2,7 @@ import 'package:app_platform/app_platform.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_starter_template/features/bookmarks/presentation/widgets/app_video_player.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:test_utils/test_utils.dart';
 
 class MockAppVideoPlayerController extends Mock
@@ -46,7 +47,7 @@ void main() {
       );
 
       expect(find.text('Mock Video Player View'), findsOneWidget);
-      expect(find.byIcon(Icons.video_library), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.video.codePoint), findsOneWidget);
     });
 
     testWidgets('renders error view when video fails to load', (
@@ -63,7 +64,7 @@ void main() {
         wrapWithMaterial(AppVideoPlayer(controller: mockController)),
       );
 
-      expect(find.byIcon(Icons.error_outline_rounded), findsOneWidget);
+      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circleExclamation.codePoint), findsOneWidget);
       expect(find.text('Invalid video file format'), findsOneWidget);
     });
   });

--- a/test/features/bookmarks/presentation/widgets/app_video_player_test.dart
+++ b/test/features/bookmarks/presentation/widgets/app_video_player_test.dart
@@ -47,7 +47,14 @@ void main() {
       );
 
       expect(find.text('Mock Video Player View'), findsOneWidget);
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.video.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.video.codePoint,
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('renders error view when video fails to load', (
@@ -64,7 +71,14 @@ void main() {
         wrapWithMaterial(AppVideoPlayer(controller: mockController)),
       );
 
-      expect(find.byWidgetPredicate((w) => w is FaIcon && w.icon?.codePoint == FontAwesomeIcons.circleExclamation.codePoint), findsOneWidget);
+      expect(
+        find.byWidgetPredicate(
+          (w) =>
+              w is FaIcon &&
+              w.icon?.codePoint == FontAwesomeIcons.circleExclamation.codePoint,
+        ),
+        findsOneWidget,
+      );
       expect(find.text('Invalid video file format'), findsOneWidget);
     });
   });


### PR DESCRIPTION
Replaced all standard Material icons with their closest equivalent in `font_awesome_flutter: ^11.0.0` to improve UI aesthetics. Also updated custom slidable components and refactored tests accordingly.