### PR TITLE
Update home dashboard UI

### DIFF
--- a/lib/features/home/presentation/widgets/home_recent.dart
+++ b/lib/features/home/presentation/widgets/home_recent.dart
@@ -164,7 +164,7 @@ class _BookmarkFeedCard extends StatelessWidget {
                     bookmark.description.isNotEmpty
                         ? bookmark.description
                         : context.l10n.homeNoDescription,
-                    maxLines: featured ? 2 : 2,
+                    maxLines: 2,
                     overflow: TextOverflow.ellipsis,
                     style: context.textTheme.bodySmall?.copyWith(
                       color: context.colorScheme.onSurfaceVariant,

--- a/lib/features/home/presentation/widgets/home_recent.dart
+++ b/lib/features/home/presentation/widgets/home_recent.dart
@@ -4,161 +4,210 @@ class _RecentBookmarksSection extends StatelessWidget {
   const _RecentBookmarksSection({
     required this.recentItems,
     required this.isEmpty,
+    required this.hasMatches,
     required this.animationDelay,
   });
 
-  static const double _carouselHeight = 188;
-
   final List<BookmarkSummary> recentItems;
   final bool isEmpty;
+  final bool hasMatches;
   final Duration animationDelay;
 
   @override
   Widget build(BuildContext context) {
-    if (isEmpty) {
-      return Material(
-        clipBehavior: Clip.antiAlias,
-        color: context.colorScheme.surfaceContainerHighest.withValues(
-          alpha: context.isDark ? 0.28 : 0.46,
-        ),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(AppRadius.lg),
-          side: BorderSide(
-            color: context.colorScheme.outlineVariant.withValues(alpha: 0.36),
-          ),
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.xl),
-          child: Row(
-            children: [
-              FaIcon(
-                FontAwesomeIcons.bookmark,
-                color: context.colorScheme.outline,
-              ),
-              const SizedBox(width: AppSpacing.md),
-              Expanded(
-                child: Text(
-                  context.l10n.homeNoBookmarks,
-                  style: context.textTheme.bodyMedium?.copyWith(
-                    color: context.colorScheme.onSurfaceVariant,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+    if (isEmpty || !hasMatches) {
+      return _EmptyBookmarksPanel(
+        message: isEmpty
+            ? context.l10n.homeNoBookmarks
+            : context.l10n.homeNoMatches,
       ).animateFadeIn(delay: animationDelay);
     }
+
     return Column(
-      mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Row(
-          children: [
-            FaIcon(
-              FontAwesomeIcons.clockRotateLeft,
-              size: AppIconSize.sm,
-              color: context.colorScheme.primary,
-            ),
-            const SizedBox(width: AppSpacing.sm),
-            Expanded(
-              child: Text(
-                context.l10n.homeRecentBookmarks,
-                style: context.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-              ),
-            ),
-          ],
+        _SectionHeader(
+          title: context.l10n.homeRecentBookmarks,
         ).animateFadeIn(delay: animationDelay),
         const SizedBox(height: AppSpacing.md),
-        AppCarousel(
-          items: recentItems
-              .map((b) => _BookmarkCarouselCard(bookmark: b))
-              .toList(),
-          showIndicators: recentItems.length > 1,
-          height: _carouselHeight,
-          viewportFraction: 0.92,
-        ).animateFadeIn(delay: animationDelay + 200.ms),
+        LayoutBuilder(
+          builder: (context, constraints) {
+            final twoColumns = constraints.maxWidth >= 620;
+            if (!twoColumns) {
+              return Column(
+                children: [
+                  for (final (index, item) in recentItems.indexed) ...[
+                    if (index > 0) const SizedBox(height: AppSpacing.md),
+                    _BookmarkFeedCard(
+                      bookmark: item,
+                      featured: index == 0,
+                    ),
+                  ],
+                ],
+              ).animateFadeIn(delay: animationDelay + 160.ms);
+            }
+
+            return Wrap(
+              spacing: AppSpacing.md,
+              runSpacing: AppSpacing.md,
+              children: [
+                for (final (index, item) in recentItems.indexed)
+                  SizedBox(
+                    width: index == 0
+                        ? constraints.maxWidth
+                        : (constraints.maxWidth - AppSpacing.md) / 2,
+                    child: _BookmarkFeedCard(
+                      bookmark: item,
+                      featured: index == 0,
+                    ),
+                  ),
+              ],
+            ).animateFadeIn(delay: animationDelay + 160.ms);
+          },
+        ),
       ],
     );
   }
 }
 
-class _BookmarkCarouselCard extends StatelessWidget {
-  const _BookmarkCarouselCard({required this.bookmark});
+class _EmptyBookmarksPanel extends StatelessWidget {
+  const _EmptyBookmarksPanel({required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ElevatedSurface(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xl),
+        child: Row(
+          children: [
+            FaIcon(
+              FontAwesomeIcons.bookmark,
+              color: context.colorScheme.outline,
+            ),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: Text(
+                message,
+                style: context.textTheme.bodyMedium?.copyWith(
+                  color: context.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BookmarkFeedCard extends StatelessWidget {
+  const _BookmarkFeedCard({
+    required this.bookmark,
+    required this.featured,
+  });
 
   final BookmarkSummary bookmark;
+  final bool featured;
 
   @override
   Widget build(BuildContext context) {
     final visibleTags = bookmark.tags.take(3).toList();
     final hiddenCount = bookmark.tags.length - visibleTags.length;
+    final tagLabel = visibleTags.isNotEmpty
+        ? visibleTags.first
+        : context.l10n.homeStatsRecent;
 
-    return Material(
-      clipBehavior: Clip.antiAlias,
-      color: context.colorScheme.surfaceContainerHighest.withValues(
-        alpha: context.isDark ? 0.32 : 0.52,
-      ),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-        side: BorderSide(
-          color: context.colorScheme.outlineVariant.withValues(alpha: 0.36),
-        ),
-      ),
+    return _ElevatedSurface(
       child: InkWell(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
         onTap: () => BookmarkDetailRoute(bookmark.id).push<void>(context),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.xl),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                bookmark.title,
-                style: context.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w700,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: AppSpacing.xs),
-              Text(
-                bookmark.url,
-                style: context.textTheme.bodySmall?.copyWith(
-                  color: context.colorScheme.primary,
-                  fontWeight: FontWeight.w600,
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: AppSpacing.md),
-              Expanded(
-                child: Text(
-                  bookmark.description.isNotEmpty
-                      ? bookmark.description
-                      : context.l10n.homeNoDescription,
-                  style: context.textTheme.bodySmall?.copyWith(
-                    color: context.colorScheme.onSurfaceVariant,
-                    height: 1.35,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _BookmarkVisual(
+              icon: featured
+                  ? FontAwesomeIcons.bookOpenReader
+                  : FontAwesomeIcons.link,
+              label: tagLabel,
+              height: featured ? 192 : 144,
+              colors: featured
+                  ? [
+                      context.colorScheme.primaryContainer,
+                      context.colorScheme.tertiaryContainer,
+                    ]
+                  : [
+                      context.colorScheme.surfaceContainerHigh,
+                      context.colorScheme.secondaryContainer,
+                    ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.lg),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    bookmark.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style:
+                        (featured
+                                ? context.textTheme.titleLarge
+                                : context.textTheme.titleMedium)
+                            ?.copyWith(
+                              fontWeight: FontWeight.w800,
+                              color: context.colorScheme.onSurface,
+                            ),
                   ),
-                  maxLines: 2,
-                  overflow: TextOverflow.ellipsis,
-                ),
-              ),
-              if (visibleTags.isNotEmpty) ...[
-                const SizedBox(height: AppSpacing.sm),
-                Wrap(
-                  spacing: AppSpacing.xs,
-                  runSpacing: AppSpacing.xs,
-                  children: [
-                    for (final tag in visibleTags) _RecentTag(label: tag),
-                    if (hiddenCount > 0) _RecentTag(label: '+$hiddenCount'),
+                  const SizedBox(height: AppSpacing.sm),
+                  Text(
+                    bookmark.description.isNotEmpty
+                        ? bookmark.description
+                        : context.l10n.homeNoDescription,
+                    maxLines: featured ? 2 : 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: context.textTheme.bodySmall?.copyWith(
+                      color: context.colorScheme.onSurfaceVariant,
+                      height: 1.4,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.md),
+                  Row(
+                    children: [
+                      FaIcon(
+                        FontAwesomeIcons.link,
+                        size: AppIconSize.sm,
+                        color: context.colorScheme.outline,
+                      ),
+                      const SizedBox(width: AppSpacing.sm),
+                      Expanded(
+                        child: Text(
+                          bookmark.url,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: context.textTheme.labelSmall?.copyWith(
+                            color: context.colorScheme.outline,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (visibleTags.isNotEmpty) ...[
+                    const SizedBox(height: AppSpacing.md),
+                    Wrap(
+                      spacing: AppSpacing.xs,
+                      runSpacing: AppSpacing.xs,
+                      children: [
+                        for (final tag in visibleTags) _RecentTag(label: tag),
+                        if (hiddenCount > 0) _RecentTag(label: '+$hiddenCount'),
+                      ],
+                    ),
                   ],
-                ),
-              ],
-            ],
-          ),
+                ],
+              ),
+            ),
+          ],
         ),
       ),
     );
@@ -175,19 +224,22 @@ class _RecentTag extends StatelessWidget {
     return Container(
       padding: const EdgeInsets.symmetric(
         horizontal: AppSpacing.sm,
-        vertical: AppSpacing.xxs,
+        vertical: AppSpacing.xs,
       ),
       decoration: BoxDecoration(
-        color: context.colorScheme.secondaryContainer.withValues(alpha: 0.72),
+        color: context.colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(AppRadius.xl),
+        border: Border.all(
+          color: context.colorScheme.outlineVariant.withValues(alpha: 0.54),
+        ),
       ),
       child: Text(
         label,
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         style: context.textTheme.labelSmall?.copyWith(
-          color: context.colorScheme.onSecondaryContainer,
-          fontWeight: FontWeight.w600,
+          color: context.colorScheme.onSurfaceVariant,
+          fontWeight: FontWeight.w700,
         ),
       ),
     );

--- a/lib/features/home/presentation/widgets/home_stats.dart
+++ b/lib/features/home/presentation/widgets/home_stats.dart
@@ -72,17 +72,7 @@ class _StatCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      clipBehavior: Clip.antiAlias,
-      color: context.colorScheme.surfaceContainerHighest.withValues(
-        alpha: context.isDark ? 0.32 : 0.48,
-      ),
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(AppRadius.lg),
-        side: BorderSide(
-          color: context.colorScheme.outlineVariant.withValues(alpha: 0.36),
-        ),
-      ),
+    return _ElevatedSurface(
       child: Padding(
         padding: const EdgeInsets.all(AppSpacing.md),
         child: Row(

--- a/lib/features/home/presentation/widgets/home_welcome.dart
+++ b/lib/features/home/presentation/widgets/home_welcome.dart
@@ -522,7 +522,7 @@ class _WeeklyDigestPanel extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  context.l10n.homeWeeklyDigestEyebrow.toUpperCase(),
+                  context.l10n.homeWeeklyDigestEyebrow,
                   style: context.textTheme.labelSmall?.copyWith(
                     color: context.colorScheme.onSecondaryContainer,
                     fontWeight: FontWeight.w800,

--- a/lib/features/home/presentation/widgets/home_welcome.dart
+++ b/lib/features/home/presentation/widgets/home_welcome.dart
@@ -1,111 +1,558 @@
 part of 'home_widgets.dart';
 
-class _WelcomeSection extends StatelessWidget {
-  const _WelcomeSection({required this.totalBookmarks});
+class _SearchSection extends StatelessWidget {
+  const _SearchSection({
+    required this.controller,
+    required this.onChanged,
+  });
 
-  final int totalBookmarks;
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    final session = SessionScope.of(context);
-    return ListenableBuilder(
-      listenable: session,
-      builder: (context, _) {
-        final username = session.currentUser?.username ?? '';
-        return Material(
-          clipBehavior: Clip.antiAlias,
-          color: context.colorScheme.primaryContainer.withValues(
-            alpha: context.isDark ? 0.34 : 0.7,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          context.l10n.homeSearchTitle,
+          style: context.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.w800,
+            color: context.colorScheme.onSurface,
           ),
+        ),
+        const SizedBox(height: AppSpacing.xs),
+        Text(
+          context.l10n.homeSearchSubtitle,
+          style: context.textTheme.bodySmall?.copyWith(
+            color: context.colorScheme.onSurfaceVariant,
+            height: 1.35,
+          ),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        Material(
+          clipBehavior: Clip.antiAlias,
+          color: context.colorScheme.surface,
+          elevation: context.isDark ? 0 : 3,
+          shadowColor: context.colorScheme.shadow.withValues(alpha: 0.08),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(AppRadius.lg),
-            side: BorderSide(
-              color: context.colorScheme.primary.withValues(alpha: 0.12),
+          ),
+          child: TextField(
+            controller: controller,
+            onChanged: onChanged,
+            textInputAction: TextInputAction.search,
+            decoration: InputDecoration(
+              hintText: context.l10n.homeSearchHint,
+              prefixIcon: const Center(
+                widthFactor: 1,
+                child: FaIcon(
+                  FontAwesomeIcons.magnifyingGlass,
+                  size: AppIconSize.sm,
+                ),
+              ),
+              suffixIcon: controller.text.isNotEmpty
+                  ? IconButton(
+                      onPressed: () {
+                        controller.clear();
+                        onChanged('');
+                      },
+                      icon: const FaIcon(
+                        FontAwesomeIcons.xmark,
+                        size: AppIconSize.sm,
+                      ),
+                      tooltip: context.l10n.bookmarksSearchClear,
+                    )
+                  : null,
+              filled: true,
+              fillColor: context.colorScheme.surface,
+              contentPadding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.lg,
+                vertical: AppSpacing.lg,
+              ),
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppRadius.lg),
+                borderSide: BorderSide.none,
+              ),
+              enabledBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppRadius.lg),
+                borderSide: BorderSide.none,
+              ),
+              focusedBorder: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(AppRadius.lg),
+                borderSide: BorderSide(
+                  color: context.colorScheme.primary,
+                  width: 2,
+                ),
+              ),
             ),
           ),
-          child: Padding(
-            padding: const EdgeInsets.all(AppSpacing.lg),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                CircleAvatar(
-                  radius: 28,
-                  backgroundColor: context.colorScheme.primary,
-                  child: FaIcon(
-                    FontAwesomeIcons.solidUser,
-                    size: AppIconSize.lg,
-                    color: context.colorScheme.onPrimary,
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.md),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      AppAnimatedText(
-                        text: context.l10n.homeWelcome(username),
-                        type: AppAnimatedTextType.fade,
-                        textStyle: context.textTheme.titleLarge?.copyWith(
-                          fontWeight: FontWeight.w700,
-                          color: context.colorScheme.onPrimaryContainer,
-                        ),
-                      ),
-                      const SizedBox(height: AppSpacing.xs),
-                      Text(
-                        context.l10n.homeSignedInBody,
-                        style: context.textTheme.bodyMedium?.copyWith(
-                          color: context.colorScheme.onPrimaryContainer
-                              .withValues(alpha: 0.78),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(width: AppSpacing.sm),
-                _BookmarkCountBadge(count: totalBookmarks),
-              ],
-            ),
-          ),
-        );
-      },
+        ),
+      ],
     );
   }
 }
 
-class _BookmarkCountBadge extends StatelessWidget {
-  const _BookmarkCountBadge({required this.count});
+class _QuickActions extends StatelessWidget {
+  const _QuickActions({
+    required this.onAdd,
+    required this.onLibrary,
+    required this.onTags,
+  });
 
-  final int count;
+  final VoidCallback onAdd;
+  final VoidCallback onLibrary;
+  final VoidCallback onTags;
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      constraints: const BoxConstraints(minWidth: 48),
-      padding: const EdgeInsets.symmetric(
-        horizontal: AppSpacing.sm,
-        vertical: AppSpacing.xs,
+    return Row(
+      children: [
+        Expanded(
+          child: _QuickActionTile(
+            icon: FontAwesomeIcons.plus,
+            label: context.l10n.homeQuickAdd,
+            onTap: onAdd,
+          ),
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: _QuickActionTile(
+            icon: FontAwesomeIcons.layerGroup,
+            label: context.l10n.homeQuickLibrary,
+            onTap: onLibrary,
+          ),
+        ),
+        const SizedBox(width: AppSpacing.sm),
+        Expanded(
+          child: _QuickActionTile(
+            icon: FontAwesomeIcons.tags,
+            label: context.l10n.homeQuickTags,
+            onTap: onTags,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _QuickActionTile extends StatelessWidget {
+  const _QuickActionTile({
+    required this.icon,
+    required this.label,
+    required this.onTap,
+  });
+
+  final FaIconData icon;
+  final String label;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      clipBehavior: Clip.antiAlias,
+      color: context.colorScheme.surfaceContainer,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        side: BorderSide(
+          color: context.colorScheme.outlineVariant.withValues(alpha: 0.3),
+        ),
       ),
-      decoration: BoxDecoration(
-        color: context.colorScheme.surface.withValues(alpha: 0.76),
-        borderRadius: BorderRadius.circular(AppRadius.sm),
-      ),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            count.toString(),
-            style: context.textTheme.titleMedium?.copyWith(
-              color: context.colorScheme.primary,
-              fontWeight: FontWeight.w800,
+      child: InkWell(
+        onTap: onTap,
+        child: SizedBox(
+          height: 80,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.sm),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                FaIcon(
+                  icon,
+                  size: AppIconSize.lg,
+                  color: context.colorScheme.primary,
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  textAlign: TextAlign.center,
+                  style: context.textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: context.colorScheme.onSurface,
+                  ),
+                ),
+              ],
             ),
           ),
-          Text(
-            context.l10n.homeStatsTotal,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: context.textTheme.labelSmall?.copyWith(
-              color: context.colorScheme.onSurfaceVariant,
-              fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterChips extends StatelessWidget {
+  const _FilterChips({
+    required this.filters,
+    required this.selectedId,
+    required this.onSelected,
+  });
+
+  final List<_HomeFilter> filters;
+  final String selectedId;
+  final ValueChanged<_HomeFilter> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      clipBehavior: Clip.none,
+      child: Row(
+        children: [
+          for (final (index, filter) in filters.indexed) ...[
+            if (index > 0) const SizedBox(width: AppSpacing.sm),
+            ChoiceChip(
+              label: Text(filter.label),
+              selected: filter.id == selectedId,
+              onSelected: (_) => onSelected(filter),
+              labelStyle: context.textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+              shape: StadiumBorder(
+                side: BorderSide(
+                  color: filter.id == selectedId
+                      ? context.colorScheme.primary
+                      : context.colorScheme.outlineVariant,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _SuggestedBookmarksSection extends StatelessWidget {
+  const _SuggestedBookmarksSection({required this.items});
+
+  final List<BookmarkSummary> items;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SectionHeader(title: context.l10n.homeSuggestedTitle),
+        const SizedBox(height: AppSpacing.md),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          clipBehavior: Clip.none,
+          child: Row(
+            children: [
+              for (final (index, item) in items.take(3).indexed) ...[
+                if (index > 0) const SizedBox(width: AppSpacing.md),
+                SizedBox(
+                  width: 240,
+                  child: _SuggestedBookmarkCard(bookmark: item),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SuggestedBookmarkCard extends StatelessWidget {
+  const _SuggestedBookmarkCard({required this.bookmark});
+
+  final BookmarkSummary bookmark;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = bookmark.tags.isNotEmpty
+        ? bookmark.tags.first
+        : context.l10n.homeStatsRecent;
+
+    return _ElevatedSurface(
+      child: InkWell(
+        onTap: () => BookmarkDetailRoute(bookmark.id).push<void>(context),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _BookmarkVisual(
+              icon: FontAwesomeIcons.clockRotateLeft,
+              label: label,
+              height: 96,
+              colors: [
+                context.colorScheme.tertiaryContainer,
+                context.colorScheme.secondaryContainer,
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.all(AppSpacing.sm),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    bookmark.title,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                    style: context.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w800,
+                      color: context.colorScheme.onSurface,
+                    ),
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    bookmark.url,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: context.textTheme.labelSmall?.copyWith(
+                      color: context.colorScheme.outline,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FeaturedCollectionsSection extends StatelessWidget {
+  const _FeaturedCollectionsSection({required this.items});
+
+  final List<BookmarkSummary> items;
+
+  @override
+  Widget build(BuildContext context) {
+    final collections = _collections(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        _SectionHeader(
+          title: context.l10n.homeFeaturedCollections,
+          actionLabel: context.l10n.homeViewAllBookmarks,
+          onActionPressed: () => const BookmarksListRoute().push<void>(context),
+        ),
+        const SizedBox(height: AppSpacing.md),
+        SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          clipBehavior: Clip.none,
+          child: Row(
+            children: [
+              for (final (index, collection) in collections.indexed) ...[
+                if (index > 0) const SizedBox(width: AppSpacing.md),
+                _CollectionCard(collection: collection),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  List<_CollectionData> _collections(BuildContext context) {
+    final tagCounts = <String, int>{};
+    for (final item in items) {
+      for (final tag in item.tags) {
+        final normalized = tag.trim();
+        if (normalized.isNotEmpty) {
+          tagCounts.update(normalized, (value) => value + 1, ifAbsent: () => 1);
+        }
+      }
+    }
+
+    final tagCollections = tagCounts.entries.toList()
+      ..sort((a, b) => b.value.compareTo(a.value));
+
+    final fromTags = tagCollections.take(3).map((entry) {
+      return _CollectionData(
+        title: entry.key,
+        icon: FontAwesomeIcons.hashtag,
+        colors: [
+          context.colorScheme.primaryContainer,
+          context.colorScheme.primary,
+        ],
+      );
+    }).toList();
+
+    if (fromTags.length >= 3) return fromTags;
+
+    return [
+      ...fromTags,
+      _CollectionData(
+        title: context.l10n.homeFilterDesign,
+        icon: FontAwesomeIcons.palette,
+        colors: [
+          context.colorScheme.primary,
+          context.colorScheme.tertiary,
+        ],
+      ),
+      _CollectionData(
+        title: context.l10n.homeFilterArticles,
+        icon: FontAwesomeIcons.bookOpen,
+        colors: [
+          context.colorScheme.tertiaryContainer,
+          context.colorScheme.tertiary,
+        ],
+      ),
+      _CollectionData(
+        title: context.l10n.homeFilterTools,
+        icon: FontAwesomeIcons.screwdriverWrench,
+        colors: [
+          context.colorScheme.secondary,
+          context.colorScheme.inverseSurface,
+        ],
+      ),
+    ].take(3).toList();
+  }
+}
+
+class _CollectionData {
+  const _CollectionData({
+    required this.title,
+    required this.icon,
+    required this.colors,
+  });
+
+  final String title;
+  final FaIconData icon;
+  final List<Color> colors;
+}
+
+class _CollectionCard extends StatelessWidget {
+  const _CollectionCard({required this.collection});
+
+  final _CollectionData collection;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      clipBehavior: Clip.antiAlias,
+      color: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Ink(
+        width: 160,
+        height: 104,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: collection.colors,
+          ),
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+        ),
+        child: InkWell(
+          onTap: () => const BookmarksListRoute().push<void>(context),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                FaIcon(
+                  collection.icon,
+                  color: context.colorScheme.onPrimary,
+                  size: AppIconSize.md,
+                ),
+                const Spacer(),
+                Text(
+                  collection.title,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.textTheme.labelMedium?.copyWith(
+                    color: context.colorScheme.onPrimary,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _WeeklyDigestPanel extends StatelessWidget {
+  const _WeeklyDigestPanel({
+    required this.recentCount,
+    required this.onPressed,
+  });
+
+  final int recentCount;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      clipBehavior: Clip.antiAlias,
+      color: context.colorScheme.secondaryContainer,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.xl),
+      ),
+      child: Stack(
+        children: [
+          PositionedDirectional(
+            top: -16,
+            end: -8,
+            child: FaIcon(
+              FontAwesomeIcons.wandMagicSparkles,
+              size: 112,
+              color: context.colorScheme.onSecondaryContainer.withValues(
+                alpha: 0.08,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(AppSpacing.xl),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  context.l10n.homeWeeklyDigestEyebrow.toUpperCase(),
+                  style: context.textTheme.labelSmall?.copyWith(
+                    color: context.colorScheme.onSecondaryContainer,
+                    fontWeight: FontWeight.w800,
+                    letterSpacing: 0.6,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.xs),
+                Text(
+                  context.l10n.homeWeeklyDigestHeadline,
+                  style: context.textTheme.titleLarge?.copyWith(
+                    color: context.colorScheme.onSecondaryContainer,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.sm),
+                Text(
+                  context.l10n.homeWeeklyDigestBody(recentCount),
+                  style: context.textTheme.bodySmall?.copyWith(
+                    color: context.colorScheme.onSecondaryContainer.withValues(
+                      alpha: 0.78,
+                    ),
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.lg),
+                FilledButton(
+                  onPressed: onPressed,
+                  child: Text(context.l10n.homeReadDigest),
+                ),
+              ],
             ),
           ),
         ],
@@ -114,63 +561,126 @@ class _BookmarkCountBadge extends StatelessWidget {
   }
 }
 
-class _PrimaryActionPanel extends StatelessWidget {
-  const _PrimaryActionPanel({required this.onPressed});
+class _SectionHeader extends StatelessWidget {
+  const _SectionHeader({
+    required this.title,
+    this.actionLabel,
+    this.onActionPressed,
+  });
 
-  final VoidCallback onPressed;
+  final String title;
+  final String? actionLabel;
+  final VoidCallback? onActionPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            title,
+            style: context.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w800,
+              color: context.colorScheme.onSurface,
+            ),
+          ),
+        ),
+        if (actionLabel != null && onActionPressed != null)
+          TextButton(
+            onPressed: onActionPressed,
+            child: Text(actionLabel!),
+          ),
+      ],
+    );
+  }
+}
+
+class _ElevatedSurface extends StatelessWidget {
+  const _ElevatedSurface({required this.child});
+
+  final Widget child;
 
   @override
   Widget build(BuildContext context) {
     return Material(
       clipBehavior: Clip.antiAlias,
-      color: context.colorScheme.surfaceContainerHighest.withValues(
-        alpha: context.isDark ? 0.28 : 0.5,
-      ),
+      color: context.colorScheme.surface,
+      elevation: context.isDark ? 0 : 3,
+      shadowColor: context.colorScheme.shadow.withValues(alpha: 0.08),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(AppRadius.lg),
         side: BorderSide(
-          color: context.colorScheme.outlineVariant.withValues(alpha: 0.36),
+          color: context.colorScheme.outlineVariant.withValues(alpha: 0.24),
         ),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(AppSpacing.md),
-        child: Row(
-          children: [
-            Container(
-              width: 44,
-              height: 44,
-              alignment: Alignment.center,
-              decoration: BoxDecoration(
-                color: context.colorScheme.secondaryContainer,
-                borderRadius: BorderRadius.circular(AppRadius.sm),
-              ),
-              child: FaIcon(
-                FontAwesomeIcons.solidBookmark,
-                size: AppIconSize.md,
-                color: context.colorScheme.onSecondaryContainer,
-              ),
+      child: child,
+    );
+  }
+}
+
+class _BookmarkVisual extends StatelessWidget {
+  const _BookmarkVisual({
+    required this.icon,
+    required this.label,
+    required this.height,
+    required this.colors,
+  });
+
+  final FaIconData icon;
+  final String label;
+  final double height;
+  final List<Color> colors;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: double.infinity,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: colors,
+        ),
+      ),
+      child: Stack(
+        children: [
+          Center(
+            child: FaIcon(
+              icon,
+              size: AppIconSize.xl,
+              color: context.colorScheme.primary.withValues(alpha: 0.7),
             ),
-            const SizedBox(width: AppSpacing.md),
-            Expanded(
+          ),
+          PositionedDirectional(
+            top: AppSpacing.sm,
+            end: AppSpacing.sm,
+            child: Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.sm,
+                vertical: AppSpacing.xs,
+              ),
+              decoration: BoxDecoration(
+                color: context.colorScheme.surface.withValues(alpha: 0.82),
+                borderRadius: BorderRadius.circular(AppRadius.sm),
+                border: Border.all(
+                  color: context.colorScheme.outlineVariant.withValues(
+                    alpha: 0.5,
+                  ),
+                ),
+              ),
               child: Text(
-                context.l10n.homeMyBookmarks,
+                label,
                 maxLines: 1,
                 overflow: TextOverflow.ellipsis,
-                style: context.textTheme.titleMedium?.copyWith(
+                style: context.textTheme.labelSmall?.copyWith(
+                  color: context.colorScheme.onSurface,
                   fontWeight: FontWeight.w700,
                 ),
               ),
             ),
-            const SizedBox(width: AppSpacing.md),
-            AppButton(
-              label: context.l10n.homeViewAllBookmarks,
-              icon: FontAwesomeIcons.arrowRight,
-              variant: AppButtonVariant.tonal,
-              size: AppButtonSize.small,
-              onPressed: onPressed,
-            ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -12,7 +12,9 @@ part 'home_welcome.dart';
 part 'home_stats.dart';
 part 'home_recent.dart';
 
+/// Entry widget for the Home feature dashboard.
 class HomeBody extends StatefulWidget {
+  /// Creates the dashboard body used by the home screen.
   const HomeBody({super.key});
 
   @override
@@ -56,6 +58,9 @@ class _HomeBodyState extends State<HomeBody> {
             builder: (context, constraints) {
               final filters = _filters(context);
               final filteredItems = _filterItems(state.recentItems, filters);
+              final hasActiveFilters =
+                  _searchController.text.trim().isNotEmpty ||
+                  _selectedFilterId != 'all';
 
               return SingleChildScrollView(
                 padding: const EdgeInsets.fromLTRB(
@@ -107,7 +112,8 @@ class _HomeBodyState extends State<HomeBody> {
                         _RecentBookmarksSection(
                           recentItems: filteredItems,
                           isEmpty: state.totalBookmarks == 0,
-                          hasMatches: filteredItems.isNotEmpty,
+                          hasMatches:
+                              !hasActiveFilters || filteredItems.isNotEmpty,
                           animationDelay: 440.ms,
                         ),
                         const SizedBox(height: AppSpacing.xl),

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -6,34 +6,62 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../../../../app/router.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
 import '../../../../shared/domain/bookmark_stats.dart';
-import '../../../../shared/presentation/session_scope.dart';
 import '../bloc/home_bloc.dart';
 import '../bloc/home_state.dart';
 part 'home_welcome.dart';
 part 'home_stats.dart';
 part 'home_recent.dart';
 
-class HomeBody extends StatelessWidget {
+class HomeBody extends StatefulWidget {
   const HomeBody({super.key});
 
+  @override
+  State<HomeBody> createState() => _HomeBodyState();
+}
+
+class _HomeBodyState extends State<HomeBody> {
   static const double _contentMaxWidth = 720;
   static const double _bottomInset = 112;
+
+  final TextEditingController _searchController = TextEditingController();
+  String _selectedFilterId = 'all';
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return AppScaffold(
       title: context.l10n.homeAppBarTitle,
       padding: EdgeInsets.zero,
-      backgroundColor: context.colorScheme.surface,
+      backgroundColor: context.colorScheme.surfaceContainerLow,
+      floatingActionButton: Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.sizeOf(context).width < AppBreakpoints.medium
+              ? 32 + MediaQuery.paddingOf(context).bottom
+              : 0,
+        ),
+        child: FloatingActionButton(
+          onPressed: () => const BookmarkNewRoute().push<void>(context),
+          tooltip: context.l10n.bookmarksAddTooltip,
+          child: const FaIcon(FontAwesomeIcons.plus),
+        ).animateScale(delay: 500.ms),
+      ),
       body: BlocBuilder<HomeBloc, HomeState>(
         builder: (context, state) {
           return LayoutBuilder(
             builder: (context, constraints) {
+              final filters = _filters(context);
+              final filteredItems = _filterItems(state.recentItems, filters);
+
               return SingleChildScrollView(
                 padding: const EdgeInsets.fromLTRB(
+                  AppSpacing.xl,
                   AppSpacing.lg,
-                  AppSpacing.md,
-                  AppSpacing.lg,
+                  AppSpacing.xl,
                   _bottomInset,
                 ),
                 child: Center(
@@ -44,22 +72,50 @@ class HomeBody extends StatelessWidget {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.stretch,
                       children: [
-                        _WelcomeSection(
-                          totalBookmarks: state.totalBookmarks,
+                        _SearchSection(
+                          controller: _searchController,
+                          onChanged: (_) => setState(() {}),
                         ).animateFadeIn(delay: 100.ms),
-                        const SizedBox(height: AppSpacing.lg),
-                        _StatsDashboard(state: state),
-                        const SizedBox(height: AppSpacing.lg),
-                        _PrimaryActionPanel(
-                          onPressed: () =>
+                        const SizedBox(height: AppSpacing.md),
+                        _QuickActions(
+                          onAdd: () =>
+                              const BookmarkNewRoute().push<void>(context),
+                          onLibrary: () =>
                               const BookmarksListRoute().push<void>(context),
-                        ).animateSlideUp(delay: 350.ms),
+                          onTags: () =>
+                              const BookmarksListRoute().push<void>(context),
+                        ).animateSlideUp(delay: 160.ms),
+                        const SizedBox(height: AppSpacing.md),
+                        _FilterChips(
+                          filters: filters,
+                          selectedId: _selectedFilterId,
+                          onSelected: (filter) {
+                            setState(() => _selectedFilterId = filter.id);
+                          },
+                        ).animateFadeIn(delay: 220.ms),
+                        const SizedBox(height: AppSpacing.xl),
+                        _StatsDashboard(state: state),
+                        const SizedBox(height: AppSpacing.xl),
+                        _SuggestedBookmarksSection(
+                          items: filteredItems,
+                        ).animateFadeIn(delay: 320.ms),
+                        const SizedBox(height: AppSpacing.xl),
+                        _FeaturedCollectionsSection(
+                          items: state.recentItems,
+                        ).animateFadeIn(delay: 380.ms),
                         const SizedBox(height: AppSpacing.xl),
                         _RecentBookmarksSection(
-                          recentItems: state.recentItems,
+                          recentItems: filteredItems,
                           isEmpty: state.totalBookmarks == 0,
-                          animationDelay: 450.ms,
+                          hasMatches: filteredItems.isNotEmpty,
+                          animationDelay: 440.ms,
                         ),
+                        const SizedBox(height: AppSpacing.xl),
+                        _WeeklyDigestPanel(
+                          recentCount: state.recentBookmarks,
+                          onPressed: () =>
+                              const BookmarksListRoute().push<void>(context),
+                        ).animateSlideUp(delay: 520.ms),
                       ],
                     ),
                   ),
@@ -71,4 +127,69 @@ class HomeBody extends StatelessWidget {
       ),
     );
   }
+
+  List<BookmarkSummary> _filterItems(
+    List<BookmarkSummary> items,
+    List<_HomeFilter> filters,
+  ) {
+    final query = _searchController.text.trim().toLowerCase();
+    final selectedFilter = filters.firstWhere(
+      (filter) => filter.id == _selectedFilterId,
+      orElse: () => filters.first,
+    );
+
+    return items.where((bookmark) {
+      final searchable = [
+        bookmark.title,
+        bookmark.url,
+        bookmark.description,
+        ...bookmark.tags,
+      ].join(' ').toLowerCase();
+      final matchesSearch = query.isEmpty || searchable.contains(query);
+      final matchesFilter =
+          selectedFilter.id == 'all' ||
+          selectedFilter.keywords.any(searchable.contains);
+      return matchesSearch && matchesFilter;
+    }).toList();
+  }
+
+  List<_HomeFilter> _filters(BuildContext context) => [
+    _HomeFilter(
+      id: 'all',
+      label: context.l10n.homeFilterAll,
+      keywords: const [],
+    ),
+    _HomeFilter(
+      id: 'design',
+      label: context.l10n.homeFilterDesign,
+      keywords: const ['design', 'ui', 'ux', 'figma'],
+    ),
+    _HomeFilter(
+      id: 'articles',
+      label: context.l10n.homeFilterArticles,
+      keywords: const ['article', 'blog', 'medium', 'read'],
+    ),
+    _HomeFilter(
+      id: 'inspiration',
+      label: context.l10n.homeFilterInspiration,
+      keywords: const ['inspiration', 'idea', 'creative', 'gallery'],
+    ),
+    _HomeFilter(
+      id: 'tools',
+      label: context.l10n.homeFilterTools,
+      keywords: const ['tool', 'app', 'extension', 'package'],
+    ),
+  ];
+}
+
+class _HomeFilter {
+  const _HomeFilter({
+    required this.id,
+    required this.label,
+    required this.keywords,
+  });
+
+  final String id;
+  final String label;
+  final List<String> keywords;
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -70,32 +70,88 @@
   "homeRecentBookmarks": "Recent Bookmarks",
   "homeNoBookmarks": "No bookmarks yet. Tap + to add one.",
   "homeSearchTitle": "Search",
+  "@homeSearchTitle": {
+    "description": "Section title above the home dashboard bookmark search field."
+  },
   "homeSearchSubtitle": "Find your saved articles, tools, and inspirations instantly.",
+  "@homeSearchSubtitle": {
+    "description": "Supporting text below the home dashboard search title."
+  },
   "homeSearchHint": "Search bookmarks...",
+  "@homeSearchHint": {
+    "description": "Placeholder text in the home dashboard bookmark search field."
+  },
   "homeQuickAdd": "Add Link",
+  "@homeQuickAdd": {
+    "description": "Label for the quick action that opens the new bookmark form."
+  },
   "homeQuickLibrary": "Library",
+  "@homeQuickLibrary": {
+    "description": "Label for the quick action that opens the full bookmarks library."
+  },
   "homeQuickTags": "Tags",
+  "@homeQuickTags": {
+    "description": "Label for the quick action that opens bookmark tag-related content."
+  },
   "homeFilterAll": "All",
+  "@homeFilterAll": {
+    "description": "Filter chip label for showing all recent bookmarks."
+  },
   "homeFilterDesign": "Design",
+  "@homeFilterDesign": {
+    "description": "Filter chip and fallback collection label for design-related bookmarks."
+  },
   "homeFilterArticles": "Articles",
+  "@homeFilterArticles": {
+    "description": "Filter chip and fallback collection label for article or blog bookmarks."
+  },
   "homeFilterInspiration": "Inspiration",
+  "@homeFilterInspiration": {
+    "description": "Filter chip label for inspiration-related bookmarks."
+  },
   "homeFilterTools": "Tools",
+  "@homeFilterTools": {
+    "description": "Filter chip and fallback collection label for tool-related bookmarks."
+  },
   "homeSuggestedTitle": "Suggested for You",
+  "@homeSuggestedTitle": {
+    "description": "Section title for suggested bookmark cards on the home dashboard."
+  },
   "homeFeaturedCollections": "Featured Collections",
+  "@homeFeaturedCollections": {
+    "description": "Section title for featured bookmark collection cards on the home dashboard."
+  },
   "homeWeeklyDigestTitle": "Weekly Digest",
+  "@homeWeeklyDigestTitle": {
+    "description": "Section title for the weekly digest panel on the home dashboard."
+  },
   "homeWeeklyDigestEyebrow": "Most Read",
+  "@homeWeeklyDigestEyebrow": {
+    "description": "Short eyebrow label displayed above the weekly digest headline."
+  },
   "homeWeeklyDigestHeadline": "Your saved knowledge catch-up",
-  "homeWeeklyDigestBody": "You saved {count} bookmarks recently. Review the highlights and keep your reading flow moving.",
+  "@homeWeeklyDigestHeadline": {
+    "description": "Headline text inside the weekly digest panel on the home dashboard."
+  },
+  "homeWeeklyDigestBody": "{count, plural, =0{You have no recent bookmarks. Review saved highlights when you add one.} =1{You saved 1 bookmark recently. Review the highlight and keep your reading flow moving.} other{You saved {count} bookmarks recently. Review the highlights and keep your reading flow moving.}}",
   "@homeWeeklyDigestBody": {
+    "description": "Body text inside the weekly digest panel. The count is the number of bookmarks saved in the recent window.",
     "placeholders": {
       "count": {
         "type": "int",
-        "example": "12"
+        "example": "12",
+        "description": "Number of bookmarks saved recently."
       }
     }
   },
   "homeReadDigest": "Read Digest",
+  "@homeReadDigest": {
+    "description": "Call-to-action button label in the weekly digest panel."
+  },
   "homeNoMatches": "No bookmarks match this view.",
+  "@homeNoMatches": {
+    "description": "Empty-state message shown when active search or filters hide all recent bookmarks."
+  },
   "homeStatsTotal": "Total",
   "homeStatsRecent": "Recent",
   "homeStatsTags": "Tags",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -69,6 +69,33 @@
   "homeSignedInBody": "You are signed in.",
   "homeRecentBookmarks": "Recent Bookmarks",
   "homeNoBookmarks": "No bookmarks yet. Tap + to add one.",
+  "homeSearchTitle": "Search",
+  "homeSearchSubtitle": "Find your saved articles, tools, and inspirations instantly.",
+  "homeSearchHint": "Search bookmarks...",
+  "homeQuickAdd": "Add Link",
+  "homeQuickLibrary": "Library",
+  "homeQuickTags": "Tags",
+  "homeFilterAll": "All",
+  "homeFilterDesign": "Design",
+  "homeFilterArticles": "Articles",
+  "homeFilterInspiration": "Inspiration",
+  "homeFilterTools": "Tools",
+  "homeSuggestedTitle": "Suggested for You",
+  "homeFeaturedCollections": "Featured Collections",
+  "homeWeeklyDigestTitle": "Weekly Digest",
+  "homeWeeklyDigestEyebrow": "Most Read",
+  "homeWeeklyDigestHeadline": "Your saved knowledge catch-up",
+  "homeWeeklyDigestBody": "You saved {count} bookmarks recently. Review the highlights and keep your reading flow moving.",
+  "@homeWeeklyDigestBody": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      }
+    }
+  },
+  "homeReadDigest": "Read Digest",
+  "homeNoMatches": "No bookmarks match this view.",
   "homeStatsTotal": "Total",
   "homeStatsRecent": "Recent",
   "homeStatsTags": "Tags",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -464,6 +464,120 @@ abstract class AppLocalizations {
   /// **'No bookmarks yet. Tap + to add one.'**
   String get homeNoBookmarks;
 
+  /// No description provided for @homeSearchTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Search'**
+  String get homeSearchTitle;
+
+  /// No description provided for @homeSearchSubtitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Find your saved articles, tools, and inspirations instantly.'**
+  String get homeSearchSubtitle;
+
+  /// No description provided for @homeSearchHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search bookmarks...'**
+  String get homeSearchHint;
+
+  /// No description provided for @homeQuickAdd.
+  ///
+  /// In en, this message translates to:
+  /// **'Add Link'**
+  String get homeQuickAdd;
+
+  /// No description provided for @homeQuickLibrary.
+  ///
+  /// In en, this message translates to:
+  /// **'Library'**
+  String get homeQuickLibrary;
+
+  /// No description provided for @homeQuickTags.
+  ///
+  /// In en, this message translates to:
+  /// **'Tags'**
+  String get homeQuickTags;
+
+  /// No description provided for @homeFilterAll.
+  ///
+  /// In en, this message translates to:
+  /// **'All'**
+  String get homeFilterAll;
+
+  /// No description provided for @homeFilterDesign.
+  ///
+  /// In en, this message translates to:
+  /// **'Design'**
+  String get homeFilterDesign;
+
+  /// No description provided for @homeFilterArticles.
+  ///
+  /// In en, this message translates to:
+  /// **'Articles'**
+  String get homeFilterArticles;
+
+  /// No description provided for @homeFilterInspiration.
+  ///
+  /// In en, this message translates to:
+  /// **'Inspiration'**
+  String get homeFilterInspiration;
+
+  /// No description provided for @homeFilterTools.
+  ///
+  /// In en, this message translates to:
+  /// **'Tools'**
+  String get homeFilterTools;
+
+  /// No description provided for @homeSuggestedTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Suggested for You'**
+  String get homeSuggestedTitle;
+
+  /// No description provided for @homeFeaturedCollections.
+  ///
+  /// In en, this message translates to:
+  /// **'Featured Collections'**
+  String get homeFeaturedCollections;
+
+  /// No description provided for @homeWeeklyDigestTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Weekly Digest'**
+  String get homeWeeklyDigestTitle;
+
+  /// No description provided for @homeWeeklyDigestEyebrow.
+  ///
+  /// In en, this message translates to:
+  /// **'Most Read'**
+  String get homeWeeklyDigestEyebrow;
+
+  /// No description provided for @homeWeeklyDigestHeadline.
+  ///
+  /// In en, this message translates to:
+  /// **'Your saved knowledge catch-up'**
+  String get homeWeeklyDigestHeadline;
+
+  /// No description provided for @homeWeeklyDigestBody.
+  ///
+  /// In en, this message translates to:
+  /// **'You saved {count} bookmarks recently. Review the highlights and keep your reading flow moving.'**
+  String homeWeeklyDigestBody(int count);
+
+  /// No description provided for @homeReadDigest.
+  ///
+  /// In en, this message translates to:
+  /// **'Read Digest'**
+  String get homeReadDigest;
+
+  /// No description provided for @homeNoMatches.
+  ///
+  /// In en, this message translates to:
+  /// **'No bookmarks match this view.'**
+  String get homeNoMatches;
+
   /// No description provided for @homeStatsTotal.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -464,115 +464,115 @@ abstract class AppLocalizations {
   /// **'No bookmarks yet. Tap + to add one.'**
   String get homeNoBookmarks;
 
-  /// No description provided for @homeSearchTitle.
+  /// Section title above the home dashboard bookmark search field.
   ///
   /// In en, this message translates to:
   /// **'Search'**
   String get homeSearchTitle;
 
-  /// No description provided for @homeSearchSubtitle.
+  /// Supporting text below the home dashboard search title.
   ///
   /// In en, this message translates to:
   /// **'Find your saved articles, tools, and inspirations instantly.'**
   String get homeSearchSubtitle;
 
-  /// No description provided for @homeSearchHint.
+  /// Placeholder text in the home dashboard bookmark search field.
   ///
   /// In en, this message translates to:
   /// **'Search bookmarks...'**
   String get homeSearchHint;
 
-  /// No description provided for @homeQuickAdd.
+  /// Label for the quick action that opens the new bookmark form.
   ///
   /// In en, this message translates to:
   /// **'Add Link'**
   String get homeQuickAdd;
 
-  /// No description provided for @homeQuickLibrary.
+  /// Label for the quick action that opens the full bookmarks library.
   ///
   /// In en, this message translates to:
   /// **'Library'**
   String get homeQuickLibrary;
 
-  /// No description provided for @homeQuickTags.
+  /// Label for the quick action that opens bookmark tag-related content.
   ///
   /// In en, this message translates to:
   /// **'Tags'**
   String get homeQuickTags;
 
-  /// No description provided for @homeFilterAll.
+  /// Filter chip label for showing all recent bookmarks.
   ///
   /// In en, this message translates to:
   /// **'All'**
   String get homeFilterAll;
 
-  /// No description provided for @homeFilterDesign.
+  /// Filter chip and fallback collection label for design-related bookmarks.
   ///
   /// In en, this message translates to:
   /// **'Design'**
   String get homeFilterDesign;
 
-  /// No description provided for @homeFilterArticles.
+  /// Filter chip and fallback collection label for article or blog bookmarks.
   ///
   /// In en, this message translates to:
   /// **'Articles'**
   String get homeFilterArticles;
 
-  /// No description provided for @homeFilterInspiration.
+  /// Filter chip label for inspiration-related bookmarks.
   ///
   /// In en, this message translates to:
   /// **'Inspiration'**
   String get homeFilterInspiration;
 
-  /// No description provided for @homeFilterTools.
+  /// Filter chip and fallback collection label for tool-related bookmarks.
   ///
   /// In en, this message translates to:
   /// **'Tools'**
   String get homeFilterTools;
 
-  /// No description provided for @homeSuggestedTitle.
+  /// Section title for suggested bookmark cards on the home dashboard.
   ///
   /// In en, this message translates to:
   /// **'Suggested for You'**
   String get homeSuggestedTitle;
 
-  /// No description provided for @homeFeaturedCollections.
+  /// Section title for featured bookmark collection cards on the home dashboard.
   ///
   /// In en, this message translates to:
   /// **'Featured Collections'**
   String get homeFeaturedCollections;
 
-  /// No description provided for @homeWeeklyDigestTitle.
+  /// Section title for the weekly digest panel on the home dashboard.
   ///
   /// In en, this message translates to:
   /// **'Weekly Digest'**
   String get homeWeeklyDigestTitle;
 
-  /// No description provided for @homeWeeklyDigestEyebrow.
+  /// Short eyebrow label displayed above the weekly digest headline.
   ///
   /// In en, this message translates to:
   /// **'Most Read'**
   String get homeWeeklyDigestEyebrow;
 
-  /// No description provided for @homeWeeklyDigestHeadline.
+  /// Headline text inside the weekly digest panel on the home dashboard.
   ///
   /// In en, this message translates to:
   /// **'Your saved knowledge catch-up'**
   String get homeWeeklyDigestHeadline;
 
-  /// No description provided for @homeWeeklyDigestBody.
+  /// Body text inside the weekly digest panel. The count is the number of bookmarks saved in the recent window.
   ///
   /// In en, this message translates to:
-  /// **'You saved {count} bookmarks recently. Review the highlights and keep your reading flow moving.'**
+  /// **'{count, plural, =0{You have no recent bookmarks. Review saved highlights when you add one.} =1{You saved 1 bookmark recently. Review the highlight and keep your reading flow moving.} other{You saved {count} bookmarks recently. Review the highlights and keep your reading flow moving.}}'**
   String homeWeeklyDigestBody(int count);
 
-  /// No description provided for @homeReadDigest.
+  /// Call-to-action button label in the weekly digest panel.
   ///
   /// In en, this message translates to:
   /// **'Read Digest'**
   String get homeReadDigest;
 
-  /// No description provided for @homeNoMatches.
+  /// Empty-state message shown when active search or filters hide all recent bookmarks.
   ///
   /// In en, this message translates to:
   /// **'No bookmarks match this view.'**

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -247,7 +247,17 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String homeWeeklyDigestBody(int count) {
-    return 'You saved $count bookmarks recently. Review the highlights and keep your reading flow moving.';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'You saved $count bookmarks recently. Review the highlights and keep your reading flow moving.',
+      one:
+          'You saved 1 bookmark recently. Review the highlight and keep your reading flow moving.',
+      zero:
+          'You have no recent bookmarks. Review saved highlights when you add one.',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -197,6 +197,66 @@ class AppLocalizationsEn extends AppLocalizations {
   String get homeNoBookmarks => 'No bookmarks yet. Tap + to add one.';
 
   @override
+  String get homeSearchTitle => 'Search';
+
+  @override
+  String get homeSearchSubtitle =>
+      'Find your saved articles, tools, and inspirations instantly.';
+
+  @override
+  String get homeSearchHint => 'Search bookmarks...';
+
+  @override
+  String get homeQuickAdd => 'Add Link';
+
+  @override
+  String get homeQuickLibrary => 'Library';
+
+  @override
+  String get homeQuickTags => 'Tags';
+
+  @override
+  String get homeFilterAll => 'All';
+
+  @override
+  String get homeFilterDesign => 'Design';
+
+  @override
+  String get homeFilterArticles => 'Articles';
+
+  @override
+  String get homeFilterInspiration => 'Inspiration';
+
+  @override
+  String get homeFilterTools => 'Tools';
+
+  @override
+  String get homeSuggestedTitle => 'Suggested for You';
+
+  @override
+  String get homeFeaturedCollections => 'Featured Collections';
+
+  @override
+  String get homeWeeklyDigestTitle => 'Weekly Digest';
+
+  @override
+  String get homeWeeklyDigestEyebrow => 'Most Read';
+
+  @override
+  String get homeWeeklyDigestHeadline => 'Your saved knowledge catch-up';
+
+  @override
+  String homeWeeklyDigestBody(int count) {
+    return 'You saved $count bookmarks recently. Review the highlights and keep your reading flow moving.';
+  }
+
+  @override
+  String get homeReadDigest => 'Read Digest';
+
+  @override
+  String get homeNoMatches => 'No bookmarks match this view.';
+
+  @override
   String get homeStatsTotal => 'Total';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -199,6 +199,66 @@ class AppLocalizationsVi extends AppLocalizations {
   String get homeNoBookmarks => 'Chưa có bookmark nào. Nhấn + để thêm.';
 
   @override
+  String get homeSearchTitle => 'Tìm kiếm';
+
+  @override
+  String get homeSearchSubtitle =>
+      'Tìm nhanh bài viết, công cụ và nguồn cảm hứng đã lưu.';
+
+  @override
+  String get homeSearchHint => 'Tìm bookmark...';
+
+  @override
+  String get homeQuickAdd => 'Thêm liên kết';
+
+  @override
+  String get homeQuickLibrary => 'Thư viện';
+
+  @override
+  String get homeQuickTags => 'Thẻ';
+
+  @override
+  String get homeFilterAll => 'Tất cả';
+
+  @override
+  String get homeFilterDesign => 'Thiết kế';
+
+  @override
+  String get homeFilterArticles => 'Bài viết';
+
+  @override
+  String get homeFilterInspiration => 'Cảm hứng';
+
+  @override
+  String get homeFilterTools => 'Công cụ';
+
+  @override
+  String get homeSuggestedTitle => 'Gợi ý cho bạn';
+
+  @override
+  String get homeFeaturedCollections => 'Bộ sưu tập nổi bật';
+
+  @override
+  String get homeWeeklyDigestTitle => 'Tóm tắt tuần';
+
+  @override
+  String get homeWeeklyDigestEyebrow => 'Đọc nhiều nhất';
+
+  @override
+  String get homeWeeklyDigestHeadline => 'Điểm lại kho tri thức đã lưu';
+
+  @override
+  String homeWeeklyDigestBody(int count) {
+    return 'Gần đây bạn đã lưu $count bookmark. Xem lại các điểm nổi bật để tiếp tục mạch đọc.';
+  }
+
+  @override
+  String get homeReadDigest => 'Đọc tóm tắt';
+
+  @override
+  String get homeNoMatches => 'Không có bookmark nào khớp với chế độ xem này.';
+
+  @override
   String get homeStatsTotal => 'Tổng cộng';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -249,7 +249,15 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String homeWeeklyDigestBody(int count) {
-    return 'Gần đây bạn đã lưu $count bookmark. Xem lại các điểm nổi bật để tiếp tục mạch đọc.';
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other:
+          'Gần đây bạn đã lưu $count bookmark. Xem lại các điểm nổi bật để tiếp tục mạch đọc.',
+      zero:
+          'Gần đây bạn chưa lưu bookmark nào. Hãy quay lại khi có nội dung mới.',
+    );
+    return '$_temp0';
   }
 
   @override

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -61,6 +61,33 @@
   "homeSignedInBody": "Bạn đã đăng nhập.",
   "homeRecentBookmarks": "Bookmark gần đây",
   "homeNoBookmarks": "Chưa có bookmark nào. Nhấn + để thêm.",
+  "homeSearchTitle": "Tìm kiếm",
+  "homeSearchSubtitle": "Tìm nhanh bài viết, công cụ và nguồn cảm hứng đã lưu.",
+  "homeSearchHint": "Tìm bookmark...",
+  "homeQuickAdd": "Thêm liên kết",
+  "homeQuickLibrary": "Thư viện",
+  "homeQuickTags": "Thẻ",
+  "homeFilterAll": "Tất cả",
+  "homeFilterDesign": "Thiết kế",
+  "homeFilterArticles": "Bài viết",
+  "homeFilterInspiration": "Cảm hứng",
+  "homeFilterTools": "Công cụ",
+  "homeSuggestedTitle": "Gợi ý cho bạn",
+  "homeFeaturedCollections": "Bộ sưu tập nổi bật",
+  "homeWeeklyDigestTitle": "Tóm tắt tuần",
+  "homeWeeklyDigestEyebrow": "Đọc nhiều nhất",
+  "homeWeeklyDigestHeadline": "Điểm lại kho tri thức đã lưu",
+  "homeWeeklyDigestBody": "Gần đây bạn đã lưu {count} bookmark. Xem lại các điểm nổi bật để tiếp tục mạch đọc.",
+  "@homeWeeklyDigestBody": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "12"
+      }
+    }
+  },
+  "homeReadDigest": "Đọc tóm tắt",
+  "homeNoMatches": "Không có bookmark nào khớp với chế độ xem này.",
   "homeStatsTotal": "Tổng cộng",
   "homeStatsRecent": "Gần đây",
   "homeStatsTags": "Thẻ",

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -77,7 +77,7 @@
   "homeWeeklyDigestTitle": "Tóm tắt tuần",
   "homeWeeklyDigestEyebrow": "Đọc nhiều nhất",
   "homeWeeklyDigestHeadline": "Điểm lại kho tri thức đã lưu",
-  "homeWeeklyDigestBody": "Gần đây bạn đã lưu {count} bookmark. Xem lại các điểm nổi bật để tiếp tục mạch đọc.",
+  "homeWeeklyDigestBody": "{count, plural, =0{Gần đây bạn chưa lưu bookmark nào. Hãy quay lại khi có nội dung mới.} other{Gần đây bạn đã lưu {count} bookmark. Xem lại các điểm nổi bật để tiếp tục mạch đọc.}}",
   "@homeWeeklyDigestBody": {
     "placeholders": {
       "count": {


### PR DESCRIPTION
Summary:
- Redesign the home screen around search, quick actions, category filters, suggested bookmarks, featured collections, a bento recent feed, and a weekly digest panel.
- Add a home FAB for creating bookmarks and keep the existing shell app bar/navigation contract.
- Add English and Vietnamese localization for the new home dashboard copy.

Tests:
- fvm flutter gen-l10n
- fvm dart format lib/features/home/presentation/widgets/home_widgets.dart lib/features/home/presentation/widgets/home_welcome.dart lib/features/home/presentation/widgets/home_stats.dart lib/features/home/presentation/widgets/home_recent.dart
- fvm flutter analyze
- fvm flutter test --exclude-tags golden

Note:
- simple_backend_server had a pre-existing unstaged change and is not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added home screen search with filter chips and quick action tiles.
  * Introduced suggested bookmarks, featured collections, and a weekly digest panel.
  * Home content now adapts between single-column and two-column layouts for better responsiveness.

* **Bug Fixes**
  * Improved empty-state handling when no home results match the current search or filter.
  * Bookmark cards now show clearer tag summaries and open details directly when tapped.

* **Style**
  * Refreshed bookmark tag and card visuals for a more polished home experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->