### PR TITLE
Make bottom navigation bar a floating frosted-glass pill

### DIFF
--- a/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
+++ b/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
@@ -58,10 +58,26 @@ class AppAdaptiveScaffold extends StatelessWidget {
       builder: (context, constraints) {
         final width = constraints.maxWidth;
         if (width < AppBreakpoints.medium) {
+          final mediaQuery = MediaQuery.of(context);
           return Scaffold(
             body: Stack(
               children: [
-                Positioned.fill(child: body),
+                // The body paints full-height behind the translucent pill so
+                // its content shows through the blur. We still add the bar's
+                // height to the body's bottom padding so its scroll views and
+                // FABs clear the pill (mirroring `Scaffold.extendBody`).
+                Positioned.fill(
+                  child: MediaQuery(
+                    data: mediaQuery.copyWith(
+                      padding: mediaQuery.padding.copyWith(
+                        bottom:
+                            mediaQuery.padding.bottom +
+                            _floatingBarReservedHeight,
+                      ),
+                    ),
+                    child: body,
+                  ),
+                ),
                 Positioned(
                   left: 0,
                   right: 0,
@@ -112,6 +128,15 @@ class AppAdaptiveScaffold extends StatelessWidget {
     );
   }
 }
+
+/// Height of the floating pill itself.
+const double _floatingBarPillHeight = 72;
+
+/// Vertical space the floating bar occupies above the device's bottom
+/// safe-area inset: the pill plus its inner and outer margins. Added to the
+/// body's bottom padding so content clears the bar.
+const double _floatingBarReservedHeight =
+    _floatingBarPillHeight + AppSpacing.xs + AppSpacing.md;
 
 /// A floating, pill-shaped bottom navigation bar.
 ///
@@ -165,7 +190,7 @@ class _FloatingBottomBar extends StatelessWidget {
                     color: colorScheme.surface.withValues(alpha: 0.7),
                   ),
                   child: SizedBox(
-                    height: 72,
+                    height: _floatingBarPillHeight,
                     child: Padding(
                       padding: const EdgeInsets.symmetric(
                         horizontal: AppSpacing.md,

--- a/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
+++ b/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
@@ -58,26 +58,13 @@ class AppAdaptiveScaffold extends StatelessWidget {
       builder: (context, constraints) {
         final width = constraints.maxWidth;
         if (width < AppBreakpoints.medium) {
-          final mediaQuery = MediaQuery.of(context);
           return Scaffold(
             body: Stack(
               children: [
-                // The body paints full-height behind the translucent pill so
-                // its content shows through the blur. We still add the bar's
-                // height to the body's bottom padding so its scroll views and
-                // FABs clear the pill (mirroring `Scaffold.extendBody`).
-                Positioned.fill(
-                  child: MediaQuery(
-                    data: mediaQuery.copyWith(
-                      padding: mediaQuery.padding.copyWith(
-                        bottom:
-                            mediaQuery.padding.bottom +
-                            _floatingBarReservedHeight,
-                      ),
-                    ),
-                    child: body,
-                  ),
-                ),
+                // The body fills the screen and paints behind the translucent
+                // pill so its content shows through the blur. Screens add their
+                // own bottom padding to keep scroll content clear of the pill.
+                Positioned.fill(child: body),
                 Positioned(
                   left: 0,
                   right: 0,
@@ -131,12 +118,6 @@ class AppAdaptiveScaffold extends StatelessWidget {
 
 /// Height of the floating pill itself.
 const double _floatingBarPillHeight = 72;
-
-/// Vertical space the floating bar occupies above the device's bottom
-/// safe-area inset: the pill plus its inner and outer margins. Added to the
-/// body's bottom padding so content clears the bar.
-const double _floatingBarReservedHeight =
-    _floatingBarPillHeight + AppSpacing.xs + AppSpacing.md;
 
 /// A floating, pill-shaped bottom navigation bar.
 ///

--- a/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
+++ b/packages/app_ui/lib/src/widgets/app_adaptive_scaffold.dart
@@ -1,3 +1,5 @@
+import 'dart:ui' show ImageFilter;
+
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
@@ -57,12 +59,20 @@ class AppAdaptiveScaffold extends StatelessWidget {
         final width = constraints.maxWidth;
         if (width < AppBreakpoints.medium) {
           return Scaffold(
-            extendBody: true,
-            body: body,
-            bottomNavigationBar: _FloatingBottomBar(
-              destinations: destinations,
-              selectedIndex: selectedIndex,
-              onDestinationSelected: onDestinationSelected,
+            body: Stack(
+              children: [
+                Positioned.fill(child: body),
+                Positioned(
+                  left: 0,
+                  right: 0,
+                  bottom: 0,
+                  child: _FloatingBottomBar(
+                    destinations: destinations,
+                    selectedIndex: selectedIndex,
+                    onDestinationSelected: onDestinationSelected,
+                  ),
+                ),
+              ],
             ),
           );
         }
@@ -139,29 +149,45 @@ class _FloatingBottomBar extends StatelessWidget {
           child: ConstrainedBox(
             constraints: const BoxConstraints(maxWidth: 320),
             child: Material(
-              color: colorScheme.surface,
+              color: Colors.transparent,
               clipBehavior: Clip.antiAlias,
-              shape: const StadiumBorder(),
+              shape: StadiumBorder(
+                side: BorderSide(
+                  color: colorScheme.outlineVariant.withValues(alpha: 0.5),
+                ),
+              ),
               shadowColor: colorScheme.shadow.withValues(alpha: 0.16),
               elevation: 14,
-              child: SizedBox(
-                height: 72,
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: AppSpacing.md,
-                    vertical: AppSpacing.xs,
+              child: BackdropFilter(
+                filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+                child: DecoratedBox(
+                  decoration: BoxDecoration(
+                    color: colorScheme.surface.withValues(alpha: 0.7),
                   ),
-                  child: Row(
-                    children: [
-                      for (var index = 0; index < destinations.length; index++)
-                        Expanded(
-                          child: _BottomBarItem(
-                            destination: destinations[index],
-                            selected: index == selectedIndex,
-                            onTap: () => onDestinationSelected(index),
-                          ),
-                        ),
-                    ],
+                  child: SizedBox(
+                    height: 72,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: AppSpacing.md,
+                        vertical: AppSpacing.xs,
+                      ),
+                      child: Row(
+                        children: [
+                          for (
+                            var index = 0;
+                            index < destinations.length;
+                            index++
+                          )
+                            Expanded(
+                              child: _BottomBarItem(
+                                destination: destinations[index],
+                                selected: index == selectedIndex,
+                                onTap: () => onDestinationSelected(index),
+                              ),
+                            ),
+                        ],
+                      ),
+                    ),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary

Makes the compact bottom navigation bar a true floating, frosted-glass pill so the page content shows through behind it instead of a flat white background.

## Changes

In `packages/app_ui/.../app_adaptive_scaffold.dart` (`AppAdaptiveScaffold` / `_FloatingBottomBar`):

- **Overlay instead of slot** — the compact layout now overlays the floating bar on the body with a `Stack` (`Positioned.fill` body + `Positioned(bottom: 0)` bar) instead of the `Scaffold.bottomNavigationBar` slot. The `bottomNavigationBar` slot lays out as a sibling band, so even with `extendBody: true` the branch `Scaffold` body didn't reliably paint behind it — leaving the blur with nothing to sample. The `Stack` guarantees the body paints full-height behind the bar.
- **Frosted glass** — the pill is now a translucent `colorScheme.surface` (70% alpha) wrapped in a `BackdropFilter` blur, with a subtle `outlineVariant` border to define its edge. Content behind softly blurs through the glass.

The medium/expanded `NavigationRail` layout is untouched. Driven entirely by `colorScheme`, so it adapts to light/dark themes.

## Test plan

- [x] `flutter analyze` — no issues (pre-push hook)
- [x] `dart format` — clean
- [ ] Visual check on device/simulator: bar floats, content blurs through, icons stay legible in light + dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style Updates**
  * Refreshed bottom navigation with translucency, backdrop blur, transparent material and a refined pill-shaped design for a sleeker, modern look.

* **Layout Improvements**
  * Improved compact-screen behavior: main content now renders behind a fixed floating bottom bar anchored to the bottom, preventing overlap while keeping navigation items interactive and responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->