### PR TITLE
Redesign notifications page + make it offline-first

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -147,7 +147,8 @@ void main() {
     expect(authBloc.state, isA<AuthAuthenticated>());
     expect((authBloc.state as AuthAuthenticated).user.username, 'alice');
 
-    // Sync started for the now-authenticated session.
+    // Both sync controllers started for the now-authenticated session.
     verify(() => sync.start()).called(greaterThanOrEqualTo(1));
+    verify(() => notificationsSync.start()).called(greaterThanOrEqualTo(1));
   });
 }

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -23,6 +23,7 @@ void main() {
 
   late StreamController<BookmarksSyncStatus> syncStatusController;
   late MockBookmarksSyncController sync;
+  late MockNotificationsSyncController notificationsSync;
   late MockAnalyticsService analytics;
   late AuthBloc authBloc;
   late ThemeBloc themeBloc;
@@ -56,6 +57,14 @@ void main() {
     when(() => sync.start()).thenAnswer((_) async {});
     when(() => sync.stop()).thenAnswer((_) async {});
     when(() => sync.sync()).thenAnswer((_) async {});
+
+    notificationsSync = MockNotificationsSyncController();
+    when(
+      () => notificationsSync.onSynced,
+    ).thenAnswer((_) => const Stream.empty());
+    when(() => notificationsSync.start()).thenAnswer((_) async {});
+    when(() => notificationsSync.stop()).thenAnswer((_) async {});
+    when(() => notificationsSync.sync()).thenAnswer((_) async {});
 
     final bookmarkStats = MockBookmarkStatsReader();
     when(
@@ -104,6 +113,7 @@ void main() {
         authBloc: authBloc,
         themeBloc: themeBloc,
         bookmarksSync: sync,
+        notificationsSync: notificationsSync,
         navigatorObservers: const [],
         videoPlayerService: MockVideoPlayerService(),
       ),

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -13,6 +13,7 @@ import '../features/auth/presentation/auth_session.dart';
 import '../features/auth/presentation/bloc/auth_bloc.dart';
 import '../features/auth/presentation/bloc/auth_state.dart';
 import '../features/bookmarks/domain/services/bookmarks_sync_controller.dart';
+import '../features/notifications/domain/services/notifications_sync_controller.dart';
 import '../l10n/app_localizations.dart';
 import '../shared/domain/session.dart';
 import '../shared/presentation/session_scope.dart';
@@ -25,6 +26,7 @@ class App extends StatefulWidget {
     this.authBloc,
     this.themeBloc,
     this.bookmarksSync,
+    this.notificationsSync,
     this.navigatorObservers,
     this.session,
     this.videoPlayerService,
@@ -33,6 +35,7 @@ class App extends StatefulWidget {
   final AuthBloc? authBloc;
   final ThemeBloc? themeBloc;
   final BookmarksSyncController? bookmarksSync;
+  final NotificationsSyncController? notificationsSync;
   final List<NavigatorObserver>? navigatorObservers;
   final Session? session;
   final VideoPlayerService? videoPlayerService;
@@ -48,6 +51,7 @@ class _AppState extends State<App> {
   late final GoRouter _router;
   late final DeepLinkState _deepLink;
   late final BookmarksSyncController _sync;
+  late final NotificationsSyncController _notificationsSync;
   late final VideoPlayerService _videoPlayerService;
   StreamSubscription<AuthState>? _authSub;
 
@@ -64,6 +68,8 @@ class _AppState extends State<App> {
     _router = result.router;
     _deepLink = result.deepLink;
     _sync = widget.bookmarksSync ?? getIt<BookmarksSyncController>();
+    _notificationsSync =
+        widget.notificationsSync ?? getIt<NotificationsSyncController>();
     _videoPlayerService =
         widget.videoPlayerService ?? getIt<VideoPlayerService>();
     _authSub = _authBloc.stream.listen(_onAuthChanged);
@@ -74,8 +80,10 @@ class _AppState extends State<App> {
   void _onAuthChanged(AuthState state) {
     if (state is AuthAuthenticated) {
       _sync.start();
+      _notificationsSync.start();
     } else {
       _sync.stop();
+      _notificationsSync.stop();
     }
   }
 
@@ -83,6 +91,7 @@ class _AppState extends State<App> {
   void dispose() {
     _authSub?.cancel();
     _sync.stop();
+    _notificationsSync.stop();
     _session.dispose();
     _router.dispose();
     super.dispose();

--- a/lib/features/notifications/data/local/activity_entity.dart
+++ b/lib/features/notifications/data/local/activity_entity.dart
@@ -1,0 +1,51 @@
+import 'package:objectbox/objectbox.dart';
+
+import '../../domain/entities/user_activity.dart';
+
+/// ObjectBox row caching a single activity-log entry. Read-only from the user's
+/// perspective — the server owns the log, so this is only ever filled by sync.
+@Entity()
+class ActivityEntity {
+  ActivityEntity({
+    this.id = 0,
+    required this.uuid,
+    required this.description,
+    required this.type,
+    required this.createdAt,
+  });
+
+  /// ObjectBox primary key. Internal — never exposed to the domain layer.
+  @Id()
+  int id;
+
+  /// Server id, stable across syncs.
+  @Unique()
+  String uuid;
+
+  String description;
+
+  /// Raw server activity type (e.g. `signed_in`); mapped to [UserActivityType]
+  /// in [toDomain]. Stored raw so an unknown future type round-trips intact.
+  String type;
+
+  /// Stored and read back as UTC.
+  @Property(type: PropertyType.dateNanoUtc)
+  DateTime createdAt;
+
+  UserActivity toDomain() => UserActivity(
+    id: uuid,
+    description: description,
+    type: activityTypeFromRaw(type),
+    createdAt: createdAt,
+  );
+}
+
+/// Maps a raw server activity type to its [UserActivityType], defaulting to
+/// [UserActivityType.other] for unrecognized values.
+UserActivityType activityTypeFromRaw(String raw) => switch (raw) {
+  'created' => UserActivityType.created,
+  'updated' => UserActivityType.updated,
+  'deleted' => UserActivityType.deleted,
+  'signed_in' => UserActivityType.signedIn,
+  _ => UserActivityType.other,
+};

--- a/lib/features/notifications/data/local/notification_entity.dart
+++ b/lib/features/notifications/data/local/notification_entity.dart
@@ -1,0 +1,65 @@
+import 'package:objectbox/objectbox.dart';
+
+import '../../domain/entities/app_notification.dart';
+
+/// ObjectBox row caching a single notification. Mutable by necessity —
+/// ObjectBox writes back into instances during property loading.
+///
+/// Identity at this layer is the string [uuid] (the server id). The integer
+/// [id] is an internal ObjectBox PK that callers never see.
+@Entity()
+class NotificationEntity {
+  NotificationEntity({
+    this.id = 0,
+    required this.uuid,
+    required this.title,
+    required this.body,
+    required this.type,
+    required this.isRead,
+    required this.createdAt,
+    this.pendingRead = false,
+  });
+
+  /// ObjectBox primary key. Internal — never exposed to the domain layer.
+  @Id()
+  int id;
+
+  /// Server id, stable across syncs.
+  @Unique()
+  String uuid;
+
+  String title;
+  String body;
+
+  /// Raw server category (e.g. `social`); mapped to [NotificationType] in
+  /// [toDomain]. Stored raw so an unknown future type round-trips intact.
+  String type;
+
+  bool isRead;
+
+  /// Stored and read back as UTC.
+  @Property(type: PropertyType.dateNanoUtc)
+  DateTime createdAt;
+
+  /// `true` when the read-mark was set locally but hasn't been pushed to the
+  /// server yet. Keeps the pull reconciler from overwriting an unsynced read.
+  bool pendingRead;
+
+  AppNotification toDomain() => AppNotification(
+    id: uuid,
+    title: title,
+    body: body,
+    type: notificationTypeFromRaw(type),
+    isRead: isRead,
+    createdAt: createdAt,
+  );
+}
+
+/// Maps a raw server notification type to its [NotificationType], defaulting
+/// to [NotificationType.system] for unrecognized values.
+NotificationType notificationTypeFromRaw(String raw) => switch (raw) {
+  'social' => NotificationType.social,
+  'reminder' => NotificationType.reminder,
+  'promotion' => NotificationType.promotion,
+  _ => NotificationType.system,
+};

--- a/lib/features/notifications/data/local/notifications_local_data_source.dart
+++ b/lib/features/notifications/data/local/notifications_local_data_source.dart
@@ -1,0 +1,129 @@
+import 'package:injectable/injectable.dart' hide Order;
+
+import '../../../../objectbox.g.dart';
+import 'activity_entity.dart';
+import 'notification_entity.dart';
+
+/// ObjectBox-backed cache for the notifications feed. All operations are
+/// synchronous on the ObjectBox side; wrapped in `Future` to keep the
+/// repository contract async-friendly.
+///
+/// Identity is the string `uuid` (the server id); the integer ObjectBox PK is
+/// internal and only used for [removeNotification] / [removeActivity].
+abstract interface class NotificationsLocalDataSource {
+  /// Cached notifications, newest-first.
+  Future<List<NotificationEntity>> notifications();
+
+  /// Cached activity entries, newest-first.
+  Future<List<ActivityEntity>> activities();
+
+  /// Notifications whose local read-mark hasn't been pushed yet.
+  Future<List<NotificationEntity>> pendingReads();
+
+  Future<NotificationEntity?> getNotification(String uuid);
+
+  Future<void> putNotification(NotificationEntity entity);
+
+  Future<void> putActivity(ActivityEntity entity);
+
+  /// Flags [uuid] as read locally and queues its read-mark for push. No-op if
+  /// the row is unknown or already read.
+  Future<void> markReadPending(String uuid);
+
+  /// Hard-removes a notification by internal PK. Used by the pull reconciler.
+  Future<void> removeNotification(int pk);
+
+  /// Hard-removes an activity entry by internal PK. Used by the pull
+  /// reconciler.
+  Future<void> removeActivity(int pk);
+}
+
+@LazySingleton(as: NotificationsLocalDataSource)
+class ObjectBoxNotificationsDataSource implements NotificationsLocalDataSource {
+  ObjectBoxNotificationsDataSource(Store store)
+    : _notifications = store.box<NotificationEntity>(),
+      _activities = store.box<ActivityEntity>();
+
+  final Box<NotificationEntity> _notifications;
+  final Box<ActivityEntity> _activities;
+
+  @override
+  Future<List<NotificationEntity>> notifications() async {
+    final query = _notifications
+        .query()
+        .order(NotificationEntity_.createdAt, flags: Order.descending)
+        .build();
+    try {
+      return query.find();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<List<ActivityEntity>> activities() async {
+    final query = _activities
+        .query()
+        .order(ActivityEntity_.createdAt, flags: Order.descending)
+        .build();
+    try {
+      return query.find();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<List<NotificationEntity>> pendingReads() async {
+    final query = _notifications
+        .query(NotificationEntity_.pendingRead.equals(true))
+        .build();
+    try {
+      return query.find();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<NotificationEntity?> getNotification(String uuid) async {
+    final query = _notifications
+        .query(NotificationEntity_.uuid.equals(uuid))
+        .build();
+    try {
+      return query.findFirst();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<void> putNotification(NotificationEntity entity) async {
+    _notifications.put(entity);
+  }
+
+  @override
+  Future<void> putActivity(ActivityEntity entity) async {
+    _activities.put(entity);
+  }
+
+  @override
+  Future<void> markReadPending(String uuid) async {
+    final row = await getNotification(uuid);
+    if (row == null || row.isRead) return;
+    row
+      ..isRead = true
+      ..pendingRead = true;
+    _notifications.put(row);
+  }
+
+  @override
+  Future<void> removeNotification(int pk) async {
+    _notifications.remove(pk);
+  }
+
+  @override
+  Future<void> removeActivity(int pk) async {
+    _activities.remove(pk);
+  }
+}

--- a/lib/features/notifications/data/repositories/notifications_repository_impl.dart
+++ b/lib/features/notifications/data/repositories/notifications_repository_impl.dart
@@ -1,73 +1,49 @@
 import 'package:architecture/architecture.dart';
 import 'package:injectable/injectable.dart';
 
-import '../../domain/entities/app_notification.dart';
 import '../../domain/entities/notifications_feed.dart';
-import '../../domain/entities/user_activity.dart';
 import '../../domain/repositories/notifications_repository.dart';
-import '../datasources/notifications_remote_data_source.dart';
-import '../models/notification_dto.dart';
-import '../models/user_activity_dto.dart';
+import '../../domain/services/notifications_sync_controller.dart';
+import '../local/notifications_local_data_source.dart';
 
+/// Offline-first: reads serve from the local ObjectBox cache, the read-mark
+/// commits locally first (and queues a push), then a fire-and-forget sync
+/// reconciles with the API. The UI renders regardless of network state.
 @LazySingleton(as: NotificationsRepository)
 class NotificationsRepositoryImpl implements NotificationsRepository {
-  NotificationsRepositoryImpl(this._remote);
+  NotificationsRepositoryImpl(this._local, this._sync);
 
-  final NotificationsRemoteDataSource _remote;
+  final NotificationsLocalDataSource _local;
+  final NotificationsSyncController _sync;
 
   @override
   Future<Result<NotificationsFeed>> getFeed() async {
-    // Fetch both lists concurrently; the record `.wait` propagates the first
-    // failure so the use case's guard can map it to a Failure.
-    final (notificationDtos, activityDtos) = await (
-      _remote.listNotifications(),
-      _remote.listActivity(),
-    ).wait;
+    final feed = await _readLocal();
+    // Refresh in the background; the read returns the cache immediately.
+    _sync.sync().uw();
+    return Ok(feed);
+  }
 
-    return Ok(
-      NotificationsFeed(
-        notifications: notificationDtos
-            .map(_toNotification)
-            .toList(growable: false),
-        activities: activityDtos.map(_toActivity).toList(growable: false),
-      ),
-    );
+  @override
+  Future<Result<NotificationsFeed>> getFeedLocal() async {
+    return Ok(await _readLocal());
   }
 
   @override
   Future<Result<void>> markRead(String id) async {
-    await _remote.markRead(id);
+    await _local.markReadPending(id);
+    _sync.sync().uw();
     return const Ok(null);
   }
 
-  AppNotification _toNotification(NotificationDto dto) => AppNotification(
-    id: dto.id,
-    title: dto.title,
-    body: dto.body,
-    type: _notificationType(dto.type),
-    isRead: dto.isRead,
-    createdAt: dto.createdAt,
-  );
-
-  UserActivity _toActivity(UserActivityDto dto) => UserActivity(
-    id: dto.id,
-    description: dto.description,
-    type: _activityType(dto.type),
-    createdAt: dto.createdAt,
-  );
-
-  NotificationType _notificationType(String raw) => switch (raw) {
-    'social' => NotificationType.social,
-    'reminder' => NotificationType.reminder,
-    'promotion' => NotificationType.promotion,
-    _ => NotificationType.system,
-  };
-
-  UserActivityType _activityType(String raw) => switch (raw) {
-    'created' => UserActivityType.created,
-    'updated' => UserActivityType.updated,
-    'deleted' => UserActivityType.deleted,
-    'signed_in' => UserActivityType.signedIn,
-    _ => UserActivityType.other,
-  };
+  Future<NotificationsFeed> _readLocal() async {
+    final notifications = await _local.notifications();
+    final activities = await _local.activities();
+    return NotificationsFeed(
+      notifications: notifications
+          .map((e) => e.toDomain())
+          .toList(growable: false),
+      activities: activities.map((e) => e.toDomain()).toList(growable: false),
+    );
+  }
 }

--- a/lib/features/notifications/data/sync/notifications_sync_service.dart
+++ b/lib/features/notifications/data/sync/notifications_sync_service.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:developer' show log;
 
 import 'package:architecture/architecture.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -43,22 +44,30 @@ class NotificationsSyncService implements NotificationsSyncController {
   Future<void>? _inflight;
   bool _wasOnline = true;
 
+  /// Bumped on every [start]/[stop] so a [start] that's awaiting async setup
+  /// can detect a [stop] that landed in the meantime and bail out.
+  int _generation = 0;
+
   @override
   Stream<void> get onSynced => _synced.stream;
 
   @override
   Future<void> start() async {
     if (_connectivitySub != null) return;
+    final generation = ++_generation;
     _connectivitySub = _connectivity.onConnectivityChanged.listen(
       _onConnectivity,
     );
     final initial = await _connectivity.checkConnectivity();
+    // If stop() ran while we awaited, don't kick off a sync after teardown.
+    if (_generation != generation) return;
     _wasOnline = _hasNetwork(initial);
     sync().uw();
   }
 
   @override
   Future<void> stop() async {
+    _generation++;
     await _connectivitySub?.cancel();
     _connectivitySub = null;
   }
@@ -83,9 +92,16 @@ class NotificationsSyncService implements NotificationsSyncController {
       await _pull();
       _synced.add(null);
     } on DioException {
-      // Offline/auth error — pending reads stay queued for the next trigger.
-    } on Object {
-      // Swallow; sync is fire-and-forget from callers.
+      // Offline/auth error — expected; pending reads stay queued for retry.
+    } on Object catch (error, stackTrace) {
+      // Unexpected (e.g. a reconciliation/ObjectBox bug). Surface it so it
+      // isn't lost, but keep sync fire-and-forget for callers.
+      log(
+        'Notifications sync failed',
+        name: 'NotificationsSyncService',
+        error: error,
+        stackTrace: stackTrace,
+      );
     }
   }
 
@@ -142,8 +158,10 @@ class NotificationsSyncService implements NotificationsSyncController {
         ..body = dto.body
         ..type = dto.type
         ..createdAt = dto.createdAt;
-      // Preserve an unpushed local read; otherwise trust the server.
-      if (!local.pendingRead) local.isRead = dto.isRead;
+      // Read state is monotonic: preserve an unpushed local read, and never
+      // let a stale server `false` flip a read we've already observed back to
+      // unread (a markRead may have cleared pendingRead earlier this cycle).
+      if (!local.pendingRead) local.isRead = local.isRead || dto.isRead;
       await _local.putNotification(local);
     }
 

--- a/lib/features/notifications/data/sync/notifications_sync_service.dart
+++ b/lib/features/notifications/data/sync/notifications_sync_service.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:architecture/architecture.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:injectable/injectable.dart';
+import 'package:network/network.dart';
+
+import '../../domain/services/notifications_sync_controller.dart';
+import '../datasources/notifications_remote_data_source.dart';
+import '../local/activity_entity.dart';
+import '../local/notification_entity.dart';
+import '../local/notifications_local_data_source.dart';
+import '../models/notification_dto.dart';
+import '../models/user_activity_dto.dart';
+
+/// Reconciles the local notification/activity cache with the remote API.
+///
+/// Triggers:
+/// - [sync] is called explicitly on app start (post-auth) and after every
+///   local read-mark.
+/// - Connectivity transitions from offline → online.
+///
+/// Strategy (notifications are read-mostly, so there is no create/update/delete
+/// queue):
+/// 1. **Push**: flush every [NotificationEntity.pendingRead] row to the server,
+///    clearing the flag on success. A failure leaves it queued for the next
+///    trigger.
+/// 2. **Pull**: GET both lists and reconcile by uuid — insert server-only rows,
+///    refresh existing ones (preserving any unpushed read-mark), and drop local
+///    rows the server no longer has.
+///
+/// Concurrent calls collapse into one in-flight sync (single-flight).
+@LazySingleton(as: NotificationsSyncController)
+class NotificationsSyncService implements NotificationsSyncController {
+  NotificationsSyncService(this._local, this._remote, this._connectivity);
+
+  final NotificationsLocalDataSource _local;
+  final NotificationsRemoteDataSource _remote;
+  final Connectivity _connectivity;
+
+  final _synced = StreamController<void>.broadcast();
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySub;
+  Future<void>? _inflight;
+  bool _wasOnline = true;
+
+  @override
+  Stream<void> get onSynced => _synced.stream;
+
+  @override
+  Future<void> start() async {
+    if (_connectivitySub != null) return;
+    _connectivitySub = _connectivity.onConnectivityChanged.listen(
+      _onConnectivity,
+    );
+    final initial = await _connectivity.checkConnectivity();
+    _wasOnline = _hasNetwork(initial);
+    sync().uw();
+  }
+
+  @override
+  Future<void> stop() async {
+    await _connectivitySub?.cancel();
+    _connectivitySub = null;
+  }
+
+  void _onConnectivity(List<ConnectivityResult> result) {
+    final online = _hasNetwork(result);
+    if (online && !_wasOnline) sync().uw();
+    _wasOnline = online;
+  }
+
+  bool _hasNetwork(List<ConnectivityResult> result) =>
+      result.any((r) => r != ConnectivityResult.none);
+
+  @override
+  Future<void> sync() {
+    return _inflight ??= _run()..whenComplete(() => _inflight = null);
+  }
+
+  Future<void> _run() async {
+    try {
+      await _pushReads();
+      await _pull();
+      _synced.add(null);
+    } on DioException {
+      // Offline/auth error — pending reads stay queued for the next trigger.
+    } on Object {
+      // Swallow; sync is fire-and-forget from callers.
+    }
+  }
+
+  Future<void> _pushReads() async {
+    final pending = await _local.pendingReads();
+    for (final row in pending) {
+      try {
+        await _remote.markRead(row.uuid);
+        row.pendingRead = false;
+        await _local.putNotification(row);
+      } on DioException catch (e) {
+        // 404: the server no longer has this notification, so stop retrying.
+        // Other errors leave the row queued.
+        if (e.response?.statusCode == 404) {
+          row.pendingRead = false;
+          await _local.putNotification(row);
+        }
+      }
+    }
+  }
+
+  Future<void> _pull() async {
+    final (notificationDtos, activityDtos) = await (
+      _remote.listNotifications(),
+      _remote.listActivity(),
+    ).wait;
+    await _reconcileNotifications(notificationDtos);
+    await _reconcileActivities(activityDtos);
+  }
+
+  Future<void> _reconcileNotifications(List<NotificationDto> dtos) async {
+    final serverIds = {for (final dto in dtos) dto.id};
+    final localByUuid = {
+      for (final row in await _local.notifications()) row.uuid: row,
+    };
+
+    for (final dto in dtos) {
+      final local = localByUuid[dto.id];
+      if (local == null) {
+        await _local.putNotification(
+          NotificationEntity(
+            uuid: dto.id,
+            title: dto.title,
+            body: dto.body,
+            type: dto.type,
+            isRead: dto.isRead,
+            createdAt: dto.createdAt,
+          ),
+        );
+        continue;
+      }
+      local
+        ..title = dto.title
+        ..body = dto.body
+        ..type = dto.type
+        ..createdAt = dto.createdAt;
+      // Preserve an unpushed local read; otherwise trust the server.
+      if (!local.pendingRead) local.isRead = dto.isRead;
+      await _local.putNotification(local);
+    }
+
+    for (final row in localByUuid.values) {
+      if (serverIds.contains(row.uuid)) continue;
+      // Keep a row whose read-mark is still queued; it's cleared once pushed.
+      if (row.pendingRead) continue;
+      await _local.removeNotification(row.id);
+    }
+  }
+
+  Future<void> _reconcileActivities(List<UserActivityDto> dtos) async {
+    final serverIds = {for (final dto in dtos) dto.id};
+    final localByUuid = {
+      for (final row in await _local.activities()) row.uuid: row,
+    };
+
+    for (final dto in dtos) {
+      final local = localByUuid[dto.id];
+      if (local == null) {
+        await _local.putActivity(
+          ActivityEntity(
+            uuid: dto.id,
+            description: dto.description,
+            type: dto.type,
+            createdAt: dto.createdAt,
+          ),
+        );
+        continue;
+      }
+      local
+        ..description = dto.description
+        ..type = dto.type
+        ..createdAt = dto.createdAt;
+      await _local.putActivity(local);
+    }
+
+    for (final row in localByUuid.values) {
+      if (serverIds.contains(row.uuid)) continue;
+      await _local.removeActivity(row.id);
+    }
+  }
+}

--- a/lib/features/notifications/domain/repositories/notifications_repository.dart
+++ b/lib/features/notifications/domain/repositories/notifications_repository.dart
@@ -2,9 +2,14 @@ import 'package:architecture/architecture.dart';
 import '../entities/notifications_feed.dart';
 
 abstract interface class NotificationsRepository {
-  /// Loads the user's notifications and recent activity in one shot.
+  /// Loads the cached feed and triggers a background refresh from the server.
   Future<Result<NotificationsFeed>> getFeed();
 
-  /// Marks the notification with [id] as read on the server.
+  /// Loads the cached feed only, without triggering a sync. Used to surface
+  /// server-side changes after a background sync completes.
+  Future<Result<NotificationsFeed>> getFeedLocal();
+
+  /// Marks the notification with [id] as read locally and queues the change
+  /// for the next sync.
   Future<Result<void>> markRead(String id);
 }

--- a/lib/features/notifications/domain/services/notifications_sync_controller.dart
+++ b/lib/features/notifications/domain/services/notifications_sync_controller.dart
@@ -1,0 +1,19 @@
+/// Reconciles the local notification/activity cache with the remote API.
+///
+/// Notifications are read-mostly, so this is lighter than a full bidirectional
+/// sync: it flushes pending read-marks, then refreshes both cached lists.
+abstract interface class NotificationsSyncController {
+  /// Emits once after each completed sync cycle so the UI can re-read the
+  /// refreshed cache without a manual pull-to-refresh.
+  Stream<void> get onSynced;
+
+  /// Begin reacting to connectivity changes and run an initial sync.
+  /// Idempotent.
+  Future<void> start();
+
+  /// Stop listening to connectivity. Called on sign-out.
+  Future<void> stop();
+
+  /// Public trigger. Concurrent callers share the in-flight future.
+  Future<void> sync();
+}

--- a/lib/features/notifications/domain/usecases/get_notifications_feed_local.dart
+++ b/lib/features/notifications/domain/usecases/get_notifications_feed_local.dart
@@ -1,0 +1,20 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../entities/notifications_feed.dart';
+import '../repositories/notifications_repository.dart';
+
+/// Reads the cached feed without triggering a sync. Used by the bloc to refresh
+/// the UI after a background sync, without kicking off another sync (which
+/// would loop).
+@injectable
+class GetNotificationsFeedLocal extends NoParamUseCase<NotificationsFeed> {
+  const GetNotificationsFeedLocal(this._repository);
+
+  final NotificationsRepository _repository;
+
+  @override
+  Future<Result<NotificationsFeed>> call([NoParams param = noParams]) {
+    return runResultGuarded(_repository.getFeedLocal);
+  }
+}

--- a/lib/features/notifications/presentation/bloc/notifications_bloc.dart
+++ b/lib/features/notifications/presentation/bloc/notifications_bloc.dart
@@ -38,6 +38,7 @@ class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
     );
 
     _activitySubscription = activityNotifier.onActivityOccurred.listen((_) {
+      if (isClosed) return;
       add(const NotificationsLoadRequested());
     });
     // Refresh the cached view after every sync cycle so server-side changes
@@ -104,6 +105,7 @@ class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
     if (result case Ok(value: final feed)) {
       emit(
         state.copyWith(
+          failure: null,
           notifications: feed.notifications,
           activities: feed.activities,
         ),
@@ -118,9 +120,9 @@ class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
   }
 
   @override
-  Future<void> close() {
-    _activitySubscription.cancel();
-    _syncSubscription.cancel();
+  Future<void> close() async {
+    await _activitySubscription.cancel();
+    await _syncSubscription.cancel();
     return super.close();
   }
 }

--- a/lib/features/notifications/presentation/bloc/notifications_bloc.dart
+++ b/lib/features/notifications/presentation/bloc/notifications_bloc.dart
@@ -7,7 +7,9 @@ import 'package:injectable/injectable.dart';
 
 import '../../../../shared/domain/activity_notifier.dart';
 import '../../domain/entities/app_notification.dart';
+import '../../domain/services/notifications_sync_controller.dart';
 import '../../domain/usecases/get_notifications_feed.dart';
+import '../../domain/usecases/get_notifications_feed_local.dart';
 import '../../domain/usecases/mark_notification_read.dart';
 import 'notifications_state.dart';
 
@@ -17,8 +19,10 @@ part 'notifications_event.dart';
 class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
   NotificationsBloc(
     this._getFeed,
+    this._getFeedLocal,
     this._markRead,
     ActivityNotifier activityNotifier,
+    NotificationsSyncController sync,
   ) : super(const NotificationsState()) {
     on<NotificationsLoadRequested>(
       _onLoadRequested,
@@ -28,15 +32,27 @@ class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
       _onMarkReadRequested,
       transformer: sequential(),
     );
+    on<_NotificationsReloadSilently>(
+      _onReloadSilently,
+      transformer: droppable(),
+    );
 
     _activitySubscription = activityNotifier.onActivityOccurred.listen((_) {
       add(const NotificationsLoadRequested());
     });
+    // Refresh the cached view after every sync cycle so server-side changes
+    // appear without the user pulling-to-refresh.
+    _syncSubscription = sync.onSynced.listen((_) {
+      if (isClosed) return;
+      add(const _NotificationsReloadSilently());
+    });
   }
 
   late final StreamSubscription<void> _activitySubscription;
+  late final StreamSubscription<void> _syncSubscription;
 
   final GetNotificationsFeed _getFeed;
+  final GetNotificationsFeedLocal _getFeedLocal;
   final MarkNotificationRead _markRead;
 
   Future<void> _onLoadRequested(
@@ -78,6 +94,23 @@ class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
     }
   }
 
+  Future<void> _onReloadSilently(
+    _NotificationsReloadSilently event,
+    Emitter<NotificationsState> emit,
+  ) async {
+    // Read the cache only — going through _getFeed() would trigger another
+    // sync, which would emit onSynced again and loop.
+    final result = await _getFeedLocal();
+    if (result case Ok(value: final feed)) {
+      emit(
+        state.copyWith(
+          notifications: feed.notifications,
+          activities: feed.activities,
+        ),
+      );
+    }
+  }
+
   List<AppNotification> _withRead(String id, {required bool isRead}) {
     return state.notifications
         .map((n) => n.id == id ? n.copyWith(isRead: isRead) : n)
@@ -87,6 +120,7 @@ class NotificationsBloc extends Bloc<NotificationsEvent, NotificationsState> {
   @override
   Future<void> close() {
     _activitySubscription.cancel();
+    _syncSubscription.cancel();
     return super.close();
   }
 }

--- a/lib/features/notifications/presentation/bloc/notifications_event.dart
+++ b/lib/features/notifications/presentation/bloc/notifications_event.dart
@@ -15,3 +15,9 @@ final class NotificationMarkReadRequested extends NotificationsEvent {
 
   final String id;
 }
+
+/// Re-reads the local cache after a background sync, without showing a loading
+/// indicator or triggering another sync.
+final class _NotificationsReloadSilently extends NotificationsEvent {
+  const _NotificationsReloadSilently();
+}

--- a/lib/features/notifications/presentation/widgets/notifications_lists.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_lists.dart
@@ -70,7 +70,10 @@ class _NotificationSectionLabel extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.only(left: AppSpacing.xs, bottom: AppSpacing.sm),
+      padding: const EdgeInsets.only(
+        left: AppSpacing.xs,
+        bottom: AppSpacing.sm,
+      ),
       child: Text(
         label.toUpperCase(),
         style: context.textTheme.labelMedium?.copyWith(
@@ -151,42 +154,17 @@ class _TabEmptyState extends StatelessWidget {
 }
 
 class _SectionHeader extends StatelessWidget {
-  const _SectionHeader({required this.title, this.badgeCount = 0});
+  const _SectionHeader({required this.title});
 
   final String title;
-  final int badgeCount;
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Text(
-          title,
-          style: context.textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        if (badgeCount > 0) ...[
-          const SizedBox(width: AppSpacing.sm),
-          Container(
-            padding: const EdgeInsets.symmetric(
-              horizontal: AppSpacing.sm,
-              vertical: AppSpacing.xxs,
-            ),
-            decoration: BoxDecoration(
-              color: context.colorScheme.primary,
-              borderRadius: BorderRadius.circular(AppRadius.xl),
-            ),
-            child: Text(
-              context.l10n.notificationsUnreadCount(badgeCount),
-              style: context.textTheme.labelSmall?.copyWith(
-                color: context.colorScheme.onPrimary,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-          ),
-        ],
-      ],
+    return Text(
+      title,
+      style: context.textTheme.titleMedium?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
     );
   }
 }

--- a/lib/features/notifications/presentation/widgets/notifications_lists.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_lists.dart
@@ -1,42 +1,83 @@
 part of 'notifications_widgets.dart';
 
 class _NotificationsList extends StatelessWidget {
-  const _NotificationsList({
-    required this.notifications,
-    required this.unreadCount,
-  });
+  const _NotificationsList({required this.notifications});
 
   final List<AppNotification> notifications;
-  final int unreadCount;
 
   @override
   Widget build(BuildContext context) {
+    final unread = notifications.where((n) => !n.isRead).toList();
+    final read = notifications.where((n) => n.isRead).toList();
+
     return RefreshIndicator(
       onRefresh: () => _refresh(context),
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
         padding: const EdgeInsets.all(AppSpacing.lg),
         children: [
-          _SectionHeader(
-            title: context.l10n.notificationsSection,
-            badgeCount: unreadCount,
-          ),
-          const SizedBox(height: AppSpacing.sm),
           if (notifications.isEmpty)
             _TabEmptyState(
               icon: FontAwesomeIcons.bell,
               title: context.l10n.notificationsNoNotifications,
               message: context.l10n.notificationsEmptyMessage,
             )
-          else
-            for (final (index, notification) in notifications.indexed)
-              _NotificationTile(
-                notification: notification,
-                onTap: () => context.read<NotificationsBloc>().add(
-                  NotificationMarkReadRequested(notification.id),
-                ),
-              ).animateSlideUp(delay: (50 * index).ms),
+          else ...[
+            if (unread.isNotEmpty) ...[
+              _NotificationSectionLabel(context.l10n.notificationsSectionNew),
+              ..._tiles(context, unread),
+            ],
+            if (read.isNotEmpty) ...[
+              if (unread.isNotEmpty) const SizedBox(height: AppSpacing.lg),
+              _NotificationSectionLabel(
+                context.l10n.notificationsSectionEarlier,
+              ),
+              ..._tiles(context, read, indexOffset: unread.length),
+            ],
+          ],
         ],
+      ),
+    );
+  }
+
+  List<Widget> _tiles(
+    BuildContext context,
+    List<AppNotification> items, {
+    int indexOffset = 0,
+  }) {
+    return [
+      for (final (index, notification) in items.indexed)
+        Padding(
+          padding: const EdgeInsets.only(bottom: AppSpacing.md),
+          child: _NotificationTile(
+            notification: notification,
+            onTap: () => context.read<NotificationsBloc>().add(
+              NotificationMarkReadRequested(notification.id),
+            ),
+          ),
+        ).animateSlideUp(delay: (50 * (indexOffset + index)).ms),
+    ];
+  }
+}
+
+/// An uppercase, tracked-out section label (e.g. "NEW", "EARLIER") used to
+/// group the notification feed.
+class _NotificationSectionLabel extends StatelessWidget {
+  const _NotificationSectionLabel(this.label);
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: AppSpacing.xs, bottom: AppSpacing.sm),
+      child: Text(
+        label.toUpperCase(),
+        style: context.textTheme.labelMedium?.copyWith(
+          color: context.colorScheme.outline,
+          fontWeight: FontWeight.w700,
+          letterSpacing: 1.2,
+        ),
       ),
     );
   }

--- a/lib/features/notifications/presentation/widgets/notifications_lists.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_lists.dart
@@ -69,17 +69,20 @@ class _NotificationSectionLabel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(
-        left: AppSpacing.xs,
-        bottom: AppSpacing.sm,
-      ),
-      child: Text(
-        label.toUpperCase(),
-        style: context.textTheme.labelMedium?.copyWith(
-          color: context.colorScheme.outline,
-          fontWeight: FontWeight.w700,
-          letterSpacing: 1.2,
+    return Semantics(
+      header: true,
+      child: Padding(
+        padding: const EdgeInsets.only(
+          left: AppSpacing.xs,
+          bottom: AppSpacing.sm,
+        ),
+        child: Text(
+          label.toUpperCase(),
+          style: context.textTheme.labelMedium?.copyWith(
+            color: context.colorScheme.outline,
+            fontWeight: FontWeight.w700,
+            letterSpacing: 1.2,
+          ),
         ),
       ),
     );

--- a/lib/features/notifications/presentation/widgets/notifications_tabs.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_tabs.dart
@@ -22,10 +22,7 @@ class _NotificationsTabs extends StatelessWidget {
           Expanded(
             child: TabBarView(
               children: [
-                _NotificationsList(
-                  notifications: state.notifications,
-                  unreadCount: state.unreadCount,
-                ),
+                _NotificationsList(notifications: state.notifications),
                 _ActivitiesList(activities: state.activities),
               ],
             ),

--- a/lib/features/notifications/presentation/widgets/notifications_tiles.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_tiles.dart
@@ -169,68 +169,65 @@ class _ReadNotificationTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = context.colorScheme;
-    return Opacity(
-      opacity: 0.85,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          color: scheme.surfaceContainerLowest,
-          borderRadius: BorderRadius.circular(AppRadius.lg),
-          border: Border.all(
-            color: scheme.outlineVariant.withValues(alpha: 0.4),
-          ),
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        border: Border.all(
+          color: scheme.outlineVariant.withValues(alpha: 0.4),
         ),
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpacing.lg),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              CircleAvatar(
-                radius: 20,
-                backgroundColor: scheme.surfaceContainerHigh,
-                child: FaIcon(
-                  _notificationIcon(notification.type),
-                  color: scheme.onSurfaceVariant,
-                  size: AppIconSize.sm,
-                ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.lg),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            CircleAvatar(
+              radius: 20,
+              backgroundColor: scheme.surfaceContainerHigh,
+              child: FaIcon(
+                _notificationIcon(notification.type),
+                color: scheme.onSurfaceVariant,
+                size: AppIconSize.sm,
               ),
-              const SizedBox(width: AppSpacing.md),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(
-                          child: Text(
-                            notification.title,
-                            style: context.textTheme.bodyMedium?.copyWith(
-                              fontWeight: FontWeight.w600,
-                            ),
+            ),
+            const SizedBox(width: AppSpacing.md),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          notification.title,
+                          style: context.textTheme.bodyMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
                           ),
                         ),
-                        const SizedBox(width: AppSpacing.sm),
-                        Text(
-                          formatRelativeTime(context, notification.createdAt),
-                          style: context.textTheme.labelSmall?.copyWith(
-                            color: scheme.outline,
-                          ),
-                        ),
-                      ],
-                    ),
-                    const SizedBox(height: AppSpacing.xs),
-                    Text(
-                      notification.body,
-                      style: context.textTheme.bodySmall?.copyWith(
-                        color: scheme.onSurfaceVariant,
-                        height: 1.4,
                       ),
+                      const SizedBox(width: AppSpacing.sm),
+                      Text(
+                        formatRelativeTime(context, notification.createdAt),
+                        style: context.textTheme.labelSmall?.copyWith(
+                          color: scheme.outline,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: AppSpacing.xs),
+                  Text(
+                    notification.body,
+                    style: context.textTheme.bodySmall?.copyWith(
+                      color: scheme.onSurfaceVariant,
+                      height: 1.4,
                     ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            ],
-          ),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/notifications/presentation/widgets/notifications_tiles.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_tiles.dart
@@ -30,6 +30,10 @@ class _ActivityTile extends StatelessWidget {
   }
 }
 
+/// A single notification, rendered in one of two visual treatments:
+///
+/// unread notifications get a prominent, elevated card (the "New" section)
+/// while read ones get a quieter, flat bordered card (the "Earlier" section).
 class _NotificationTile extends StatelessWidget {
   const _NotificationTile({required this.notification, required this.onTap});
 
@@ -39,49 +43,195 @@ class _NotificationTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final accent = _notificationColor(context, notification.type);
-    return Card(
-      elevation: notification.isRead ? 0 : 1,
-      color: notification.isRead
-          ? context.colorScheme.surfaceContainerHighest.withValues(alpha: 0.4)
-          : context.colorScheme.surface,
-      shape: RoundedRectangleBorder(
+    return notification.isRead
+        ? _ReadNotificationTile(notification: notification, accent: accent)
+        : _UnreadNotificationTile(
+            notification: notification,
+            accent: accent,
+            onTap: onTap,
+          );
+  }
+}
+
+class _UnreadNotificationTile extends StatelessWidget {
+  const _UnreadNotificationTile({
+    required this.notification,
+    required this.accent,
+    required this.onTap,
+  });
+
+  final AppNotification notification;
+  final Color accent;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = context.colorScheme;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerLowest,
         borderRadius: BorderRadius.circular(AppRadius.lg),
+        border: Border.all(color: accent.withValues(alpha: 0.25)),
+        boxShadow: [
+          BoxShadow(
+            color: context.isDark
+                ? Colors.black.withValues(alpha: 0.32)
+                : accent.withValues(alpha: 0.12),
+            blurRadius: 20,
+            offset: const Offset(0, 4),
+          ),
+        ],
       ),
-      child: ListTile(
-        onTap: notification.isRead ? null : onTap,
-        leading: CircleAvatar(
-          backgroundColor: accent.withValues(alpha: 0.15),
-          child: FaIcon(_notificationIcon(notification.type), color: accent),
-        ),
-        title: Text(
-          notification.title,
-          style: TextStyle(
-            fontWeight: notification.isRead ? FontWeight.w400 : FontWeight.w600,
+      child: Material(
+        type: MaterialType.transparency,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CircleAvatar(
+                  radius: 24,
+                  backgroundColor: accent.withValues(alpha: 0.15),
+                  child: FaIcon(
+                    _notificationIcon(notification.type),
+                    color: accent,
+                    size: AppIconSize.md,
+                  ),
+                ),
+                const SizedBox(width: AppSpacing.md),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Expanded(
+                            child: Text(
+                              notification.title,
+                              style: context.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: AppSpacing.sm),
+                          Text(
+                            formatRelativeTime(context, notification.createdAt),
+                            style: context.textTheme.labelSmall?.copyWith(
+                              color: scheme.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          const SizedBox(width: AppSpacing.sm),
+                          Container(
+                            width: 8,
+                            height: 8,
+                            margin: const EdgeInsets.only(top: AppSpacing.xs),
+                            decoration: BoxDecoration(
+                              color: scheme.primary,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: AppSpacing.xs),
+                      Text(
+                        notification.body,
+                        style: context.textTheme.bodyMedium?.copyWith(
+                          color: scheme.onSurfaceVariant,
+                          height: 1.4,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
           ),
         ),
-        subtitle: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text(notification.body),
-            const SizedBox(height: AppSpacing.xxs),
-            Text(
-              formatRelativeTime(context, notification.createdAt),
-              style: context.textTheme.labelSmall?.copyWith(
-                color: context.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ],
+      ),
+    );
+  }
+}
+
+class _ReadNotificationTile extends StatelessWidget {
+  const _ReadNotificationTile({
+    required this.notification,
+    required this.accent,
+  });
+
+  final AppNotification notification;
+  final Color accent;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = context.colorScheme;
+    return Opacity(
+      opacity: 0.85,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: scheme.surfaceContainerLowest,
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+          border: Border.all(
+            color: scheme.outlineVariant.withValues(alpha: 0.4),
+          ),
         ),
-        trailing: notification.isRead
-            ? null
-            : Container(
-                width: 10,
-                height: 10,
-                decoration: BoxDecoration(
-                  color: accent,
-                  shape: BoxShape.circle,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              CircleAvatar(
+                radius: 20,
+                backgroundColor: scheme.surfaceContainerHigh,
+                child: FaIcon(
+                  _notificationIcon(notification.type),
+                  color: scheme.onSurfaceVariant,
+                  size: AppIconSize.sm,
                 ),
               ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Expanded(
+                          child: Text(
+                            notification.title,
+                            style: context.textTheme.bodyMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: AppSpacing.sm),
+                        Text(
+                          formatRelativeTime(context, notification.createdAt),
+                          style: context.textTheme.labelSmall?.copyWith(
+                            color: scheme.outline,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: AppSpacing.xs),
+                    Text(
+                      notification.body,
+                      style: context.textTheme.bodySmall?.copyWith(
+                        color: scheme.onSurfaceVariant,
+                        height: 1.4,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -263,6 +263,8 @@
   "notificationsAppBarTitle": "Notifications",
   "notificationsActivitySection": "Your activity",
   "notificationsSection": "Notifications",
+  "notificationsSectionNew": "New",
+  "notificationsSectionEarlier": "Earlier",
   "notificationsEmptyTitle": "Nothing here yet",
   "notificationsEmptyMessage": "Your notifications and recent activity will appear here.",
   "notificationsNoNotifications": "No notifications yet.",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1040,6 +1040,18 @@ abstract class AppLocalizations {
   /// **'Notifications'**
   String get notificationsSection;
 
+  /// No description provided for @notificationsSectionNew.
+  ///
+  /// In en, this message translates to:
+  /// **'New'**
+  String get notificationsSectionNew;
+
+  /// No description provided for @notificationsSectionEarlier.
+  ///
+  /// In en, this message translates to:
+  /// **'Earlier'**
+  String get notificationsSectionEarlier;
+
   /// No description provided for @notificationsEmptyTitle.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -510,6 +510,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get notificationsSection => 'Notifications';
 
   @override
+  String get notificationsSectionNew => 'New';
+
+  @override
+  String get notificationsSectionEarlier => 'Earlier';
+
+  @override
   String get notificationsEmptyTitle => 'Nothing here yet';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -511,6 +511,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get notificationsSection => 'Thông báo';
 
   @override
+  String get notificationsSectionNew => 'Mới';
+
+  @override
+  String get notificationsSectionEarlier => 'Trước đó';
+
+  @override
   String get notificationsEmptyTitle => 'Chưa có gì ở đây';
 
   @override

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -173,6 +173,8 @@
   "notificationsAppBarTitle": "Thông báo",
   "notificationsActivitySection": "Hoạt động của bạn",
   "notificationsSection": "Thông báo",
+  "notificationsSectionNew": "Mới",
+  "notificationsSectionEarlier": "Trước đó",
   "notificationsEmptyTitle": "Chưa có gì ở đây",
   "notificationsEmptyMessage": "Thông báo và hoạt động gần đây của bạn sẽ hiển thị ở đây.",
   "notificationsNoNotifications": "Chưa có thông báo nào.",

--- a/lib/objectbox-model.json
+++ b/lib/objectbox-model.json
@@ -73,10 +73,97 @@
         }
       ],
       "relations": []
+    },
+    {
+      "id": "2:919939177363945290",
+      "lastPropertyId": "5:3358862512730183168",
+      "name": "ActivityEntity",
+      "properties": [
+        {
+          "id": "1:1252568795501351072",
+          "name": "id",
+          "type": 6,
+          "flags": 1
+        },
+        {
+          "id": "2:8712645750653639276",
+          "name": "uuid",
+          "indexId": "2:4900372963106232767",
+          "type": 9,
+          "flags": 2080
+        },
+        {
+          "id": "3:8458822913889059882",
+          "name": "description",
+          "type": 9
+        },
+        {
+          "id": "4:8330749528174122264",
+          "name": "type",
+          "type": 9
+        },
+        {
+          "id": "5:3358862512730183168",
+          "name": "createdAt",
+          "type": 12
+        }
+      ],
+      "relations": []
+    },
+    {
+      "id": "3:1349722681213321324",
+      "lastPropertyId": "8:310238830684819705",
+      "name": "NotificationEntity",
+      "properties": [
+        {
+          "id": "1:5623171801112591648",
+          "name": "id",
+          "type": 6,
+          "flags": 1
+        },
+        {
+          "id": "2:3490771905479002669",
+          "name": "uuid",
+          "indexId": "3:7678540160299865532",
+          "type": 9,
+          "flags": 2080
+        },
+        {
+          "id": "3:2530253008106623603",
+          "name": "title",
+          "type": 9
+        },
+        {
+          "id": "4:4962516224363033753",
+          "name": "body",
+          "type": 9
+        },
+        {
+          "id": "5:6903004669254115199",
+          "name": "type",
+          "type": 9
+        },
+        {
+          "id": "6:3496464928661177200",
+          "name": "isRead",
+          "type": 1
+        },
+        {
+          "id": "7:1877937495822827689",
+          "name": "createdAt",
+          "type": 12
+        },
+        {
+          "id": "8:310238830684819705",
+          "name": "pendingRead",
+          "type": 1
+        }
+      ],
+      "relations": []
     }
   ],
-  "lastEntityId": "1:8542772984841996240",
-  "lastIndexId": "1:1205513408758410617",
+  "lastEntityId": "3:1349722681213321324",
+  "lastIndexId": "3:7678540160299865532",
   "lastRelationId": "0:0",
   "lastSequenceId": "0:0",
   "modelVersion": 5,

--- a/lib/objectbox.g.dart
+++ b/lib/objectbox.g.dart
@@ -15,6 +15,8 @@ import 'package:objectbox/objectbox.dart' as obx;
 import 'package:objectbox_flutter_libs/objectbox_flutter_libs.dart';
 
 import 'features/bookmarks/data/local/bookmark_entity.dart';
+import 'features/notifications/data/local/activity_entity.dart';
+import 'features/notifications/data/local/notification_entity.dart';
 
 export 'package:objectbox/objectbox.dart'; // so that callers only have to import this file
 
@@ -102,6 +104,106 @@ final _entities = <obx_int.ModelEntity>[
     relations: <obx_int.ModelRelation>[],
     backlinks: <obx_int.ModelBacklink>[],
   ),
+  obx_int.ModelEntity(
+    id: const obx_int.IdUid(2, 919939177363945290),
+    name: 'ActivityEntity',
+    lastPropertyId: const obx_int.IdUid(5, 3358862512730183168),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 1252568795501351072),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 8712645750653639276),
+        name: 'uuid',
+        type: 9,
+        flags: 2080,
+        indexId: const obx_int.IdUid(2, 4900372963106232767),
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 8458822913889059882),
+        name: 'description',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 8330749528174122264),
+        name: 'type',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 3358862512730183168),
+        name: 'createdAt',
+        type: 12,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
+  obx_int.ModelEntity(
+    id: const obx_int.IdUid(3, 1349722681213321324),
+    name: 'NotificationEntity',
+    lastPropertyId: const obx_int.IdUid(8, 310238830684819705),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 5623171801112591648),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 3490771905479002669),
+        name: 'uuid',
+        type: 9,
+        flags: 2080,
+        indexId: const obx_int.IdUid(3, 7678540160299865532),
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 2530253008106623603),
+        name: 'title',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 4962516224363033753),
+        name: 'body',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 6903004669254115199),
+        name: 'type',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 3496464928661177200),
+        name: 'isRead',
+        type: 1,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 1877937495822827689),
+        name: 'createdAt',
+        type: 12,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 310238830684819705),
+        name: 'pendingRead',
+        type: 1,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
 ];
 
 /// Shortcut for [obx.Store.new] that passes [getObjectBoxModel] and for Flutter
@@ -147,8 +249,8 @@ obx_int.ModelDefinition getObjectBoxModel() {
     // Typically, this is done with `dart run build_runner build`.
     generatorVersion: obx_int.GeneratorVersion.v2025_12_16,
     entities: _entities,
-    lastEntityId: const obx_int.IdUid(1, 8542772984841996240),
-    lastIndexId: const obx_int.IdUid(1, 1205513408758410617),
+    lastEntityId: const obx_int.IdUid(3, 1349722681213321324),
+    lastIndexId: const obx_int.IdUid(3, 7678540160299865532),
     lastRelationId: const obx_int.IdUid(0, 0),
     lastSequenceId: const obx_int.IdUid(0, 0),
     retiredEntityUids: const [],
@@ -281,6 +383,138 @@ obx_int.ModelDefinition getObjectBoxModel() {
         return object;
       },
     ),
+    ActivityEntity: obx_int.EntityDefinition<ActivityEntity>(
+      model: _entities[1],
+      toOneRelations: (ActivityEntity object) => [],
+      toManyRelations: (ActivityEntity object) => {},
+      getId: (ActivityEntity object) => object.id,
+      setId: (ActivityEntity object, int id) {
+        object.id = id;
+      },
+      objectToFB: (ActivityEntity object, fb.Builder fbb) {
+        final uuidOffset = fbb.writeString(object.uuid);
+        final descriptionOffset = fbb.writeString(object.description);
+        final typeOffset = fbb.writeString(object.type);
+        fbb.startTable(6);
+        fbb.addInt64(0, object.id);
+        fbb.addOffset(1, uuidOffset);
+        fbb.addOffset(2, descriptionOffset);
+        fbb.addOffset(3, typeOffset);
+        fbb.addInt64(4, object.createdAt.microsecondsSinceEpoch * 1000);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final uuidParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 6, '');
+        final descriptionParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 8, '');
+        final typeParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 10, '');
+        final createdAtParam = DateTime.fromMicrosecondsSinceEpoch(
+          (const fb.Int64Reader().vTableGet(buffer, rootOffset, 12, 0) / 1000)
+              .round(),
+          isUtc: true,
+        );
+        final object = ActivityEntity(
+          id: idParam,
+          uuid: uuidParam,
+          description: descriptionParam,
+          type: typeParam,
+          createdAt: createdAtParam,
+        );
+
+        return object;
+      },
+    ),
+    NotificationEntity: obx_int.EntityDefinition<NotificationEntity>(
+      model: _entities[2],
+      toOneRelations: (NotificationEntity object) => [],
+      toManyRelations: (NotificationEntity object) => {},
+      getId: (NotificationEntity object) => object.id,
+      setId: (NotificationEntity object, int id) {
+        object.id = id;
+      },
+      objectToFB: (NotificationEntity object, fb.Builder fbb) {
+        final uuidOffset = fbb.writeString(object.uuid);
+        final titleOffset = fbb.writeString(object.title);
+        final bodyOffset = fbb.writeString(object.body);
+        final typeOffset = fbb.writeString(object.type);
+        fbb.startTable(9);
+        fbb.addInt64(0, object.id);
+        fbb.addOffset(1, uuidOffset);
+        fbb.addOffset(2, titleOffset);
+        fbb.addOffset(3, bodyOffset);
+        fbb.addOffset(4, typeOffset);
+        fbb.addBool(5, object.isRead);
+        fbb.addInt64(6, object.createdAt.microsecondsSinceEpoch * 1000);
+        fbb.addBool(7, object.pendingRead);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final uuidParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 6, '');
+        final titleParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 8, '');
+        final bodyParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 10, '');
+        final typeParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 12, '');
+        final isReadParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          14,
+          false,
+        );
+        final createdAtParam = DateTime.fromMicrosecondsSinceEpoch(
+          (const fb.Int64Reader().vTableGet(buffer, rootOffset, 16, 0) / 1000)
+              .round(),
+          isUtc: true,
+        );
+        final pendingReadParam = const fb.BoolReader().vTableGet(
+          buffer,
+          rootOffset,
+          18,
+          false,
+        );
+        final object = NotificationEntity(
+          id: idParam,
+          uuid: uuidParam,
+          title: titleParam,
+          body: bodyParam,
+          type: typeParam,
+          isRead: isReadParam,
+          createdAt: createdAtParam,
+          pendingRead: pendingReadParam,
+        );
+
+        return object;
+      },
+    ),
   };
 
   return obx_int.ModelDefinition(model, bindings);
@@ -346,5 +580,76 @@ class BookmarkEntity_ {
   /// See [BookmarkEntity.videoUrl].
   static final videoUrl = obx.QueryStringProperty<BookmarkEntity>(
     _entities[0].properties[11],
+  );
+}
+
+/// [ActivityEntity] entity fields to define ObjectBox queries.
+class ActivityEntity_ {
+  /// See [ActivityEntity.id].
+  static final id = obx.QueryIntegerProperty<ActivityEntity>(
+    _entities[1].properties[0],
+  );
+
+  /// See [ActivityEntity.uuid].
+  static final uuid = obx.QueryStringProperty<ActivityEntity>(
+    _entities[1].properties[1],
+  );
+
+  /// See [ActivityEntity.description].
+  static final description = obx.QueryStringProperty<ActivityEntity>(
+    _entities[1].properties[2],
+  );
+
+  /// See [ActivityEntity.type].
+  static final type = obx.QueryStringProperty<ActivityEntity>(
+    _entities[1].properties[3],
+  );
+
+  /// See [ActivityEntity.createdAt].
+  static final createdAt = obx.QueryDateNanoProperty<ActivityEntity>(
+    _entities[1].properties[4],
+  );
+}
+
+/// [NotificationEntity] entity fields to define ObjectBox queries.
+class NotificationEntity_ {
+  /// See [NotificationEntity.id].
+  static final id = obx.QueryIntegerProperty<NotificationEntity>(
+    _entities[2].properties[0],
+  );
+
+  /// See [NotificationEntity.uuid].
+  static final uuid = obx.QueryStringProperty<NotificationEntity>(
+    _entities[2].properties[1],
+  );
+
+  /// See [NotificationEntity.title].
+  static final title = obx.QueryStringProperty<NotificationEntity>(
+    _entities[2].properties[2],
+  );
+
+  /// See [NotificationEntity.body].
+  static final body = obx.QueryStringProperty<NotificationEntity>(
+    _entities[2].properties[3],
+  );
+
+  /// See [NotificationEntity.type].
+  static final type = obx.QueryStringProperty<NotificationEntity>(
+    _entities[2].properties[4],
+  );
+
+  /// See [NotificationEntity.isRead].
+  static final isRead = obx.QueryBooleanProperty<NotificationEntity>(
+    _entities[2].properties[5],
+  );
+
+  /// See [NotificationEntity.createdAt].
+  static final createdAt = obx.QueryDateNanoProperty<NotificationEntity>(
+    _entities[2].properties[6],
+  );
+
+  /// See [NotificationEntity.pendingRead].
+  static final pendingRead = obx.QueryBooleanProperty<NotificationEntity>(
+    _entities[2].properties[7],
   );
 }

--- a/test/features/notifications/data/repositories/notifications_repository_impl_test.dart
+++ b/test/features/notifications/data/repositories/notifications_repository_impl_test.dart
@@ -1,110 +1,104 @@
 import 'package:architecture/architecture.dart';
-import 'package:flutter_starter_template/features/notifications/data/datasources/notifications_remote_data_source.dart';
-import 'package:flutter_starter_template/features/notifications/data/models/notification_dto.dart';
-import 'package:flutter_starter_template/features/notifications/data/models/user_activity_dto.dart';
+import 'package:flutter_starter_template/features/notifications/data/local/activity_entity.dart';
+import 'package:flutter_starter_template/features/notifications/data/local/notification_entity.dart';
+import 'package:flutter_starter_template/features/notifications/data/local/notifications_local_data_source.dart';
 import 'package:flutter_starter_template/features/notifications/data/repositories/notifications_repository_impl.dart';
 import 'package:flutter_starter_template/features/notifications/domain/entities/app_notification.dart';
 import 'package:flutter_starter_template/features/notifications/domain/entities/notifications_feed.dart';
 import 'package:flutter_starter_template/features/notifications/domain/entities/user_activity.dart';
+import 'package:flutter_starter_template/features/notifications/domain/services/notifications_sync_controller.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:test_utils/test_utils.dart';
 
-class MockNotificationsRemoteDataSource extends Mock
-    implements NotificationsRemoteDataSource {}
+class MockNotificationsLocalDataSource extends Mock
+    implements NotificationsLocalDataSource {}
+
+class MockNotificationsSyncController extends Mock
+    implements NotificationsSyncController {}
 
 void main() {
-  late MockNotificationsRemoteDataSource remote;
+  late MockNotificationsLocalDataSource local;
+  late MockNotificationsSyncController sync;
   late NotificationsRepositoryImpl repository;
 
   final now = DateTime(2026, 6, 1, 12);
 
   setUp(() {
-    remote = MockNotificationsRemoteDataSource();
-    repository = NotificationsRepositoryImpl(remote);
+    local = MockNotificationsLocalDataSource();
+    sync = MockNotificationsSyncController();
+    repository = NotificationsRepositoryImpl(local, sync);
+
+    when(() => sync.sync()).thenAnswer((_) async {});
+    when(() => local.notifications()).thenAnswer(
+      (_) async => [
+        NotificationEntity(
+          uuid: 'n-1',
+          title: 'Mention',
+          body: 'Alice mentioned you',
+          type: 'social',
+          isRead: false,
+          createdAt: now,
+        ),
+        NotificationEntity(
+          uuid: 'n-2',
+          title: 'Fallback',
+          body: 'Unknown type',
+          type: 'unexpected',
+          isRead: true,
+          createdAt: now.add(const Duration(minutes: 1)),
+        ),
+      ],
+    );
+    when(() => local.activities()).thenAnswer(
+      (_) async => [
+        ActivityEntity(
+          uuid: 'a-1',
+          description: 'Signed in',
+          type: 'signed_in',
+          createdAt: now,
+        ),
+        ActivityEntity(
+          uuid: 'a-2',
+          description: 'Fallback',
+          type: 'unexpected',
+          createdAt: now.add(const Duration(minutes: 1)),
+        ),
+      ],
+    );
   });
 
   group('NotificationsRepositoryImpl', () {
-    test('getFeed maps remote DTOs to domain entities', () async {
-      when(() => remote.listNotifications()).thenAnswer(
-        (_) async => [
-          NotificationDto(
-            id: 'n-1',
-            title: 'Mention',
-            body: 'Alice mentioned you',
-            type: 'social',
-            createdAt: now,
-          ),
-          NotificationDto(
-            id: 'n-2',
-            title: 'Reminder',
-            body: 'Review saved links',
-            type: 'reminder',
-            isRead: true,
-            createdAt: now.add(const Duration(minutes: 1)),
-          ),
-          NotificationDto(
-            id: 'n-3',
-            title: 'Promo',
-            body: 'Try premium',
-            type: 'promotion',
-            createdAt: now.add(const Duration(minutes: 2)),
-          ),
-          NotificationDto(
-            id: 'n-4',
-            title: 'Fallback',
-            body: 'Unknown type',
-            type: 'unexpected',
-            createdAt: now.add(const Duration(minutes: 3)),
-          ),
-        ],
-      );
-      when(() => remote.listActivity()).thenAnswer(
-        (_) async => [
-          UserActivityDto(
-            id: 'a-1',
-            description: 'Created bookmark',
-            type: 'created',
-            createdAt: now,
-          ),
-          UserActivityDto(
-            id: 'a-2',
-            description: 'Signed in',
-            type: 'signed_in',
-            createdAt: now.add(const Duration(minutes: 1)),
-          ),
-          UserActivityDto(
-            id: 'a-3',
-            description: 'Fallback',
-            type: 'unexpected',
-            createdAt: now.add(const Duration(minutes: 2)),
-          ),
-        ],
-      );
-
+    test('getFeed maps cached rows to domain and triggers a sync', () async {
       final result = await repository.getFeed();
 
       final ok = result as Ok<NotificationsFeed>;
-      expect(ok.value.notifications, hasLength(4));
+      expect(ok.value.notifications, hasLength(2));
       expect(ok.value.notifications[0].type, NotificationType.social);
-      expect(ok.value.notifications[1].type, NotificationType.reminder);
+      expect(ok.value.notifications[1].type, NotificationType.system);
       expect(ok.value.notifications[1].isRead, isTrue);
-      expect(ok.value.notifications[2].type, NotificationType.promotion);
-      expect(ok.value.notifications[3].type, NotificationType.system);
-      expect(ok.value.activities, hasLength(3));
-      expect(ok.value.activities[0].type, UserActivityType.created);
-      expect(ok.value.activities[1].type, UserActivityType.signedIn);
-      expect(ok.value.activities[2].type, UserActivityType.other);
-      verify(() => remote.listNotifications()).called(1);
-      verify(() => remote.listActivity()).called(1);
+      expect(ok.value.activities, hasLength(2));
+      expect(ok.value.activities[0].type, UserActivityType.signedIn);
+      expect(ok.value.activities[1].type, UserActivityType.other);
+      verify(() => sync.sync()).called(1);
     });
 
-    test('markRead delegates to the remote data source', () async {
-      when(() => remote.markRead('n-1')).thenAnswer((_) async {});
+    test('getFeedLocal reads the cache without triggering a sync', () async {
+      final result = await repository.getFeedLocal();
+
+      expect(result, isA<Ok<NotificationsFeed>>());
+      verify(() => local.notifications()).called(1);
+      verify(() => local.activities()).called(1);
+      verifyNever(() => sync.sync());
+    });
+
+    test('markRead queues the read locally and triggers a sync', () async {
+      when(() => local.markReadPending('n-1')).thenAnswer((_) async {});
 
       final result = await repository.markRead('n-1');
 
       expect(result, isA<Ok<void>>());
-      verify(() => remote.markRead('n-1')).called(1);
+      verify(() => local.markReadPending('n-1')).called(1);
+      verify(() => sync.sync()).called(1);
     });
   });
 }

--- a/test/features/notifications/presentation/bloc/notifications_bloc_test.dart
+++ b/test/features/notifications/presentation/bloc/notifications_bloc_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_starter_template/features/notifications/domain/entities/
 import 'package:flutter_starter_template/features/notifications/domain/entities/notifications_feed.dart';
 import 'package:flutter_starter_template/features/notifications/domain/entities/user_activity.dart';
 import 'package:flutter_starter_template/features/notifications/domain/usecases/get_notifications_feed.dart';
+import 'package:flutter_starter_template/features/notifications/domain/usecases/get_notifications_feed_local.dart';
 import 'package:flutter_starter_template/features/notifications/domain/usecases/mark_notification_read.dart';
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_bloc.dart';
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_state.dart';
@@ -13,11 +14,16 @@ import '../../../../test_utils.dart';
 
 class MockGetNotificationsFeed extends Mock implements GetNotificationsFeed {}
 
+class MockGetNotificationsFeedLocal extends Mock
+    implements GetNotificationsFeedLocal {}
+
 class MockMarkNotificationRead extends Mock implements MarkNotificationRead {}
 
 void main() {
   late MockGetNotificationsFeed getFeed;
+  late MockGetNotificationsFeedLocal getFeedLocal;
   late MockMarkNotificationRead markRead;
+  late MockNotificationsSyncController sync;
 
   final now = DateTime(2026, 6, 1, 12);
   late AppNotification unreadNotification;
@@ -29,11 +35,14 @@ void main() {
 
   setUp(() {
     getFeed = MockGetNotificationsFeed();
+    getFeedLocal = MockGetNotificationsFeedLocal();
     markRead = MockMarkNotificationRead();
+    sync = MockNotificationsSyncController();
     activityNotifier = MockActivityNotifier();
     when(
       () => activityNotifier.onActivityOccurred,
     ).thenAnswer((_) => const Stream.empty());
+    when(() => sync.onSynced).thenAnswer((_) => const Stream.empty());
 
     unreadNotification = AppNotification(
       id: 'n-1',
@@ -63,8 +72,13 @@ void main() {
     );
   });
 
-  NotificationsBloc buildBloc() =>
-      NotificationsBloc(getFeed, markRead, activityNotifier);
+  NotificationsBloc buildBloc() => NotificationsBloc(
+    getFeed,
+    getFeedLocal,
+    markRead,
+    activityNotifier,
+    sync,
+  );
 
   group('NotificationsBloc', () {
     test('initial state is empty', () {
@@ -161,6 +175,26 @@ void main() {
               !state.notifications.first.isRead && state.unreadCount == 1,
         ),
       ],
+    );
+
+    blocTest<NotificationsBloc, NotificationsState>(
+      'silently refreshes from the cache after a sync completes',
+      setUp: () {
+        when(() => getFeedLocal()).thenAnswer((_) async => Ok(feed));
+        when(() => sync.onSynced).thenAnswer((_) => Stream.value(null));
+      },
+      build: buildBloc,
+      expect: () => [
+        predicate<NotificationsState>(
+          (state) =>
+              !state.isLoading &&
+              state.notifications.length == 2 &&
+              state.activities.length == 1,
+        ),
+      ],
+      verify: (_) {
+        verify(() => getFeedLocal()).called(1);
+      },
     );
 
     blocTest<NotificationsBloc, NotificationsState>(

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -14,6 +14,7 @@ import 'package:flutter_starter_template/features/bookmarks/domain/usecases/get_
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_bookmarks.dart';
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_local_bookmarks.dart';
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/update_bookmark.dart';
+import 'package:flutter_starter_template/features/notifications/domain/services/notifications_sync_controller.dart';
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_bloc.dart';
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_state.dart';
 import 'package:flutter_starter_template/shared/domain/activity_notifier.dart';
@@ -56,6 +57,9 @@ class MockDeleteBookmark extends Mock implements DeleteBookmark {}
 
 class MockBookmarksSyncController extends Mock
     implements BookmarksSyncController {}
+
+class MockNotificationsSyncController extends Mock
+    implements NotificationsSyncController {}
 
 class FakeBookmarkInput extends Fake implements BookmarkInput {}
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -21,6 +21,7 @@ import 'test_utils.dart';
 void main() {
   late StreamController<BookmarksSyncStatus> syncStatusController;
   late MockBookmarksSyncController sync;
+  late MockNotificationsSyncController notificationsSync;
   late MockAnalyticsService analytics;
   late AuthBloc authBloc;
   late ThemeBloc themeBloc;
@@ -56,6 +57,14 @@ void main() {
     when(() => sync.start()).thenAnswer((_) async {});
     when(() => sync.stop()).thenAnswer((_) async {});
     when(() => sync.sync()).thenAnswer((_) async {});
+
+    notificationsSync = MockNotificationsSyncController();
+    when(
+      () => notificationsSync.onSynced,
+    ).thenAnswer((_) => const Stream.empty());
+    when(() => notificationsSync.start()).thenAnswer((_) async {});
+    when(() => notificationsSync.stop()).thenAnswer((_) async {});
+    when(() => notificationsSync.sync()).thenAnswer((_) async {});
 
     final bookmarkStats = MockBookmarkStatsReader();
     when(
@@ -99,6 +108,7 @@ void main() {
         authBloc: authBloc,
         themeBloc: themeBloc,
         bookmarksSync: sync,
+        notificationsSync: notificationsSync,
         navigatorObservers: const [],
         videoPlayerService: MockVideoPlayerService(),
       ),


### PR DESCRIPTION
## Summary

Two related changes to the notifications page, in two commits:

1. **Redesign the feed UI** to match the minimalist reference design.
2. **Make the feed offline-first** so it works without (or with flaky) network.

### 1. UI redesign
- Group the notifications tab into **New** (unread) and **Earlier** (read) sections with uppercase section labels.
- Unread notifications get a prominent elevated card (accent-tinted border + soft ambient shadow + unread dot); read ones get a quieter flat bordered card.
- All colors come from the theme, so it stays dark-mode aware.
- Added `notificationsSectionNew` / `notificationsSectionEarlier` strings (en + vi).

### 2. Offline-first
Previously the feature was **remote-only**: `getFeed()` always hit the API, so an offline launch showed nothing and a "mark read" tap was lost if the request failed. Now it mirrors the bookmarks offline-first stack, scaled down for read-mostly data (no create/update/delete to sync):

- Cache notifications + activity in ObjectBox (`NotificationEntity` with a `pendingRead` flag, `ActivityEntity`).
- Reads serve the local cache immediately, then refresh in the background.
- `markRead` commits locally first and queues the read-mark; a lightweight sync service flushes pending reads, then pulls/merges both lists (preserving unpushed reads). Triggered on app start (post-auth) and on offline→online.
- The bloc re-reads the cache after each sync cycle so server-side changes appear without a manual pull-to-refresh.

| | Before | After |
|---|---|---|
| Offline launch | error / empty | renders cached feed |
| Read path | network-only | cache-first, then background refresh |
| Mark read | server-only, lost if offline | local-first + queued, pushed on reconnect |
| Server-side changes | only on manual refresh | auto-applied after each sync |

## Notes
- The reference's per-card View/Dismiss buttons were intentionally omitted — `AppNotification` has no action model, so they'd be non-functional.
- `objectbox-model.json` / `objectbox.g.dart` are committed (stable entity IDs); `injection.config.dart` stays git-ignored and is regenerated in CI, consistent with the existing project setup.

## Testing
- `flutter analyze` clean; codegen (`build_runner`) regenerated ObjectBox model + DI.
- Full suite **187 tests pass**, including new coverage for the cache-backed repo, queued read-marks, and the post-sync silent refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline-first notifications: instant local cache with background sync and sync-driven refreshes.
  * Activity log surfaced alongside notifications.
  * Notifications now grouped into "New" and "Earlier" sections.

* **Improvements**
  * Distinct read/unread card designs and improved animations.
  * Mark-as-read works offline (queued) and syncs in background; views refresh silently after syncs.

* **Localization**
  * Added English and Vietnamese labels for notification sections.

* **Tests**
  * Test coverage updated to exercise local cache and sync behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->