### PR TITLE
Redesign profile settings into bento cards

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_about.dart
+++ b/lib/features/profile/presentation/widgets/profile_about.dart
@@ -1,5 +1,17 @@
 part of 'profile_widgets.dart';
 
+class _AboutCard extends StatelessWidget {
+  const _AboutCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return _SettingsCard(
+      title: context.l10n.profileSectionAbout,
+      child: const _AppInfoTile(),
+    );
+  }
+}
+
 class _AppInfoTile extends StatelessWidget {
   const _AppInfoTile();
 

--- a/lib/features/profile/presentation/widgets/profile_account.dart
+++ b/lib/features/profile/presentation/widgets/profile_account.dart
@@ -1,5 +1,25 @@
 part of 'profile_widgets.dart';
 
+class _AccountCard extends StatelessWidget {
+  const _AccountCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return _SettingsCard(
+      title: context.l10n.profileSectionAccount,
+      child: const Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _ChangePasswordTile(),
+          _SettingsDivider(),
+          _DeleteAccountTile(),
+          SizedBox(height: AppSpacing.xs),
+        ],
+      ),
+    );
+  }
+}
+
 class _ChangePasswordTile extends StatelessWidget {
   const _ChangePasswordTile();
 

--- a/lib/features/profile/presentation/widgets/profile_appearance.dart
+++ b/lib/features/profile/presentation/widgets/profile_appearance.dart
@@ -1,5 +1,29 @@
 part of 'profile_widgets.dart';
 
+class _AppearanceCard extends StatelessWidget {
+  const _AppearanceCard();
+
+  @override
+  Widget build(BuildContext context) {
+    return _SettingsCard(
+      title: context.l10n.profileSectionAppearance,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _SubLabel(context.l10n.profileAppearanceThemeLabel),
+          const _ThemeModeSelector(),
+          const _SettingsDivider(),
+          _SubLabel(context.l10n.profileAppearanceColorLabel),
+          const SizedBox(height: AppSpacing.xs),
+          const _ColorSchemeSelector(),
+          const SizedBox(height: AppSpacing.lg),
+        ],
+      ),
+    );
+  }
+}
+
 class _ThemeModeSelector extends StatelessWidget {
   const _ThemeModeSelector();
 

--- a/lib/features/profile/presentation/widgets/profile_header.dart
+++ b/lib/features/profile/presentation/widgets/profile_header.dart
@@ -5,36 +5,47 @@ class _ProfileHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    final theme = context.theme;
     final session = SessionScope.of(context);
-    return ListenableBuilder(
-      listenable: session,
-      builder: (context, _) {
-        final user = session.currentUser;
-        final username = user?.username ?? '';
-        final initial = username.isNotEmpty ? username[0].toUpperCase() : '?';
-        return Column(
-          children: [
-            CircleAvatar(
-              radius: 48,
-              backgroundColor: theme.colorScheme.primaryContainer,
-              child: Text(
-                initial,
-                style: theme.textTheme.headlineMedium?.copyWith(
-                  color: theme.colorScheme.onPrimaryContainer,
+    return _SettingsCard(
+      child: ListenableBuilder(
+        listenable: session,
+        builder: (context, _) {
+          final user = session.currentUser;
+          final username = user?.username ?? '';
+          final initial = username.isNotEmpty ? username[0].toUpperCase() : '?';
+          return Padding(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.lg,
+              vertical: AppSpacing.xl,
+            ),
+            child: Column(
+              children: [
+                CircleAvatar(
+                  radius: 44,
+                  backgroundColor: theme.colorScheme.primaryContainer,
+                  child: Text(
+                    initial,
+                    style: theme.textTheme.headlineMedium?.copyWith(
+                      color: theme.colorScheme.onPrimaryContainer,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ).animateScale(),
+                const SizedBox(height: AppSpacing.md),
+                Text(
+                  username,
+                  style: theme.textTheme.titleLarge?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
                 ),
-              ),
-            ).animateScale(),
-            const SizedBox(height: AppSpacing.md),
-            Text(
-              username,
-              style: theme.textTheme.titleLarge,
-            ).animateSlideDown(delay: 150.ms),
-            const SizedBox(height: AppSpacing.xs),
-            _CopyableId(id: user?.id ?? '').animateFadeIn(delay: 250.ms),
-          ],
-        );
-      },
+                const SizedBox(height: AppSpacing.xs),
+                _CopyableId(id: user?.id ?? ''),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 }
@@ -78,32 +89,6 @@ class _CopyableId extends StatelessWidget {
               color: theme.colorScheme.onSurfaceVariant,
             ),
           ],
-        ),
-      ),
-    );
-  }
-}
-
-class _SectionLabel extends StatelessWidget {
-  const _SectionLabel(this.text);
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(
-        AppSpacing.xl,
-        AppSpacing.xs,
-        AppSpacing.xl,
-        AppSpacing.sm,
-      ),
-      child: Text(
-        text.toUpperCase(),
-        style: theme.textTheme.labelSmall?.copyWith(
-          color: theme.colorScheme.primary,
-          letterSpacing: 0.8,
         ),
       ),
     );

--- a/lib/features/profile/presentation/widgets/profile_header.dart
+++ b/lib/features/profile/presentation/widgets/profile_header.dart
@@ -76,10 +76,13 @@ class _CopyableId extends StatelessWidget {
         child: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              id,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+            Expanded(
+              child: Text(
+                id,
+                maxLines: 1,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
             const SizedBox(width: AppSpacing.xs),

--- a/lib/features/profile/presentation/widgets/profile_widgets.dart
+++ b/lib/features/profile/presentation/widgets/profile_widgets.dart
@@ -46,32 +46,134 @@ class ProfileBody extends StatelessWidget {
         title: context.l10n.profileAppBarTitle,
         padding: EdgeInsets.zero,
         body: ListView(
-          padding: const EdgeInsets.symmetric(vertical: AppSpacing.lg),
+          padding: const EdgeInsets.fromLTRB(
+            AppSpacing.xl,
+            AppSpacing.lg,
+            AppSpacing.xl,
+            AppSpacing.xxxl,
+          ),
           children: [
-            const _ProfileHeader(),
+            const _ProfileHeader().animateSlideDown(),
+            const SizedBox(height: AppSpacing.lg),
+            const _AccountCard().animateSlideUp(delay: 120.ms),
+            const SizedBox(height: AppSpacing.lg),
+            const _AppearanceCard().animateSlideUp(delay: 200.ms),
+            const SizedBox(height: AppSpacing.lg),
+            const _AboutCard().animateSlideUp(delay: 280.ms),
             const SizedBox(height: AppSpacing.xxl),
-            _SectionLabel(
-              context.l10n.profileSectionAccount,
-            ).animateSlideRight(delay: 300.ms),
-            const _ChangePasswordTile().animateSlideRight(delay: 325.ms),
-            const _DeleteAccountTile().animateSlideRight(delay: 340.ms),
-            const SizedBox(height: AppSpacing.xxl),
-            _SectionLabel(
-              context.l10n.profileSectionAppearance,
-            ).animateSlideRight(delay: 350.ms),
-            const _ThemeModeSelector().animateSlideRight(delay: 375.ms),
-            const SizedBox(height: AppSpacing.sm),
-            const _ColorSchemeSelector().animateSlideRight(delay: 400.ms),
-            const SizedBox(height: AppSpacing.xxl),
-            _SectionLabel(
-              context.l10n.profileSectionAbout,
-            ).animateSlideRight(delay: 425.ms),
-            const _AppInfoTile().animateSlideRight(delay: 450.ms),
-            const SizedBox(height: AppSpacing.xxxl),
-            const _SignOutButton().animateSlideUp(delay: 500.ms),
+            const _SignOutButton().animateFadeIn(delay: 360.ms),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Bento-style surface used to group related settings: a white (lowest-tone)
+/// rounded card with a soft ambient shadow, optionally led by a [title].
+class _SettingsCard extends StatelessWidget {
+  const _SettingsCard({required this.child, this.title});
+
+  final Widget child;
+  final String? title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+    final isLight = theme.brightness == Brightness.light;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        boxShadow: [
+          BoxShadow(
+            color: const Color(
+              0xFF0A192F,
+            ).withValues(alpha: isLight ? 0.05 : 0.2),
+            blurRadius: 20,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Material(
+        color: theme.colorScheme.surfaceContainerLowest,
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+        clipBehavior: Clip.antiAlias,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (title != null) _CardTitle(title!),
+            child,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _CardTitle extends StatelessWidget {
+  const _CardTitle(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.lg,
+        AppSpacing.lg,
+        AppSpacing.xs,
+      ),
+      child: Text(
+        text,
+        style: context.textTheme.titleMedium?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+}
+
+/// Small uppercase caption used to label a group of controls inside a card.
+class _SubLabel extends StatelessWidget {
+  const _SubLabel(this.text);
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = context.theme;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppSpacing.lg,
+        AppSpacing.sm,
+        AppSpacing.lg,
+        AppSpacing.xs,
+      ),
+      child: Text(
+        text.toUpperCase(),
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: theme.colorScheme.onSurfaceVariant,
+          letterSpacing: 0.8,
+        ),
+      ),
+    );
+  }
+}
+
+/// Hairline separator between rows within a [_SettingsCard].
+class _SettingsDivider extends StatelessWidget {
+  const _SettingsDivider();
+
+  @override
+  Widget build(BuildContext context) {
+    return Divider(
+      height: 1,
+      thickness: 1,
+      indent: AppSpacing.lg,
+      endIndent: AppSpacing.lg,
+      color: context.colorScheme.outlineVariant.withValues(alpha: 0.4),
     );
   }
 }

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -170,6 +170,8 @@
   "changePasswordMismatchError": "New passwords do not match.",
   "profileSectionAbout": "About",
   "profileUserIdCopied": "User ID copied",
+  "profileAppearanceThemeLabel": "Theme",
+  "profileAppearanceColorLabel": "Accent color",
   "profileThemeSystemDefault": "System default",
   "profileThemeLight": "Light",
   "profileThemeDark": "Dark",

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -668,6 +668,18 @@ abstract class AppLocalizations {
   /// **'User ID copied'**
   String get profileUserIdCopied;
 
+  /// No description provided for @profileAppearanceThemeLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Theme'**
+  String get profileAppearanceThemeLabel;
+
+  /// No description provided for @profileAppearanceColorLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Accent color'**
+  String get profileAppearanceColorLabel;
+
   /// No description provided for @profileThemeSystemDefault.
   ///
   /// In en, this message translates to:

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -314,6 +314,12 @@ class AppLocalizationsEn extends AppLocalizations {
   String get profileUserIdCopied => 'User ID copied';
 
   @override
+  String get profileAppearanceThemeLabel => 'Theme';
+
+  @override
+  String get profileAppearanceColorLabel => 'Accent color';
+
+  @override
   String get profileThemeSystemDefault => 'System default';
 
   @override

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -314,6 +314,12 @@ class AppLocalizationsVi extends AppLocalizations {
   String get profileUserIdCopied => 'Đã sao chép ID người dùng';
 
   @override
+  String get profileAppearanceThemeLabel => 'Chủ đề';
+
+  @override
+  String get profileAppearanceColorLabel => 'Màu nhấn';
+
+  @override
   String get profileThemeSystemDefault => 'Mặc định hệ thống';
 
   @override

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -111,6 +111,8 @@
   "changePasswordMismatchError": "Mật khẩu mới không khớp.",
   "profileSectionAbout": "Giới thiệu",
   "profileUserIdCopied": "Đã sao chép ID người dùng",
+  "profileAppearanceThemeLabel": "Chủ đề",
+  "profileAppearanceColorLabel": "Màu nhấn",
   "profileThemeSystemDefault": "Mặc định hệ thống",
   "profileThemeLight": "Sáng",
   "profileThemeDark": "Tối",


### PR DESCRIPTION
## What

Reworks the Profile/Settings screen into a **"Digital Zen" bento-card** layout, replacing the flat section-label list. Only real, wired-up content is surfaced — no placeholder stats/collections/plan from the reference mock.

### Structure
- **`_SettingsCard`** — reusable lowest-tone rounded-16 surface with a soft ambient shadow (`0px 4px 20px rgba(10,25,47,0.05)`), ink clipped to corners, optional title. Plus `_SubLabel` and `_SettingsDivider` helpers.
- **Header card** — avatar, username, copyable user-ID.
- **Account card** — Change Password + Delete Account, divider-separated.
- **Appearance card** — "Theme" (mode radios) and "Accent color" (scheme swatches) grouped under one card.
- **About card** — app info.
- **Sign out** button below.

Cards stagger in via the existing animation helpers; 20px page gutter.

### l10n
Adds `profileAppearanceThemeLabel` and `profileAppearanceColorLabel` (en + vi), regenerated localizations.

## Test plan
- `flutter analyze` → no issues
- Profile widget/bloc tests pass
- All existing behavior preserved: copy ID, change password, delete-account dialog, theme/scheme switching, sign out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned profile page with a new card-based layout for better organization and visual clarity
  * Added appearance customization section with theme and accent color selector options

* **Style**
  * Restructured profile sections (header, account, appearance, about) with improved spacing and visual hierarchy
  * Refined profile header styling with adjusted avatar size and typography
  * Simplified animations for a cleaner user experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->