### PR TITLE
Replace mock Featured Collections with a real Collections feature

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -162,6 +162,7 @@ void main() {
 
     // Both sync controllers started for the now-authenticated session.
     verify(() => sync.start()).called(greaterThanOrEqualTo(1));
+    verify(() => collectionsSync.start()).called(greaterThanOrEqualTo(1));
     verify(() => notificationsSync.start()).called(greaterThanOrEqualTo(1));
   });
 }

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_st
 import 'package:flutter_starter_template/features/bookmarks/domain/services/bookmarks_sync_controller.dart';
 import 'package:flutter_starter_template/features/home/presentation/bloc/home_bloc.dart';
 import 'package:flutter_starter_template/shared/domain/bookmark_stats.dart';
+import 'package:flutter_starter_template/shared/domain/collections.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:storage/storage.dart';
@@ -23,6 +24,7 @@ void main() {
 
   late StreamController<BookmarksSyncStatus> syncStatusController;
   late MockBookmarksSyncController sync;
+  late MockCollectionsSyncController collectionsSync;
   late MockNotificationsSyncController notificationsSync;
   late MockAnalyticsService analytics;
   late AuthBloc authBloc;
@@ -58,6 +60,11 @@ void main() {
     when(() => sync.stop()).thenAnswer((_) async {});
     when(() => sync.sync()).thenAnswer((_) async {});
 
+    collectionsSync = MockCollectionsSyncController();
+    when(() => collectionsSync.start()).thenAnswer((_) async {});
+    when(() => collectionsSync.stop()).thenAnswer((_) async {});
+    when(() => collectionsSync.sync()).thenAnswer((_) async {});
+
     notificationsSync = MockNotificationsSyncController();
     when(
       () => notificationsSync.onSynced,
@@ -71,6 +78,11 @@ void main() {
       bookmarkStats.call,
     ).thenAnswer((_) async => const Ok(BookmarkStats()));
 
+    final collectionsReader = MockCollectionsReader();
+    when(
+      collectionsReader.call,
+    ).thenAnswer((_) async => const Ok<List<CollectionSummary>>([]));
+
     authBloc = AuthBloc(
       signIn: signIn,
       register: MockRegister(),
@@ -81,7 +93,7 @@ void main() {
     themeBloc = ThemeBloc(await SharedPreferences.getInstance(), analytics);
 
     getIt.registerFactory<HomeBloc>(() {
-      final bloc = HomeBloc(bookmarkStats);
+      final bloc = HomeBloc(bookmarkStats, collectionsReader);
       homeBloc = bloc;
       return bloc;
     });
@@ -113,6 +125,7 @@ void main() {
         authBloc: authBloc,
         themeBloc: themeBloc,
         bookmarksSync: sync,
+        collectionsSync: collectionsSync,
         notificationsSync: notificationsSync,
         navigatorObservers: const [],
         videoPlayerService: MockVideoPlayerService(),

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -13,6 +13,7 @@ import '../features/auth/presentation/auth_session.dart';
 import '../features/auth/presentation/bloc/auth_bloc.dart';
 import '../features/auth/presentation/bloc/auth_state.dart';
 import '../features/bookmarks/domain/services/bookmarks_sync_controller.dart';
+import '../features/collections/domain/services/collections_sync_controller.dart';
 import '../features/notifications/domain/services/notifications_sync_controller.dart';
 import '../l10n/app_localizations.dart';
 import '../shared/domain/session.dart';
@@ -26,6 +27,7 @@ class App extends StatefulWidget {
     this.authBloc,
     this.themeBloc,
     this.bookmarksSync,
+    this.collectionsSync,
     this.notificationsSync,
     this.navigatorObservers,
     this.session,
@@ -35,6 +37,7 @@ class App extends StatefulWidget {
   final AuthBloc? authBloc;
   final ThemeBloc? themeBloc;
   final BookmarksSyncController? bookmarksSync;
+  final CollectionsSyncController? collectionsSync;
   final NotificationsSyncController? notificationsSync;
   final List<NavigatorObserver>? navigatorObservers;
   final Session? session;
@@ -51,6 +54,7 @@ class _AppState extends State<App> {
   late final GoRouter _router;
   late final DeepLinkState _deepLink;
   late final BookmarksSyncController _sync;
+  late final CollectionsSyncController _collectionsSync;
   late final NotificationsSyncController _notificationsSync;
   late final VideoPlayerService _videoPlayerService;
   StreamSubscription<AuthState>? _authSub;
@@ -68,6 +72,8 @@ class _AppState extends State<App> {
     _router = result.router;
     _deepLink = result.deepLink;
     _sync = widget.bookmarksSync ?? getIt<BookmarksSyncController>();
+    _collectionsSync =
+        widget.collectionsSync ?? getIt<CollectionsSyncController>();
     _notificationsSync =
         widget.notificationsSync ?? getIt<NotificationsSyncController>();
     _videoPlayerService =
@@ -80,9 +86,11 @@ class _AppState extends State<App> {
   void _onAuthChanged(AuthState state) {
     if (state is AuthAuthenticated) {
       _sync.start();
+      _collectionsSync.start();
       _notificationsSync.start();
     } else {
       _sync.stop();
+      _collectionsSync.stop();
       _notificationsSync.stop();
     }
   }
@@ -91,6 +99,7 @@ class _AppState extends State<App> {
   void dispose() {
     _authSub?.cancel();
     _sync.stop();
+    _collectionsSync.stop();
     _notificationsSync.stop();
     _session.dispose();
     _router.dispose();

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -11,6 +11,9 @@ import '../features/auth/presentation/screens/register_screen.dart';
 import '../features/bookmarks/presentation/screens/bookmark_detail_screen.dart';
 import '../features/bookmarks/presentation/screens/bookmark_form_screen.dart';
 import '../features/bookmarks/presentation/screens/bookmarks_list_screen.dart';
+import '../features/collections/presentation/screens/collection_detail_screen.dart';
+import '../features/collections/presentation/screens/collection_form_screen.dart';
+import '../features/collections/presentation/screens/collections_list_screen.dart';
 import '../features/home/presentation/screens/home_screen.dart';
 import '../features/notifications/presentation/screens/notifications_screen.dart';
 import '../features/profile/presentation/screens/profile_screen.dart';
@@ -196,6 +199,60 @@ class BookmarkEditRoute extends GoRouteData with $BookmarkEditRoute {
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       BookmarkFormScreen(id: id);
+}
+
+/// Route data for the standalone collections browser.
+@TypedGoRoute<CollectionsListRoute>(path: '/collections', name: 'collections')
+class CollectionsListRoute extends GoRouteData with $CollectionsListRoute {
+  const CollectionsListRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const CollectionsListScreen();
+}
+
+/// Route data for creating a collection. Declared above the `:id` route so the
+/// literal `new` segment matches first.
+@TypedGoRoute<CollectionNewRoute>(
+  path: '/collections/new',
+  name: 'collection_new',
+)
+class CollectionNewRoute extends GoRouteData with $CollectionNewRoute {
+  const CollectionNewRoute();
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      const CollectionFormScreen();
+}
+
+/// Route data for the collection detail, shown full-screen (no shell).
+@TypedGoRoute<CollectionDetailRoute>(
+  path: '/collections/:id',
+  name: 'collection_detail',
+)
+class CollectionDetailRoute extends GoRouteData with $CollectionDetailRoute {
+  const CollectionDetailRoute(this.id);
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      CollectionDetailScreen(id: id);
+}
+
+/// Route data for editing a collection, shown full-screen (no shell).
+@TypedGoRoute<CollectionEditRoute>(
+  path: '/collections/:id/edit',
+  name: 'collection_edit',
+)
+class CollectionEditRoute extends GoRouteData with $CollectionEditRoute {
+  const CollectionEditRoute(this.id);
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context, GoRouterState state) =>
+      CollectionFormScreen(id: id);
 }
 
 /// Tracks deep-link targets and splash-screen completion so the redirect can

--- a/lib/features/bookmarks/domain/services/bookmark_summaries_service.dart
+++ b/lib/features/bookmarks/domain/services/bookmark_summaries_service.dart
@@ -1,0 +1,40 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../shared/domain/bookmark_stats.dart';
+import '../../../../shared/domain/bookmark_summaries.dart';
+import '../entities/bookmark.dart';
+import '../usecases/list_bookmarks.dart';
+
+/// Projects every [Bookmark] to a [BookmarkSummary].
+///
+/// Implements the shared [BookmarkSummariesReader] so the collections feature
+/// can resolve member bookmarks without depending on the bookmarks domain.
+@LazySingleton(as: BookmarkSummariesReader)
+class BookmarkSummariesService extends BookmarkSummariesReader {
+  const BookmarkSummariesService(this._listBookmarks);
+
+  final ListBookmarks _listBookmarks;
+
+  @override
+  Future<Result<List<BookmarkSummary>>> call([
+    NoParams param = noParams,
+  ]) async {
+    final result = await _listBookmarks();
+    return switch (result) {
+      Ok(value: final items) => Ok(
+        items.map(_toSummary).toList(growable: false),
+      ),
+      Err(:final failure) => Err(failure),
+    };
+  }
+
+  BookmarkSummary _toSummary(Bookmark bookmark) => BookmarkSummary(
+    id: bookmark.id,
+    title: bookmark.title,
+    url: bookmark.url,
+    description: bookmark.description,
+    tags: bookmark.tags,
+    imageUrls: bookmark.imageUrls,
+  );
+}

--- a/lib/features/bookmarks/presentation/widgets/bookmark_detail_widgets.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmark_detail_widgets.dart
@@ -12,6 +12,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../../../app/di/injection.dart';
 import '../../../../app/router.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../collections/presentation/widgets/add_to_collection_sheet.dart';
 import '../../domain/entities/bookmark.dart';
 import '../bloc/bookmark_detail/bookmark_detail_bloc.dart';
 import '../bloc/bookmark_detail/bookmark_detail_state.dart';
@@ -100,6 +101,11 @@ class BookmarkDetailView extends StatelessWidget {
                       context.read<BookmarkDetailBloc>().add(
                         BookmarkDetailShareRequested(state.bookmark),
                       );
+                    case _DetailAction.addToCollection:
+                      AddToCollectionSheet.show(
+                        context,
+                        bookmarkId: state.bookmark.id,
+                      );
                     case _DetailAction.edit:
                       _openEditor(context);
                     case _DetailAction.delete:
@@ -112,6 +118,13 @@ class BookmarkDetailView extends StatelessWidget {
                     child: _MenuItem(
                       icon: FontAwesomeIcons.shareNodes,
                       label: l10n.commonShare,
+                    ),
+                  ),
+                  PopupMenuItem(
+                    value: _DetailAction.addToCollection,
+                    child: _MenuItem(
+                      icon: FontAwesomeIcons.layerGroup,
+                      label: l10n.addToCollectionTitle,
                     ),
                   ),
                   PopupMenuItem(
@@ -578,7 +591,7 @@ class _DetailCard extends StatelessWidget {
 }
 
 /// Overflow-menu actions on the detail app bar.
-enum _DetailAction { share, edit, delete }
+enum _DetailAction { share, addToCollection, edit, delete }
 
 /// A single row in the app-bar overflow menu: leading icon + label.
 class _MenuItem extends StatelessWidget {

--- a/lib/features/bookmarks/presentation/widgets/bookmarks_list_master.dart
+++ b/lib/features/bookmarks/presentation/widgets/bookmarks_list_master.dart
@@ -5,6 +5,7 @@ import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
 import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../collections/presentation/widgets/collections_list_view.dart';
 import '../../domain/entities/bookmark.dart';
 import '../bloc/bookmarks_list/bookmarks_list_bloc.dart';
 import '../bloc/bookmarks_list/bookmarks_list_state.dart';
@@ -13,8 +14,9 @@ import 'bookmarks_list_card.dart';
 
 /// The bookmark browsing tabs shown above the grid.
 ///
-/// [collections] has no backing data model yet and renders a "coming soon"
-/// placeholder; [recent] filters to bookmarks created within the last week.
+/// [collections] embeds the collections feature's self-contained list view (a
+/// single-consumer capability); [recent] filters to bookmarks created within
+/// the last week.
 enum BookmarkTab { all, recent, collections }
 
 /// How recent a bookmark must be to appear under [BookmarkTab.recent].
@@ -53,6 +55,12 @@ class BookmarksListMaster extends StatelessWidget {
         Expanded(
           child: BlocBuilder<BookmarksListBloc, BookmarksListState>(
             builder: (context, state) {
+              // The collections tab owns its own data/state, so it short-
+              // circuits before the bookmark loading/error guards below.
+              if (activeTab == BookmarkTab.collections) {
+                return const CollectionsListView();
+              }
+
               if (state.isLoading && state.items.isEmpty) {
                 return const AppSkeletonList(hasLeading: false);
               }
@@ -63,10 +71,6 @@ class BookmarksListMaster extends StatelessWidget {
                     const BookmarksListLoadRequested(),
                   ),
                 );
-              }
-
-              if (activeTab == BookmarkTab.collections) {
-                return _CollectionsComingSoon();
               }
 
               final visible = _itemsForTab(state.visibleItems, activeTab);
@@ -273,17 +277,6 @@ class _BookmarksSearchField extends StatelessWidget {
         ),
       ),
     ).animateSlideDown(duration: 300.ms);
-  }
-}
-
-class _CollectionsComingSoon extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return AppEmptyView(
-      icon: FontAwesomeIcons.layerGroup,
-      title: context.l10n.bookmarksCollectionsComingSoonTitle,
-      message: context.l10n.bookmarksCollectionsComingSoonMessage,
-    );
   }
 }
 

--- a/lib/features/collections/data/datasources/collections_remote_data_source.dart
+++ b/lib/features/collections/data/datasources/collections_remote_data_source.dart
@@ -1,0 +1,27 @@
+import 'package:network/network.dart';
+
+import '../models/collection_dto.dart';
+import '../models/collection_request.dart';
+
+part 'collections_remote_data_source.g.dart';
+
+@RestApi()
+abstract class CollectionsRemoteDataSource {
+  factory CollectionsRemoteDataSource(Dio dio, {String baseUrl}) =
+      _CollectionsRemoteDataSource;
+
+  @GET('/api/collections')
+  Future<List<CollectionDto>> list();
+
+  @POST('/api/collections')
+  Future<CollectionDto> create(@Body() CollectionRequest body);
+
+  @PUT('/api/collections/{id}')
+  Future<CollectionDto> update(
+    @Path('id') String id,
+    @Body() CollectionRequest body,
+  );
+
+  @DELETE('/api/collections/{id}')
+  Future<void> delete(@Path('id') String id);
+}

--- a/lib/features/collections/data/datasources/collections_remote_module.dart
+++ b/lib/features/collections/data/datasources/collections_remote_module.dart
@@ -1,0 +1,11 @@
+import 'package:injectable/injectable.dart';
+import 'package:network/network.dart';
+
+import 'collections_remote_data_source.dart';
+
+@module
+abstract class CollectionsRemoteModule {
+  @lazySingleton
+  CollectionsRemoteDataSource provideCollectionsRemoteDataSource(Dio dio) =>
+      CollectionsRemoteDataSource(dio);
+}

--- a/lib/features/collections/data/local/collection_entity.dart
+++ b/lib/features/collections/data/local/collection_entity.dart
@@ -1,0 +1,107 @@
+import 'package:objectbox/objectbox.dart' hide SyncState;
+
+import '../../domain/entities/collection.dart';
+
+/// Sync lifecycle for a local row. Stored as int via [SyncState.code] so
+/// ObjectBox doesn't need a converter.
+///
+/// Kept local to the collections feature (mirroring the bookmarks feature)
+/// so the data layer stays self-contained rather than reaching across the
+/// feature boundary for a shared enum.
+enum SyncState {
+  synced(0),
+  pendingCreate(1),
+  pendingUpdate(2),
+  pendingDelete(3);
+
+  const SyncState(this.code);
+
+  final int code;
+
+  static SyncState fromCode(int code) {
+    for (final s in SyncState.values) {
+      if (s.code == code) return s;
+    }
+    return SyncState.synced;
+  }
+
+  bool get isPending => this != SyncState.synced;
+}
+
+/// ObjectBox row for a collection. Mutable by necessity — ObjectBox writes
+/// back into instances during property loading, so this cannot be a
+/// Freezed/sealed class.
+@Entity()
+class CollectionEntity {
+  CollectionEntity({
+    this.id = 0,
+    required this.uuid,
+    required this.name,
+    required this.icon,
+    required this.color,
+    required this.bookmarkIds,
+    required this.createdAt,
+    required this.updatedAt,
+    this.serverUpdatedAt,
+    this.syncStateCode = 0,
+  });
+
+  /// ObjectBox primary key. Internal — never exposed to the domain layer.
+  /// 0 means "new"; ObjectBox assigns it on first `put`.
+  @Id()
+  int id;
+
+  /// Stable string ID used by the domain layer and by the server. Generated
+  /// client-side at create time so the row has a meaningful id before the
+  /// first successful sync.
+  @Unique()
+  String uuid;
+
+  String name;
+  String icon;
+  int color;
+  List<String> bookmarkIds;
+
+  /// Stored and read back as UTC. Domain layer handles any presentation-time
+  /// conversion to local.
+  @Property(type: PropertyType.dateNanoUtc)
+  DateTime createdAt;
+
+  /// Local mutation time — bumped on any local change. Compared against
+  /// [serverUpdatedAt] on pull to implement last-write-wins.
+  @Property(type: PropertyType.dateNanoUtc)
+  DateTime updatedAt;
+
+  /// Server's view of `updatedAt` at the time of the last successful pull/push.
+  /// `null` for rows that haven't been synced yet (pendingCreate).
+  @Property(type: PropertyType.dateNanoUtc)
+  DateTime? serverUpdatedAt;
+
+  /// Stored form of [syncState]. Use the [syncState] getter/setter instead.
+  int syncStateCode;
+
+  @Transient()
+  SyncState get syncState => SyncState.fromCode(syncStateCode);
+  set syncState(SyncState value) => syncStateCode = value.code;
+
+  Collection toDomain() => Collection(
+    id: uuid,
+    name: name,
+    icon: icon,
+    color: color,
+    bookmarkIds: List.unmodifiable(bookmarkIds),
+    createdAt: createdAt,
+    updatedAt: updatedAt,
+    isPendingSync: syncState.isPending,
+  );
+
+  /// Mutates this entity from a [CollectionInput] for create/update flows.
+  /// Bumps `updatedAt`; leaves `createdAt` alone so updates preserve it.
+  void applyInput(CollectionInput input, {required DateTime now}) {
+    name = input.name;
+    icon = input.icon;
+    color = input.color;
+    bookmarkIds = List.of(input.bookmarkIds);
+    updatedAt = now;
+  }
+}

--- a/lib/features/collections/data/local/collections_local_data_source.dart
+++ b/lib/features/collections/data/local/collections_local_data_source.dart
@@ -1,0 +1,109 @@
+import 'package:injectable/injectable.dart' hide Order;
+
+import '../../../../objectbox.g.dart' hide SyncState;
+import 'collection_entity.dart';
+
+/// ObjectBox-backed CRUD + sync helpers. All operations are synchronous on
+/// the ObjectBox side; wrapped in `Future` to keep the repository contract
+/// async-friendly.
+///
+/// Identity at this layer is the string [CollectionEntity.uuid]. The integer
+/// `id` is an internal ObjectBox PK that callers never see.
+abstract interface class CollectionsLocalDataSource {
+  /// All non-tombstoned collections, newest-first.
+  Future<List<CollectionEntity>> listVisible();
+
+  /// Includes tombstoned (pendingDelete) rows. Used by the sync service.
+  Future<List<CollectionEntity>> listAll();
+
+  Future<CollectionEntity?> getByUuid(String uuid);
+
+  /// Rows with any non-synced state, ordered by [CollectionEntity.updatedAt].
+  Future<List<CollectionEntity>> listPending();
+
+  /// Inserts a new row in [SyncState.pendingCreate].
+  Future<CollectionEntity> putNew(CollectionEntity entity);
+
+  /// Persists changes to an existing row. Caller owns sync state changes.
+  Future<void> put(CollectionEntity entity);
+
+  /// Hard-removes by internal PK. Used after a successful pendingDelete push.
+  Future<void> hardDelete(int pk);
+}
+
+@LazySingleton(as: CollectionsLocalDataSource)
+class ObjectBoxCollectionsDataSource implements CollectionsLocalDataSource {
+  ObjectBoxCollectionsDataSource(Store store)
+    : _box = store.box<CollectionEntity>();
+
+  final Box<CollectionEntity> _box;
+
+  @override
+  Future<List<CollectionEntity>> listVisible() async {
+    final query = _box
+        .query(
+          CollectionEntity_.syncStateCode.notEquals(
+            SyncState.pendingDelete.code,
+          ),
+        )
+        .order(CollectionEntity_.createdAt, flags: Order.descending)
+        .build();
+    try {
+      return query.find();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<List<CollectionEntity>> listAll() async {
+    final query = _box
+        .query()
+        .order(CollectionEntity_.createdAt, flags: Order.descending)
+        .build();
+    try {
+      return query.find();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<CollectionEntity?> getByUuid(String uuid) async {
+    final query = _box.query(CollectionEntity_.uuid.equals(uuid)).build();
+    try {
+      return query.findFirst();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<List<CollectionEntity>> listPending() async {
+    final query = _box
+        .query(CollectionEntity_.syncStateCode.notEquals(SyncState.synced.code))
+        .order(CollectionEntity_.updatedAt)
+        .build();
+    try {
+      return query.find();
+    } finally {
+      query.close();
+    }
+  }
+
+  @override
+  Future<CollectionEntity> putNew(CollectionEntity entity) async {
+    _box.put(entity);
+    return entity;
+  }
+
+  @override
+  Future<void> put(CollectionEntity entity) async {
+    _box.put(entity);
+  }
+
+  @override
+  Future<void> hardDelete(int pk) async {
+    _box.remove(pk);
+  }
+}

--- a/lib/features/collections/data/models/collection_dto.dart
+++ b/lib/features/collections/data/models/collection_dto.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'collection_dto.freezed.dart';
+part 'collection_dto.g.dart';
+
+@Freezed(copyWith: false, equal: false)
+abstract class CollectionDto with _$CollectionDto {
+  const factory CollectionDto({
+    required String id,
+    required String name,
+    required String icon,
+    required int color,
+    @JsonKey(name: 'bookmark_ids') @Default([]) List<String> bookmarkIds,
+    @JsonKey(name: 'created_at') required DateTime createdAt,
+    @JsonKey(name: 'updated_at') required DateTime updatedAt,
+  }) = _CollectionDto;
+
+  factory CollectionDto.fromJson(Map<String, dynamic> json) =>
+      _$CollectionDtoFromJson(json);
+}

--- a/lib/features/collections/data/models/collection_request.dart
+++ b/lib/features/collections/data/models/collection_request.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'collection_request.freezed.dart';
+part 'collection_request.g.dart';
+
+/// Wire payload for both create (POST) and update (PUT). The optional `id`
+/// is only used by POST so offline-minted client UUIDs become the server's
+/// canonical id; PUT ignores it (path id wins).
+@Freezed(copyWith: false, equal: false)
+abstract class CollectionRequest with _$CollectionRequest {
+  const factory CollectionRequest({
+    String? id,
+    required String name,
+    required String icon,
+    required int color,
+    @JsonKey(name: 'bookmark_ids') @Default([]) List<String> bookmarkIds,
+  }) = _CollectionRequest;
+
+  factory CollectionRequest.fromJson(Map<String, dynamic> json) =>
+      _$CollectionRequestFromJson(json);
+}

--- a/lib/features/collections/data/repositories/collections_repository_impl.dart
+++ b/lib/features/collections/data/repositories/collections_repository_impl.dart
@@ -1,0 +1,118 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../domain/entities/collection.dart';
+import '../../domain/repositories/collections_repository.dart';
+import '../../domain/services/collections_sync_controller.dart';
+import '../local/collection_entity.dart';
+import '../local/collections_local_data_source.dart';
+
+/// Offline-first: reads always serve from the local ObjectBox store, writes
+/// commit locally first (and mark sync state), then kick a fire-and-forget
+/// sync. The UI gets immediate confirmation regardless of network state.
+@LazySingleton(as: CollectionsRepository)
+class CollectionsRepositoryImpl implements CollectionsRepository {
+  CollectionsRepositoryImpl(this._local, this._sync, this._uuid);
+
+  final CollectionsLocalDataSource _local;
+  final CollectionsSyncController _sync;
+  final Uuid _uuid;
+
+  @override
+  Future<Result<List<Collection>>> list() async {
+    final result = await listLocal();
+    // Trigger a refresh in the background; reads return immediately.
+    _sync.sync().uw();
+    return result;
+  }
+
+  @override
+  Future<Result<List<Collection>>> listLocal() async {
+    final rows = await _local.listVisible();
+    return Ok(rows.map((e) => e.toDomain()).toList(growable: false));
+  }
+
+  @override
+  Future<Result<Collection>> get(String id) async {
+    final row = await _local.getByUuid(id);
+    if (row == null || row.syncState == SyncState.pendingDelete) {
+      return const Err(NotFoundFailure('Collection not found.'));
+    }
+    return Ok(row.toDomain());
+  }
+
+  @override
+  Future<Result<Collection>> create(CollectionInput input) async {
+    final normalized = _normalize(input);
+    final now = DateTime.now().toUtc();
+    final entity = CollectionEntity(
+      uuid: _uuid.v4(),
+      name: normalized.name,
+      icon: normalized.icon,
+      color: normalized.color,
+      bookmarkIds: List.of(normalized.bookmarkIds),
+      createdAt: now,
+      updatedAt: now,
+      syncStateCode: SyncState.pendingCreate.code,
+    );
+    await _local.putNew(entity);
+    _sync.sync().uw();
+    return Ok(entity.toDomain());
+  }
+
+  @override
+  Future<Result<Collection>> update(String id, CollectionInput input) async {
+    final existing = await _local.getByUuid(id);
+    if (existing == null || existing.syncState == SyncState.pendingDelete) {
+      return const Err(NotFoundFailure('Collection not found.'));
+    }
+    final normalized = _normalize(input);
+    existing.applyInput(normalized, now: DateTime.now().toUtc());
+    // pendingCreate stays pendingCreate (still need the initial POST);
+    // synced flips to pendingUpdate.
+    if (existing.syncState == SyncState.synced) {
+      existing.syncState = SyncState.pendingUpdate;
+    }
+    await _local.put(existing);
+    _sync.sync().uw();
+    return Ok(existing.toDomain());
+  }
+
+  @override
+  Future<Result<void>> delete(String id) async {
+    final existing = await _local.getByUuid(id);
+    if (existing == null || existing.syncState == SyncState.pendingDelete) {
+      return const Err(NotFoundFailure('Collection not found.'));
+    }
+    // A pendingCreate that's never been synced can be dropped outright —
+    // the server has never seen it, so there's nothing to tell it.
+    if (existing.syncState == SyncState.pendingCreate) {
+      await _local.hardDelete(existing.id);
+      return const Ok(null);
+    }
+    existing.syncState = SyncState.pendingDelete;
+    existing.updatedAt = DateTime.now().toUtc();
+    await _local.put(existing);
+    _sync.sync().uw();
+    return const Ok(null);
+  }
+
+  /// Trim the name + dedupe bookmark ids so storage matches what the server
+  /// would compute.
+  CollectionInput _normalize(CollectionInput input) {
+    final seen = <String>{};
+    final bookmarkIds = <String>[];
+    for (final raw in input.bookmarkIds) {
+      final id = raw.trim();
+      if (id.isEmpty || !seen.add(id)) continue;
+      bookmarkIds.add(id);
+    }
+    return CollectionInput(
+      name: input.name.trim(),
+      icon: input.icon,
+      color: input.color,
+      bookmarkIds: bookmarkIds,
+    );
+  }
+}

--- a/lib/features/collections/data/sync/collections_pull_reconciler.dart
+++ b/lib/features/collections/data/sync/collections_pull_reconciler.dart
@@ -1,0 +1,57 @@
+import '../datasources/collections_remote_data_source.dart';
+import '../local/collection_entity.dart';
+import '../local/collections_local_data_source.dart';
+
+/// Reconciles the local collection store with the server's latest list.
+class CollectionsPullReconciler {
+  CollectionsPullReconciler(this._local, this._remote);
+
+  final CollectionsLocalDataSource _local;
+  final CollectionsRemoteDataSource _remote;
+
+  Future<void> pull() async {
+    final serverList = await _remote.list();
+    final serverByUuid = {for (final dto in serverList) dto.id: dto};
+    final localByUuid = <String, CollectionEntity>{
+      for (final row in await _local.listAll()) row.uuid: row,
+    };
+
+    for (final dto in serverList) {
+      final local = localByUuid[dto.id];
+      if (local == null) {
+        await _local.put(
+          CollectionEntity(
+            uuid: dto.id,
+            name: dto.name,
+            icon: dto.icon,
+            color: dto.color,
+            bookmarkIds: List.of(dto.bookmarkIds),
+            createdAt: dto.createdAt,
+            updatedAt: dto.updatedAt,
+            serverUpdatedAt: dto.updatedAt,
+            syncStateCode: SyncState.synced.code,
+          ),
+        );
+        continue;
+      }
+
+      if (local.syncState.isPending) continue;
+      if (dto.updatedAt.isAfter(local.updatedAt)) {
+        local
+          ..name = dto.name
+          ..icon = dto.icon
+          ..color = dto.color
+          ..bookmarkIds = List.of(dto.bookmarkIds)
+          ..updatedAt = dto.updatedAt
+          ..serverUpdatedAt = dto.updatedAt;
+        await _local.put(local);
+      }
+    }
+
+    for (final local in localByUuid.values) {
+      if (local.syncState != SyncState.synced) continue;
+      if (serverByUuid.containsKey(local.uuid)) continue;
+      await _local.hardDelete(local.id);
+    }
+  }
+}

--- a/lib/features/collections/data/sync/collections_push_queue.dart
+++ b/lib/features/collections/data/sync/collections_push_queue.dart
@@ -1,0 +1,86 @@
+import 'package:network/network.dart';
+
+import '../datasources/collections_remote_data_source.dart';
+import '../local/collection_entity.dart';
+import '../local/collections_local_data_source.dart';
+import '../models/collection_dto.dart';
+import '../models/collection_request.dart';
+
+/// Pushes pending local collection mutations to the remote API.
+class CollectionsPushQueue {
+  CollectionsPushQueue(this._local, this._remote);
+
+  final CollectionsLocalDataSource _local;
+  final CollectionsRemoteDataSource _remote;
+
+  /// Drains every pending row. Each row is isolated so a single permanently
+  /// rejected row cannot block the rest of the queue. Returns true if any row
+  /// failed and stayed pending.
+  Future<bool> push() async {
+    final pending = await _local.listPending();
+    var hadFailure = false;
+    for (final row in pending) {
+      try {
+        await _pushRow(row);
+      } on Object {
+        hadFailure = true;
+      }
+    }
+    return hadFailure;
+  }
+
+  Future<void> _pushRow(CollectionEntity row) async {
+    switch (row.syncState) {
+      case SyncState.pendingCreate:
+        try {
+          final dto = await _remote.create(
+            CollectionRequest(
+              id: row.uuid,
+              name: row.name,
+              icon: row.icon,
+              color: row.color,
+              bookmarkIds: row.bookmarkIds,
+            ),
+          );
+          _markSynced(row, dto);
+          await _local.put(row);
+        } on DioException catch (e) {
+          // 409: a previous attempt already created this row server-side, but
+          // its response was lost. Pull reconciliation refreshes its fields.
+          if (e.response?.statusCode != 409) rethrow;
+          row.syncState = SyncState.synced;
+          await _local.put(row);
+        }
+      case SyncState.pendingUpdate:
+        final dto = await _remote.update(
+          row.uuid,
+          CollectionRequest(
+            name: row.name,
+            icon: row.icon,
+            color: row.color,
+            bookmarkIds: row.bookmarkIds,
+          ),
+        );
+        _markSynced(row, dto);
+        await _local.put(row);
+      case SyncState.pendingDelete:
+        try {
+          await _remote.delete(row.uuid);
+        } on DioException catch (e) {
+          // 404 is fine: server already lost it. Anything else leaves the row
+          // pending for the next sync.
+          if (e.response?.statusCode != 404) rethrow;
+        }
+        await _local.hardDelete(row.id);
+      case SyncState.synced:
+        break;
+    }
+  }
+
+  void _markSynced(CollectionEntity row, CollectionDto dto) {
+    row
+      ..syncState = SyncState.synced
+      ..serverUpdatedAt = dto.updatedAt
+      ..bookmarkIds = List.of(dto.bookmarkIds);
+  }
+}

--- a/lib/features/collections/data/sync/collections_sync_service.dart
+++ b/lib/features/collections/data/sync/collections_sync_service.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+
+import 'package:architecture/architecture.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:injectable/injectable.dart';
+import 'package:network/network.dart';
+
+import '../../domain/services/collections_sync_controller.dart';
+import '../datasources/collections_remote_data_source.dart';
+import '../local/collections_local_data_source.dart';
+import 'collections_pull_reconciler.dart';
+import 'collections_push_queue.dart';
+
+/// Reconciles the local ObjectBox store with the remote API.
+///
+/// Triggers:
+/// - [sync] is called explicitly on app start (post-auth) and after every
+///   local mutation.
+/// - Connectivity transitions from offline → online (via connectivity_plus).
+///
+/// Strategy:
+/// 1. **Push**: drain every row in [SyncState.pendingCreate/pendingUpdate/
+///    pendingDelete] to the server, marking each `synced` on success. A
+///    failure leaves the row in its pending state so the next trigger retries.
+/// 2. **Pull**: GET the full server list and reconcile by uuid:
+///    - Server-only → insert locally as `synced`.
+///    - Both sides → last-write-wins by `updated_at` (server vs local).
+///    - Local-only synced row not in server payload → server deleted it
+///      elsewhere; remove locally.
+///    - Local-only pendingCreate not in server payload → keep, push next time.
+///
+/// Concurrent calls collapse into one in-flight sync (single-flight).
+@LazySingleton(as: CollectionsSyncController)
+class CollectionsSyncService implements CollectionsSyncController {
+  CollectionsSyncService(
+    CollectionsLocalDataSource local,
+    CollectionsRemoteDataSource remote,
+    this._connectivity,
+  ) : _pushQueue = CollectionsPushQueue(local, remote),
+      _pullReconciler = CollectionsPullReconciler(local, remote);
+
+  final Connectivity _connectivity;
+  final CollectionsPushQueue _pushQueue;
+  final CollectionsPullReconciler _pullReconciler;
+
+  final _status = StreamController<CollectionsSyncStatus>.broadcast();
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySub;
+  Future<void>? _inflight;
+  bool _wasOnline = true;
+  CollectionsSyncStatus _statusNow = CollectionsSyncStatus.idle;
+
+  /// UI subscribes to drive sync indicators. The latest value is also
+  /// available via [statusNow].
+  @override
+  Stream<CollectionsSyncStatus> get statusStream => _status.stream;
+  @override
+  CollectionsSyncStatus get statusNow => _statusNow;
+
+  /// Begin reacting to connectivity changes and run an initial sync. Idempotent.
+  @override
+  Future<void> start() async {
+    if (_connectivitySub != null) return;
+    _connectivitySub = _connectivity.onConnectivityChanged.listen(
+      _onConnectivity,
+    );
+    final initial = await _connectivity.checkConnectivity();
+    _wasOnline = _hasNetwork(initial);
+    sync().uw();
+  }
+
+  /// Stop listening and reset state. Called on sign-out.
+  @override
+  Future<void> stop() async {
+    await _connectivitySub?.cancel();
+    _connectivitySub = null;
+  }
+
+  void _onConnectivity(List<ConnectivityResult> result) {
+    final online = _hasNetwork(result);
+    if (online && !_wasOnline) {
+      sync().uw();
+    }
+    _wasOnline = online;
+  }
+
+  bool _hasNetwork(List<ConnectivityResult> result) =>
+      result.any((r) => r != ConnectivityResult.none);
+
+  /// Public trigger. Concurrent callers share the in-flight future.
+  @override
+  Future<void> sync() {
+    return _inflight ??= _run()..whenComplete(() => _inflight = null);
+  }
+
+  Future<void> _run() async {
+    _emit(CollectionsSyncStatus.syncing);
+    try {
+      final pushHadFailures = await _pushQueue.push();
+      await _pullReconciler.pull();
+      // A failed row keeps its pending state and is retried next trigger; we
+      // still surface `error` so the UI reflects that the sync was incomplete.
+      _emit(
+        pushHadFailures
+            ? CollectionsSyncStatus.error
+            : CollectionsSyncStatus.idle,
+      );
+    } on DioException {
+      // Network/auth error — leave pending rows untouched so the next trigger
+      // retries. Don't propagate; sync is fire-and-forget from callers.
+      _emit(CollectionsSyncStatus.error);
+    } on Object catch (_) {
+      _emit(CollectionsSyncStatus.error);
+    }
+  }
+
+  void _emit(CollectionsSyncStatus s) {
+    _statusNow = s;
+    _status.add(s);
+  }
+}

--- a/lib/features/collections/domain/entities/collection.dart
+++ b/lib/features/collections/domain/entities/collection.dart
@@ -1,0 +1,48 @@
+/// A user-created folder grouping bookmarks by their stable ids.
+class Collection {
+  const Collection({
+    required this.id,
+    required this.name,
+    required this.icon,
+    required this.color,
+    required this.bookmarkIds,
+    required this.createdAt,
+    required this.updatedAt,
+    this.isPendingSync = false,
+  });
+
+  final String id;
+  final String name;
+
+  /// Stable icon token (see `collectionPalette`).
+  final String icon;
+
+  /// ARGB seed color for the collection card gradient.
+  final int color;
+
+  /// Stable ids (bookmark uuids) of the bookmarks in this collection.
+  final List<String> bookmarkIds;
+
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  /// `true` when this collection has local changes not yet pushed to the
+  /// server. UI surfaces a badge for these.
+  final bool isPendingSync;
+
+  int get itemCount => bookmarkIds.length;
+}
+
+class CollectionInput {
+  const CollectionInput({
+    required this.name,
+    required this.icon,
+    required this.color,
+    this.bookmarkIds = const [],
+  });
+
+  final String name;
+  final String icon;
+  final int color;
+  final List<String> bookmarkIds;
+}

--- a/lib/features/collections/domain/repositories/collections_repository.dart
+++ b/lib/features/collections/domain/repositories/collections_repository.dart
@@ -1,0 +1,16 @@
+import 'package:architecture/architecture.dart';
+import '../entities/collection.dart';
+
+abstract interface class CollectionsRepository {
+  Future<Result<List<Collection>>> list();
+
+  /// Reads the local store without triggering a background sync.
+  ///
+  /// Used for re-reads that follow a sync cycle, so reloading the freshly
+  /// pulled data does not kick off yet another sync.
+  Future<Result<List<Collection>>> listLocal();
+  Future<Result<Collection>> get(String id);
+  Future<Result<Collection>> create(CollectionInput input);
+  Future<Result<Collection>> update(String id, CollectionInput input);
+  Future<Result<void>> delete(String id);
+}

--- a/lib/features/collections/domain/services/collections_summary_service.dart
+++ b/lib/features/collections/domain/services/collections_summary_service.dart
@@ -1,0 +1,38 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../shared/domain/collections.dart';
+import '../entities/collection.dart';
+import '../usecases/list_collections.dart';
+
+/// Projects each [Collection] to a [CollectionSummary].
+///
+/// Implements the shared [CollectionsReader] so other features can display
+/// collections without depending on the collections domain.
+@LazySingleton(as: CollectionsReader)
+class CollectionsSummaryService extends CollectionsReader {
+  const CollectionsSummaryService(this._listCollections);
+
+  final ListCollections _listCollections;
+
+  @override
+  Future<Result<List<CollectionSummary>>> call([
+    NoParams param = noParams,
+  ]) async {
+    final result = await _listCollections();
+    return switch (result) {
+      Ok(value: final items) => Ok(
+        items.map(_toSummary).toList(growable: false),
+      ),
+      Err(:final failure) => Err(failure),
+    };
+  }
+
+  CollectionSummary _toSummary(Collection collection) => CollectionSummary(
+    id: collection.id,
+    name: collection.name,
+    icon: collection.icon,
+    color: collection.color,
+    itemCount: collection.itemCount,
+  );
+}

--- a/lib/features/collections/domain/services/collections_sync_controller.dart
+++ b/lib/features/collections/domain/services/collections_sync_controller.dart
@@ -1,0 +1,10 @@
+enum CollectionsSyncStatus { idle, syncing, error }
+
+abstract interface class CollectionsSyncController {
+  Stream<CollectionsSyncStatus> get statusStream;
+  CollectionsSyncStatus get statusNow;
+
+  Future<void> start();
+  Future<void> stop();
+  Future<void> sync();
+}

--- a/lib/features/collections/domain/usecases/_collection_validation.dart
+++ b/lib/features/collections/domain/usecases/_collection_validation.dart
@@ -1,0 +1,11 @@
+import 'package:architecture/architecture.dart';
+import '../entities/collection.dart';
+
+/// Domain validation for [CollectionInput]. Returns the first failure found, or
+/// null when the input is acceptable.
+Failure? validateCollectionInput(CollectionInput input) {
+  if (input.name.trim().isEmpty) {
+    return const ValidationFailure('Name is required.');
+  }
+  return null;
+}

--- a/lib/features/collections/domain/usecases/create_collection.dart
+++ b/lib/features/collections/domain/usecases/create_collection.dart
@@ -1,0 +1,20 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../entities/collection.dart';
+import '../repositories/collections_repository.dart';
+import '_collection_validation.dart';
+
+@injectable
+class CreateCollection extends UseCase<CollectionInput, Collection> {
+  const CreateCollection(this._repository);
+
+  final CollectionsRepository _repository;
+
+  @override
+  Future<Result<Collection>> call(CollectionInput param) {
+    final failure = validateCollectionInput(param);
+    if (failure != null) return Future.value(Err(failure));
+    return runResultGuarded(() => _repository.create(param));
+  }
+}

--- a/lib/features/collections/domain/usecases/delete_collection.dart
+++ b/lib/features/collections/domain/usecases/delete_collection.dart
@@ -1,0 +1,16 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../repositories/collections_repository.dart';
+
+@injectable
+class DeleteCollection extends UseCase<String, void> {
+  const DeleteCollection(this._repository);
+
+  final CollectionsRepository _repository;
+
+  @override
+  Future<Result<void>> call(String param) {
+    return runResultGuarded(() => _repository.delete(param));
+  }
+}

--- a/lib/features/collections/domain/usecases/get_collection.dart
+++ b/lib/features/collections/domain/usecases/get_collection.dart
@@ -1,0 +1,17 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../entities/collection.dart';
+import '../repositories/collections_repository.dart';
+
+@injectable
+class GetCollection extends UseCase<String, Collection> {
+  const GetCollection(this._repository);
+
+  final CollectionsRepository _repository;
+
+  @override
+  Future<Result<Collection>> call(String param) {
+    return runResultGuarded(() => _repository.get(param));
+  }
+}

--- a/lib/features/collections/domain/usecases/list_collections.dart
+++ b/lib/features/collections/domain/usecases/list_collections.dart
@@ -1,0 +1,17 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../entities/collection.dart';
+import '../repositories/collections_repository.dart';
+
+@injectable
+class ListCollections extends NoParamUseCase<List<Collection>> {
+  const ListCollections(this._repository);
+
+  final CollectionsRepository _repository;
+
+  @override
+  Future<Result<List<Collection>>> call([NoParams param = noParams]) {
+    return runResultGuarded(_repository.list);
+  }
+}

--- a/lib/features/collections/domain/usecases/list_local_collections.dart
+++ b/lib/features/collections/domain/usecases/list_local_collections.dart
@@ -1,0 +1,21 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../entities/collection.dart';
+import '../repositories/collections_repository.dart';
+
+/// Reads collections from the local store without triggering a sync.
+///
+/// Used to refresh the list after a sync cycle completes, avoiding the
+/// read-triggers-sync feedback loop that `ListCollections` would cause.
+@injectable
+class ListLocalCollections extends NoParamUseCase<List<Collection>> {
+  const ListLocalCollections(this._repository);
+
+  final CollectionsRepository _repository;
+
+  @override
+  Future<Result<List<Collection>>> call([NoParams param = noParams]) {
+    return runResultGuarded(_repository.listLocal);
+  }
+}

--- a/lib/features/collections/domain/usecases/update_collection.dart
+++ b/lib/features/collections/domain/usecases/update_collection.dart
@@ -1,0 +1,28 @@
+import 'package:architecture/architecture.dart';
+import 'package:injectable/injectable.dart';
+
+import '../entities/collection.dart';
+import '../repositories/collections_repository.dart';
+import '_collection_validation.dart';
+
+/// Parameters for [UpdateCollection]: the collection id plus the new input.
+class UpdateCollectionParams {
+  const UpdateCollectionParams({required this.id, required this.input});
+
+  final String id;
+  final CollectionInput input;
+}
+
+@injectable
+class UpdateCollection extends UseCase<UpdateCollectionParams, Collection> {
+  const UpdateCollection(this._repository);
+
+  final CollectionsRepository _repository;
+
+  @override
+  Future<Result<Collection>> call(UpdateCollectionParams param) {
+    final failure = validateCollectionInput(param.input);
+    if (failure != null) return Future.value(Err(failure));
+    return runResultGuarded(() => _repository.update(param.id, param.input));
+  }
+}

--- a/lib/features/collections/presentation/bloc/add_to_collection/add_to_collection_cubit.dart
+++ b/lib/features/collections/presentation/bloc/add_to_collection/add_to_collection_cubit.dart
@@ -1,0 +1,92 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../domain/entities/collection.dart';
+import '../../../domain/usecases/list_collections.dart';
+import '../../../domain/usecases/update_collection.dart';
+import 'add_to_collection_state.dart';
+
+/// Drives the bottom sheet that toggles a single bookmark's membership across
+/// the user's collections.
+///
+/// This is the collections feature's "capability" surfaced inside the
+/// bookmarks detail screen (the single-consumer exception in the architecture
+/// rules).
+@injectable
+class AddToCollectionCubit extends Cubit<AddToCollectionState> {
+  AddToCollectionCubit(this._list, this._update)
+    : super(const AddToCollectionState());
+
+  final ListCollections _list;
+  final UpdateCollection _update;
+
+  Future<void> load(String bookmarkId) async {
+    emit(state.copyWith(isLoading: true, failure: null));
+    final result = await _list();
+    switch (result) {
+      case Ok(value: final collections):
+        emit(
+          state.copyWith(
+            isLoading: false,
+            collections: collections,
+            memberOf: {
+              for (final c in collections)
+                if (c.bookmarkIds.contains(bookmarkId)) c.id,
+            },
+          ),
+        );
+      case Err(:final failure):
+        emit(state.copyWith(isLoading: false, failure: failure));
+    }
+  }
+
+  /// Adds or removes [bookmarkId] from the collection with [collectionId].
+  Future<void> toggle(String collectionId, String bookmarkId) async {
+    if (state.busyIds.contains(collectionId)) return;
+    final collection = state.collections.firstWhere(
+      (c) => c.id == collectionId,
+    );
+    final isMember = state.memberOf.contains(collectionId);
+    final nextIds = isMember
+        ? collection.bookmarkIds.where((id) => id != bookmarkId).toList()
+        : [...collection.bookmarkIds, bookmarkId];
+
+    emit(state.copyWith(busyIds: {...state.busyIds, collectionId}));
+    final result = await _update(
+      UpdateCollectionParams(
+        id: collectionId,
+        input: CollectionInput(
+          name: collection.name,
+          icon: collection.icon,
+          color: collection.color,
+          bookmarkIds: nextIds,
+        ),
+      ),
+    );
+
+    final busy = {...state.busyIds}..remove(collectionId);
+    switch (result) {
+      case Ok(value: final updated):
+        final collections = [
+          for (final c in state.collections)
+            if (c.id == collectionId) updated else c,
+        ];
+        final memberOf = {...state.memberOf};
+        if (isMember) {
+          memberOf.remove(collectionId);
+        } else {
+          memberOf.add(collectionId);
+        }
+        emit(
+          state.copyWith(
+            collections: collections,
+            memberOf: memberOf,
+            busyIds: busy,
+          ),
+        );
+      case Err(:final failure):
+        emit(state.copyWith(busyIds: busy, failure: failure));
+    }
+  }
+}

--- a/lib/features/collections/presentation/bloc/add_to_collection/add_to_collection_cubit.dart
+++ b/lib/features/collections/presentation/bloc/add_to_collection/add_to_collection_cubit.dart
@@ -44,9 +44,10 @@ class AddToCollectionCubit extends Cubit<AddToCollectionState> {
   /// Adds or removes [bookmarkId] from the collection with [collectionId].
   Future<void> toggle(String collectionId, String bookmarkId) async {
     if (state.busyIds.contains(collectionId)) return;
-    final collection = state.collections.firstWhere(
-      (c) => c.id == collectionId,
-    );
+    final index = state.collections.indexWhere((c) => c.id == collectionId);
+    // The collection may have disappeared between render and tap.
+    if (index == -1) return;
+    final collection = state.collections[index];
     final isMember = state.memberOf.contains(collectionId);
     final nextIds = isMember
         ? collection.bookmarkIds.where((id) => id != bookmarkId).toList()

--- a/lib/features/collections/presentation/bloc/add_to_collection/add_to_collection_state.dart
+++ b/lib/features/collections/presentation/bloc/add_to_collection/add_to_collection_state.dart
@@ -1,0 +1,40 @@
+import 'package:architecture/architecture.dart';
+
+import '../../../domain/entities/collection.dart';
+
+/// State for the "add this bookmark to collections" bottom sheet.
+class AddToCollectionState {
+  const AddToCollectionState({
+    this.isLoading = false,
+    this.collections = const [],
+    this.memberOf = const {},
+    this.busyIds = const {},
+    this.failure,
+  });
+
+  final bool isLoading;
+  final List<Collection> collections;
+
+  /// Ids of collections that currently contain the target bookmark.
+  final Set<String> memberOf;
+
+  /// Ids of collections with an in-flight toggle.
+  final Set<String> busyIds;
+  final Failure? failure;
+
+  AddToCollectionState copyWith({
+    bool? isLoading,
+    List<Collection>? collections,
+    Set<String>? memberOf,
+    Set<String>? busyIds,
+    Failure? failure,
+  }) {
+    return AddToCollectionState(
+      isLoading: isLoading ?? this.isLoading,
+      collections: collections ?? this.collections,
+      memberOf: memberOf ?? this.memberOf,
+      busyIds: busyIds ?? this.busyIds,
+      failure: failure,
+    );
+  }
+}

--- a/lib/features/collections/presentation/bloc/collection_detail/collection_detail_cubit.dart
+++ b/lib/features/collections/presentation/bloc/collection_detail/collection_detail_cubit.dart
@@ -61,7 +61,7 @@ class CollectionDetailCubit extends Cubit<CollectionDetailState> {
   /// Deletes the whole collection.
   Future<void> delete() async {
     final current = state.collection;
-    if (current == null) return;
+    if (current == null || state.isUpdating) return;
     emit(state.copyWith(isUpdating: true, failure: null));
     final result = await _delete(current.id);
     switch (result) {
@@ -81,6 +81,7 @@ class CollectionDetailCubit extends Cubit<CollectionDetailState> {
   }
 
   Future<void> _persist(Collection current, List<String> bookmarkIds) async {
+    if (state.isUpdating) return;
     emit(state.copyWith(isUpdating: true, failure: null));
     final result = await _update(
       UpdateCollectionParams(

--- a/lib/features/collections/presentation/bloc/collection_detail/collection_detail_cubit.dart
+++ b/lib/features/collections/presentation/bloc/collection_detail/collection_detail_cubit.dart
@@ -1,0 +1,117 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../../../shared/domain/bookmark_stats.dart';
+import '../../../../../shared/domain/bookmark_summaries.dart';
+import '../../../domain/entities/collection.dart';
+import '../../../domain/usecases/delete_collection.dart';
+import '../../../domain/usecases/get_collection.dart';
+import '../../../domain/usecases/update_collection.dart';
+import 'collection_detail_state.dart';
+
+@injectable
+class CollectionDetailCubit extends Cubit<CollectionDetailState> {
+  CollectionDetailCubit(
+    this._get,
+    this._update,
+    this._delete,
+    this._bookmarkSummaries,
+  ) : super(const CollectionDetailState());
+
+  final GetCollection _get;
+  final UpdateCollection _update;
+  final DeleteCollection _delete;
+  final BookmarkSummariesReader _bookmarkSummaries;
+
+  Future<void> load(String id) async {
+    emit(state.copyWith(isLoading: true, failure: null));
+    final collectionResult = await _get(id);
+    if (collectionResult case Err(:final failure)) {
+      emit(state.copyWith(isLoading: false, failure: failure));
+      return;
+    }
+    final collection = (collectionResult as Ok<Collection>).value;
+    final summariesResult = await _bookmarkSummaries();
+    final allBookmarks = switch (summariesResult) {
+      Ok(value: final items) => items,
+      Err() => const <BookmarkSummary>[],
+    };
+    emit(
+      state.copyWith(
+        isLoading: false,
+        collection: collection,
+        allBookmarks: allBookmarks,
+        members: _membersOf(collection, allBookmarks),
+      ),
+    );
+  }
+
+  /// Adds [bookmarkIds] to the collection (union with current members).
+  Future<void> addBookmarks(Set<String> bookmarkIds) {
+    final current = state.collection;
+    if (current == null || bookmarkIds.isEmpty) return Future.value();
+    final next = <String>[...current.bookmarkIds];
+    for (final id in bookmarkIds) {
+      if (!next.contains(id)) next.add(id);
+    }
+    return _persist(current, next);
+  }
+
+  /// Deletes the whole collection.
+  Future<void> delete() async {
+    final current = state.collection;
+    if (current == null) return;
+    emit(state.copyWith(isUpdating: true, failure: null));
+    final result = await _delete(current.id);
+    switch (result) {
+      case Ok():
+        emit(state.copyWith(isUpdating: false, deleted: true));
+      case Err(:final failure):
+        emit(state.copyWith(isUpdating: false, failure: failure));
+    }
+  }
+
+  /// Removes a single bookmark from the collection.
+  Future<void> removeBookmark(String bookmarkId) {
+    final current = state.collection;
+    if (current == null) return Future.value();
+    final next = current.bookmarkIds.where((id) => id != bookmarkId).toList();
+    return _persist(current, next);
+  }
+
+  Future<void> _persist(Collection current, List<String> bookmarkIds) async {
+    emit(state.copyWith(isUpdating: true, failure: null));
+    final result = await _update(
+      UpdateCollectionParams(
+        id: current.id,
+        input: CollectionInput(
+          name: current.name,
+          icon: current.icon,
+          color: current.color,
+          bookmarkIds: bookmarkIds,
+        ),
+      ),
+    );
+    switch (result) {
+      case Ok(value: final updated):
+        emit(
+          state.copyWith(
+            isUpdating: false,
+            collection: updated,
+            members: _membersOf(updated, state.allBookmarks),
+          ),
+        );
+      case Err(:final failure):
+        emit(state.copyWith(isUpdating: false, failure: failure));
+    }
+  }
+
+  List<BookmarkSummary> _membersOf(
+    Collection collection,
+    List<BookmarkSummary> all,
+  ) {
+    final byId = {for (final b in all) b.id: b};
+    return [for (final id in collection.bookmarkIds) ?byId[id]];
+  }
+}

--- a/lib/features/collections/presentation/bloc/collection_detail/collection_detail_state.dart
+++ b/lib/features/collections/presentation/bloc/collection_detail/collection_detail_state.dart
@@ -1,0 +1,56 @@
+import 'package:architecture/architecture.dart';
+
+import '../../../../../shared/domain/bookmark_stats.dart';
+import '../../../domain/entities/collection.dart';
+
+/// State for the collection detail screen: the collection itself, its member
+/// bookmarks, and the full bookmark list used by the "add bookmarks" picker.
+class CollectionDetailState {
+  const CollectionDetailState({
+    this.isLoading = false,
+    this.isUpdating = false,
+    this.deleted = false,
+    this.collection,
+    this.members = const [],
+    this.allBookmarks = const [],
+    this.failure,
+  });
+
+  final bool isLoading;
+  final bool isUpdating;
+
+  /// Flips to true after a successful delete so the screen can pop.
+  final bool deleted;
+  final Collection? collection;
+  final List<BookmarkSummary> members;
+  final List<BookmarkSummary> allBookmarks;
+  final Failure? failure;
+
+  /// Bookmarks not yet in the collection — candidates for the picker.
+  List<BookmarkSummary> get candidates {
+    final memberIds = collection?.bookmarkIds.toSet() ?? const <String>{};
+    return allBookmarks
+        .where((b) => !memberIds.contains(b.id))
+        .toList(growable: false);
+  }
+
+  CollectionDetailState copyWith({
+    bool? isLoading,
+    bool? isUpdating,
+    bool? deleted,
+    Collection? collection,
+    List<BookmarkSummary>? members,
+    List<BookmarkSummary>? allBookmarks,
+    Failure? failure,
+  }) {
+    return CollectionDetailState(
+      isLoading: isLoading ?? this.isLoading,
+      isUpdating: isUpdating ?? this.isUpdating,
+      deleted: deleted ?? this.deleted,
+      collection: collection ?? this.collection,
+      members: members ?? this.members,
+      allBookmarks: allBookmarks ?? this.allBookmarks,
+      failure: failure,
+    );
+  }
+}

--- a/lib/features/collections/presentation/bloc/collection_form/collection_form_cubit.dart
+++ b/lib/features/collections/presentation/bloc/collection_form/collection_form_cubit.dart
@@ -1,0 +1,60 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../domain/entities/collection.dart';
+import '../../../domain/usecases/create_collection.dart';
+import '../../../domain/usecases/get_collection.dart';
+import '../../../domain/usecases/update_collection.dart';
+import 'collection_form_state.dart';
+
+@injectable
+class CollectionFormCubit extends Cubit<CollectionFormState> {
+  CollectionFormCubit(this._create, this._update, this._get)
+    : super(const CollectionFormState());
+
+  final CreateCollection _create;
+  final UpdateCollection _update;
+  final GetCollection _get;
+
+  /// Loads an existing collection for editing. No-op for the create flow.
+  Future<void> loadForEdit(String id) async {
+    emit(state.copyWith(isLoading: true, failure: null));
+    final result = await _get(id);
+    switch (result) {
+      case Ok(value: final collection):
+        emit(state.copyWith(isLoading: false, initial: collection));
+      case Err(:final failure):
+        emit(state.copyWith(isLoading: false, failure: failure));
+    }
+  }
+
+  Future<void> submit({
+    required String name,
+    required String icon,
+    required int color,
+  }) async {
+    if (state.isSubmitting) return;
+    emit(state.copyWith(isSubmitting: true, failure: null));
+
+    final existing = state.initial;
+    final input = CollectionInput(
+      name: name,
+      icon: icon,
+      color: color,
+      // Preserve membership across edits; create starts empty.
+      bookmarkIds: existing?.bookmarkIds ?? const [],
+    );
+
+    final result = existing == null
+        ? await _create(input)
+        : await _update(UpdateCollectionParams(id: existing.id, input: input));
+
+    switch (result) {
+      case Ok():
+        emit(state.copyWith(isSubmitting: false, saved: true));
+      case Err(:final failure):
+        emit(state.copyWith(isSubmitting: false, failure: failure));
+    }
+  }
+}

--- a/lib/features/collections/presentation/bloc/collection_form/collection_form_state.dart
+++ b/lib/features/collections/presentation/bloc/collection_form/collection_form_state.dart
@@ -1,0 +1,42 @@
+import 'package:architecture/architecture.dart';
+
+import '../../../domain/entities/collection.dart';
+
+/// State for the create/edit collection form.
+class CollectionFormState {
+  const CollectionFormState({
+    this.isLoading = false,
+    this.isSubmitting = false,
+    this.initial,
+    this.saved = false,
+    this.failure,
+  });
+
+  final bool isLoading;
+  final bool isSubmitting;
+
+  /// The existing collection when editing; null when creating.
+  final Collection? initial;
+
+  /// Flips to true after a successful create/update so the screen can pop.
+  final bool saved;
+  final Failure? failure;
+
+  bool get isEditing => initial != null;
+
+  CollectionFormState copyWith({
+    bool? isLoading,
+    bool? isSubmitting,
+    Collection? initial,
+    bool? saved,
+    Failure? failure,
+  }) {
+    return CollectionFormState(
+      isLoading: isLoading ?? this.isLoading,
+      isSubmitting: isSubmitting ?? this.isSubmitting,
+      initial: initial ?? this.initial,
+      saved: saved ?? this.saved,
+      failure: failure,
+    );
+  }
+}

--- a/lib/features/collections/presentation/bloc/collections_list/collections_list_bloc.dart
+++ b/lib/features/collections/presentation/bloc/collections_list/collections_list_bloc.dart
@@ -1,0 +1,107 @@
+import 'dart:async';
+
+import 'package:architecture/architecture.dart';
+import 'package:bloc_concurrency/bloc_concurrency.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+
+import '../../../domain/services/collections_sync_controller.dart';
+import '../../../domain/usecases/delete_collection.dart';
+import '../../../domain/usecases/list_collections.dart';
+import '../../../domain/usecases/list_local_collections.dart';
+import 'collections_list_state.dart';
+
+part 'collections_list_event.dart';
+
+@injectable
+class CollectionsListBloc
+    extends Bloc<CollectionsListEvent, CollectionsListState> {
+  CollectionsListBloc(this._list, this._listLocal, this._delete, this._sync)
+    : super(const CollectionsListState()) {
+    on<CollectionsListLoadRequested>(
+      _onLoadRequested,
+      transformer: sequential(),
+    );
+    on<CollectionsListDeleteRequested>(
+      _onDeleteRequested,
+      transformer: sequential(),
+    );
+    on<_CollectionsSyncStatusChanged>(
+      _onSyncStatusChanged,
+      transformer: sequential(),
+    );
+    on<_CollectionsReloadSilentlyRequested>(
+      _onReloadSilentlyRequested,
+      transformer: sequential(),
+    );
+    // Reload local data after every sync cycle so server-side changes appear
+    // without the user pulling-to-refresh.
+    _syncSub = _sync.statusStream.listen((status) {
+      if (isClosed) return;
+      add(_CollectionsSyncStatusChanged(status));
+    });
+  }
+
+  final ListCollections _list;
+  final ListLocalCollections _listLocal;
+  final DeleteCollection _delete;
+  final CollectionsSyncController _sync;
+  late final StreamSubscription<CollectionsSyncStatus> _syncSub;
+  CollectionsSyncStatus _lastSyncStatus = CollectionsSyncStatus.idle;
+
+  Future<void> _onLoadRequested(
+    CollectionsListLoadRequested event,
+    Emitter<CollectionsListState> emit,
+  ) async {
+    emit(state.copyWith(isLoading: true, failure: null));
+    final result = await _list();
+    switch (result) {
+      case Ok(value: final items):
+        emit(state.copyWith(isLoading: false, items: items));
+      case Err(:final failure):
+        emit(state.copyWith(isLoading: false, failure: failure));
+    }
+  }
+
+  Future<void> _onDeleteRequested(
+    CollectionsListDeleteRequested event,
+    Emitter<CollectionsListState> emit,
+  ) async {
+    final result = await _delete(event.id);
+    switch (result) {
+      case Ok():
+        add(const _CollectionsReloadSilentlyRequested());
+      case Err(:final failure):
+        emit(state.copyWith(failure: failure));
+    }
+  }
+
+  void _onSyncStatusChanged(
+    _CollectionsSyncStatusChanged event,
+    Emitter<CollectionsListState> emit,
+  ) {
+    final wasSyncing = _lastSyncStatus == CollectionsSyncStatus.syncing;
+    _lastSyncStatus = event.status;
+    emit(state.copyWith(syncStatus: event.status));
+    // When a sync cycle finishes, refresh from local so pulled changes show.
+    if (wasSyncing && event.status != CollectionsSyncStatus.syncing) {
+      add(const _CollectionsReloadSilentlyRequested());
+    }
+  }
+
+  Future<void> _onReloadSilentlyRequested(
+    _CollectionsReloadSilentlyRequested event,
+    Emitter<CollectionsListState> emit,
+  ) async {
+    final result = await _listLocal();
+    if (result case Ok(value: final items)) {
+      emit(state.copyWith(items: items));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _syncSub.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/collections/presentation/bloc/collections_list/collections_list_event.dart
+++ b/lib/features/collections/presentation/bloc/collections_list/collections_list_event.dart
@@ -1,0 +1,25 @@
+part of 'collections_list_bloc.dart';
+
+sealed class CollectionsListEvent {
+  const CollectionsListEvent();
+}
+
+final class CollectionsListLoadRequested extends CollectionsListEvent {
+  const CollectionsListLoadRequested();
+}
+
+final class CollectionsListDeleteRequested extends CollectionsListEvent {
+  const CollectionsListDeleteRequested(this.id);
+
+  final String id;
+}
+
+final class _CollectionsSyncStatusChanged extends CollectionsListEvent {
+  const _CollectionsSyncStatusChanged(this.status);
+
+  final CollectionsSyncStatus status;
+}
+
+final class _CollectionsReloadSilentlyRequested extends CollectionsListEvent {
+  const _CollectionsReloadSilentlyRequested();
+}

--- a/lib/features/collections/presentation/bloc/collections_list/collections_list_state.dart
+++ b/lib/features/collections/presentation/bloc/collections_list/collections_list_state.dart
@@ -1,0 +1,17 @@
+import 'package:architecture/architecture.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../../domain/entities/collection.dart';
+import '../../../domain/services/collections_sync_controller.dart';
+
+part 'collections_list_state.freezed.dart';
+
+@freezed
+abstract class CollectionsListState with _$CollectionsListState {
+  const factory CollectionsListState({
+    @Default(false) bool isLoading,
+    @Default(CollectionsSyncStatus.idle) CollectionsSyncStatus syncStatus,
+    @Default([]) List<Collection> items,
+    Failure? failure,
+  }) = _CollectionsListState;
+}

--- a/lib/features/collections/presentation/screens/collection_detail_screen.dart
+++ b/lib/features/collections/presentation/screens/collection_detail_screen.dart
@@ -1,0 +1,223 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../../../app/di/injection.dart';
+import '../../../../app/router.dart';
+import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../../shared/domain/bookmark_stats.dart';
+import '../../../../shared/presentation/collection_visuals.dart';
+import '../bloc/collection_detail/collection_detail_cubit.dart';
+import '../bloc/collection_detail/collection_detail_state.dart';
+import '../widgets/add_bookmarks_sheet.dart';
+
+class CollectionDetailScreen extends StatelessWidget {
+  const CollectionDetailScreen({super.key, required this.id});
+
+  final String id;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => getIt<CollectionDetailCubit>()..load(id),
+      child: _CollectionDetailView(id: id),
+    );
+  }
+}
+
+class _CollectionDetailView extends StatelessWidget {
+  const _CollectionDetailView({required this.id});
+
+  final String id;
+
+  Future<void> _confirmDelete(BuildContext context, String name) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) => AlertDialog(
+        title: Text(context.l10n.collectionDeleteDialogTitle),
+        content: Text(context.l10n.collectionDeleteDialogMessage(name)),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: Text(MaterialLocalizations.of(context).cancelButtonLabel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: Text(context.l10n.collectionDeleteAction),
+          ),
+        ],
+      ),
+    );
+    if ((confirmed ?? false) && context.mounted) {
+      await context.read<CollectionDetailCubit>().delete();
+    }
+  }
+
+  Future<void> _addBookmarks(BuildContext context) async {
+    final cubit = context.read<CollectionDetailCubit>();
+    final selected = await AddBookmarksSheet.show(
+      context,
+      candidates: cubit.state.candidates,
+    );
+    if (selected != null && selected.isNotEmpty) {
+      await cubit.addBookmarks(selected);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<CollectionDetailCubit, CollectionDetailState>(
+      listener: (context, state) {
+        if (state.deleted) Navigator.of(context).pop();
+        if (state.failure != null) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(SnackBar(content: Text(state.failure!.message)));
+        }
+      },
+      builder: (context, state) {
+        final collection = state.collection;
+        return AppScaffold(
+          title: collection?.name ?? context.l10n.collectionsTitle,
+          padding: EdgeInsets.zero,
+          isLoading: state.isLoading && collection == null,
+          actions: collection == null
+              ? null
+              : [
+                  IconButton(
+                    icon: const FaIcon(FontAwesomeIcons.penToSquare),
+                    iconSize: AppIconSize.sm,
+                    tooltip: context.l10n.collectionsEditTitle,
+                    onPressed: () =>
+                        CollectionEditRoute(id).push<void>(context),
+                  ),
+                  IconButton(
+                    icon: const FaIcon(FontAwesomeIcons.trash),
+                    iconSize: AppIconSize.sm,
+                    tooltip: context.l10n.collectionDeleteAction,
+                    onPressed: () => _confirmDelete(context, collection.name),
+                  ),
+                ],
+          floatingActionButton: collection == null
+              ? null
+              : FloatingActionButton.extended(
+                  heroTag: 'collection-add-bookmarks-fab',
+                  onPressed: () => _addBookmarks(context),
+                  icon: const FaIcon(FontAwesomeIcons.plus),
+                  label: Text(context.l10n.collectionAddBookmarks),
+                ),
+          body: collection == null
+              ? const SizedBox.shrink()
+              : _MembersList(
+                  color: collection.color,
+                  icon: collection.icon,
+                  itemCount: collection.itemCount,
+                  members: state.members,
+                ),
+        );
+      },
+    );
+  }
+}
+
+class _MembersList extends StatelessWidget {
+  const _MembersList({
+    required this.color,
+    required this.icon,
+    required this.itemCount,
+    required this.members,
+  });
+
+  final int color;
+  final String icon;
+  final int itemCount;
+  final List<BookmarkSummary> members;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        SliverToBoxAdapter(
+          child: Container(
+            margin: const EdgeInsets.all(AppSpacing.lg),
+            padding: const EdgeInsets.all(AppSpacing.lg),
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: collectionGradientFor(color),
+              ),
+              borderRadius: BorderRadius.circular(AppRadius.lg),
+            ),
+            child: Row(
+              children: [
+                FaIcon(
+                  collectionIconFor(icon),
+                  color: Colors.white,
+                  size: AppIconSize.lg,
+                ),
+                const SizedBox(width: AppSpacing.md),
+                Text(
+                  context.l10n.collectionItemsCount(itemCount),
+                  style: context.textTheme.titleMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (members.isEmpty)
+          SliverFillRemaining(
+            hasScrollBody: false,
+            child: AppEmptyView(
+              icon: FontAwesomeIcons.bookmark,
+              message: context.l10n.collectionEmptyBookmarks,
+            ),
+          )
+        else
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              0,
+              AppSpacing.lg,
+              96,
+            ),
+            sliver: SliverList.builder(
+              itemCount: members.length,
+              itemBuilder: (context, index) {
+                final bookmark = members[index];
+                return Card(
+                  margin: const EdgeInsets.only(bottom: AppSpacing.sm),
+                  child: ListTile(
+                    title: Text(
+                      bookmark.title,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    subtitle: Text(
+                      bookmark.url,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    trailing: IconButton(
+                      icon: const FaIcon(FontAwesomeIcons.xmark),
+                      iconSize: AppIconSize.sm,
+                      tooltip: context.l10n.collectionRemoveBookmark,
+                      onPressed: () => context
+                          .read<CollectionDetailCubit>()
+                          .removeBookmark(bookmark.id),
+                    ),
+                    onTap: () =>
+                        BookmarkDetailRoute(bookmark.id).push<void>(context),
+                  ),
+                );
+              },
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/collections/presentation/screens/collection_form_screen.dart
+++ b/lib/features/collections/presentation/screens/collection_form_screen.dart
@@ -141,26 +141,31 @@ class _PalettePicker extends StatelessWidget {
       runSpacing: AppSpacing.md,
       children: [
         for (final (index, option) in collectionPalette.indexed)
-          GestureDetector(
-            onTap: () => onSelected(index),
-            child: Container(
-              width: 56,
-              height: 56,
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors: collectionGradientFor(option.color.toARGB32()),
+          Semantics(
+            button: true,
+            selected: index == selectedIndex,
+            label: '${context.l10n.collectionAppearanceLabel} ${index + 1}',
+            child: GestureDetector(
+              onTap: () => onSelected(index),
+              child: Container(
+                width: 56,
+                height: 56,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                    colors: collectionGradientFor(option.color.toARGB32()),
+                  ),
+                  borderRadius: BorderRadius.circular(AppRadius.sm),
+                  border: index == selectedIndex
+                      ? Border.all(
+                          color: context.colorScheme.onSurface,
+                          width: 3,
+                        )
+                      : null,
                 ),
-                borderRadius: BorderRadius.circular(AppRadius.sm),
-                border: index == selectedIndex
-                    ? Border.all(
-                        color: context.colorScheme.onSurface,
-                        width: 3,
-                      )
-                    : null,
+                child: FaIcon(option.icon, color: Colors.white, size: 22),
               ),
-              child: FaIcon(option.icon, color: Colors.white, size: 22),
             ),
           ),
       ],

--- a/lib/features/collections/presentation/screens/collection_form_screen.dart
+++ b/lib/features/collections/presentation/screens/collection_form_screen.dart
@@ -1,0 +1,169 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../../../app/di/injection.dart';
+import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../../shared/presentation/collection_visuals.dart';
+import '../bloc/collection_form/collection_form_cubit.dart';
+import '../bloc/collection_form/collection_form_state.dart';
+
+/// Create or edit a collection. Pass [id] to edit an existing one.
+class CollectionFormScreen extends StatelessWidget {
+  const CollectionFormScreen({super.key, this.id});
+
+  final String? id;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) {
+        final cubit = getIt<CollectionFormCubit>();
+        if (id != null) cubit.loadForEdit(id!);
+        return cubit;
+      },
+      child: _CollectionFormView(isEditing: id != null),
+    );
+  }
+}
+
+class _CollectionFormView extends StatefulWidget {
+  const _CollectionFormView({required this.isEditing});
+
+  final bool isEditing;
+
+  @override
+  State<_CollectionFormView> createState() => _CollectionFormViewState();
+}
+
+class _CollectionFormViewState extends State<_CollectionFormView> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameController = TextEditingController();
+  int _selectedIndex = 0;
+  bool _hydrated = false;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  void _hydrateFrom(CollectionFormState state) {
+    if (_hydrated || state.initial == null) return;
+    final initial = state.initial!;
+    _nameController.text = initial.name;
+    final index = collectionPalette.indexWhere((o) => o.token == initial.icon);
+    if (index != -1) _selectedIndex = index;
+    _hydrated = true;
+  }
+
+  void _submit(BuildContext context) {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+    final option = collectionPalette[_selectedIndex];
+    context.read<CollectionFormCubit>().submit(
+      name: _nameController.text,
+      icon: option.token,
+      color: option.color.toARGB32(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<CollectionFormCubit, CollectionFormState>(
+      listener: (context, state) {
+        _hydrateFrom(state);
+        if (state.saved) Navigator.of(context).pop();
+        if (state.failure != null) {
+          ScaffoldMessenger.of(context)
+            ..hideCurrentSnackBar()
+            ..showSnackBar(SnackBar(content: Text(state.failure!.message)));
+        }
+      },
+      builder: (context, state) {
+        return AppScaffold(
+          title: widget.isEditing
+              ? context.l10n.collectionsEditTitle
+              : context.l10n.collectionsCreateTitle,
+          isLoading: state.isLoading,
+          body: Form(
+            key: _formKey,
+            child: ListView(
+              children: [
+                AppTextField(
+                  controller: _nameController,
+                  label: context.l10n.collectionNameLabel,
+                  hint: context.l10n.collectionNameHint,
+                  textCapitalization: TextCapitalization.sentences,
+                  validator: (value) => (value == null || value.trim().isEmpty)
+                      ? context.l10n.collectionNameRequired
+                      : null,
+                ),
+                const SizedBox(height: AppSpacing.xl),
+                Text(
+                  context.l10n.collectionAppearanceLabel,
+                  style: context.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: AppSpacing.md),
+                _PalettePicker(
+                  selectedIndex: _selectedIndex,
+                  onSelected: (index) => setState(() => _selectedIndex = index),
+                ),
+                const SizedBox(height: AppSpacing.xxl),
+                AppButton(
+                  label: context.l10n.collectionSave,
+                  icon: FontAwesomeIcons.check,
+                  expand: true,
+                  isLoading: state.isSubmitting,
+                  onPressed: () => _submit(context),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _PalettePicker extends StatelessWidget {
+  const _PalettePicker({required this.selectedIndex, required this.onSelected});
+
+  final int selectedIndex;
+  final ValueChanged<int> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: AppSpacing.md,
+      runSpacing: AppSpacing.md,
+      children: [
+        for (final (index, option) in collectionPalette.indexed)
+          GestureDetector(
+            onTap: () => onSelected(index),
+            child: Container(
+              width: 56,
+              height: 56,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: collectionGradientFor(option.color.toARGB32()),
+                ),
+                borderRadius: BorderRadius.circular(AppRadius.sm),
+                border: index == selectedIndex
+                    ? Border.all(
+                        color: context.colorScheme.onSurface,
+                        width: 3,
+                      )
+                    : null,
+              ),
+              child: FaIcon(option.icon, color: Colors.white, size: 22),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/lib/features/collections/presentation/screens/collections_list_screen.dart
+++ b/lib/features/collections/presentation/screens/collections_list_screen.dart
@@ -1,0 +1,27 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../../../app/router.dart';
+import '../../../../core/extensions/build_context_extensions.dart';
+import '../widgets/collections_list_view.dart';
+
+/// Standalone collections browser (reachable at `/collections`).
+class CollectionsListScreen extends StatelessWidget {
+  const CollectionsListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AppScaffold(
+      title: context.l10n.collectionsTitle,
+      padding: EdgeInsets.zero,
+      floatingActionButton: FloatingActionButton(
+        heroTag: 'collections-add-fab',
+        tooltip: context.l10n.collectionsCreate,
+        onPressed: () => const CollectionNewRoute().push<void>(context),
+        child: const FaIcon(FontAwesomeIcons.plus),
+      ),
+      body: const CollectionsListView(),
+    );
+  }
+}

--- a/lib/features/collections/presentation/widgets/add_bookmarks_sheet.dart
+++ b/lib/features/collections/presentation/widgets/add_bookmarks_sheet.dart
@@ -1,0 +1,115 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../../shared/domain/bookmark_stats.dart';
+
+/// Multi-select sheet for adding bookmarks to a collection.
+///
+/// Returns the set of selected bookmark ids, or null if dismissed.
+class AddBookmarksSheet extends StatefulWidget {
+  const AddBookmarksSheet({super.key, required this.candidates});
+
+  final List<BookmarkSummary> candidates;
+
+  static Future<Set<String>?> show(
+    BuildContext context, {
+    required List<BookmarkSummary> candidates,
+  }) {
+    return showModalBottomSheet<Set<String>>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => AddBookmarksSheet(candidates: candidates),
+    );
+  }
+
+  @override
+  State<AddBookmarksSheet> createState() => _AddBookmarksSheetState();
+}
+
+class _AddBookmarksSheetState extends State<AddBookmarksSheet> {
+  final _selected = <String>{};
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.candidates.isEmpty) {
+      return Padding(
+        padding: const EdgeInsets.all(AppSpacing.xxl),
+        child: Text(
+          context.l10n.collectionPickerEmpty,
+          textAlign: TextAlign.center,
+          style: context.textTheme.bodyMedium?.copyWith(
+            color: context.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      );
+    }
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+            child: Text(
+              context.l10n.collectionAddBookmarks,
+              style: context.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+          const SizedBox(height: AppSpacing.sm),
+          Flexible(
+            child: ListView.builder(
+              shrinkWrap: true,
+              itemCount: widget.candidates.length,
+              itemBuilder: (context, index) {
+                final bookmark = widget.candidates[index];
+                final checked = _selected.contains(bookmark.id);
+                return CheckboxListTile(
+                  value: checked,
+                  title: Text(
+                    bookmark.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  subtitle: Text(
+                    bookmark.url,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  onChanged: (value) => setState(() {
+                    if (value ?? false) {
+                      _selected.add(bookmark.id);
+                    } else {
+                      _selected.remove(bookmark.id);
+                    }
+                  }),
+                );
+              },
+            ),
+          ),
+          const SizedBox(height: AppSpacing.md),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(
+              AppSpacing.lg,
+              0,
+              AppSpacing.lg,
+              AppSpacing.lg,
+            ),
+            child: AppButton(
+              label: context.l10n.collectionPickerAddCount(_selected.length),
+              icon: FontAwesomeIcons.plus,
+              expand: true,
+              onPressed: _selected.isEmpty
+                  ? null
+                  : () => Navigator.of(context).pop(_selected),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/collections/presentation/widgets/add_to_collection_sheet.dart
+++ b/lib/features/collections/presentation/widgets/add_to_collection_sheet.dart
@@ -68,6 +68,30 @@ class _AddToCollectionBody extends StatelessWidget {
                   padding: EdgeInsets.all(AppSpacing.xxl),
                   child: AppLoading(),
                 )
+              else if (state.failure != null && state.collections.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.all(AppSpacing.xxl),
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        context.l10n.collectionsLoadError,
+                        textAlign: TextAlign.center,
+                        style: context.textTheme.bodyMedium?.copyWith(
+                          color: context.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.md),
+                      AppButton(
+                        label: context.l10n.commonRetry,
+                        variant: AppButtonVariant.tonal,
+                        onPressed: () => context
+                            .read<AddToCollectionCubit>()
+                            .load(bookmarkId),
+                      ),
+                    ],
+                  ),
+                )
               else if (state.collections.isEmpty)
                 Padding(
                   padding: const EdgeInsets.all(AppSpacing.xxl),

--- a/lib/features/collections/presentation/widgets/add_to_collection_sheet.dart
+++ b/lib/features/collections/presentation/widgets/add_to_collection_sheet.dart
@@ -1,0 +1,145 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../../../app/di/injection.dart';
+import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../../shared/presentation/collection_visuals.dart';
+import '../bloc/add_to_collection/add_to_collection_cubit.dart';
+import '../bloc/add_to_collection/add_to_collection_state.dart';
+
+/// Bottom sheet that toggles a single bookmark's membership across the user's
+/// collections.
+///
+/// This is the collections feature's capability surfaced inside the bookmarks
+/// detail screen — the single-consumer exception in the architecture rules.
+class AddToCollectionSheet extends StatelessWidget {
+  const AddToCollectionSheet({super.key, required this.bookmarkId});
+
+  final String bookmarkId;
+
+  static Future<void> show(BuildContext context, {required String bookmarkId}) {
+    return showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      builder: (_) => AddToCollectionSheet(bookmarkId: bookmarkId),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => getIt<AddToCollectionCubit>()..load(bookmarkId),
+      child: _AddToCollectionBody(bookmarkId: bookmarkId),
+    );
+  }
+}
+
+class _AddToCollectionBody extends StatelessWidget {
+  const _AddToCollectionBody({required this.bookmarkId});
+
+  final String bookmarkId;
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: BlocBuilder<AddToCollectionCubit, AddToCollectionState>(
+        builder: (context, state) {
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: AppSpacing.lg),
+                child: Align(
+                  alignment: Alignment.centerLeft,
+                  child: Text(
+                    context.l10n.addToCollectionTitle,
+                    style: context.textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: AppSpacing.sm),
+              if (state.isLoading)
+                const Padding(
+                  padding: EdgeInsets.all(AppSpacing.xxl),
+                  child: AppLoading(),
+                )
+              else if (state.collections.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.all(AppSpacing.xxl),
+                  child: Text(
+                    context.l10n.addToCollectionEmpty,
+                    textAlign: TextAlign.center,
+                    style: context.textTheme.bodyMedium?.copyWith(
+                      color: context.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                )
+              else
+                Flexible(
+                  child: ListView.builder(
+                    shrinkWrap: true,
+                    itemCount: state.collections.length,
+                    itemBuilder: (context, index) {
+                      final collection = state.collections[index];
+                      final isMember = state.memberOf.contains(collection.id);
+                      final isBusy = state.busyIds.contains(collection.id);
+                      return ListTile(
+                        leading: Container(
+                          width: 40,
+                          height: 40,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: collectionGradientFor(collection.color),
+                            ),
+                            borderRadius: BorderRadius.circular(AppRadius.sm),
+                          ),
+                          child: FaIcon(
+                            collectionIconFor(collection.icon),
+                            color: Colors.white,
+                            size: 18,
+                          ),
+                        ),
+                        title: Text(
+                          collection.name,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                        trailing: isBusy
+                            ? const SizedBox(
+                                width: 20,
+                                height: 20,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              )
+                            : FaIcon(
+                                isMember
+                                    ? FontAwesomeIcons.solidCircleCheck
+                                    : FontAwesomeIcons.circlePlus,
+                                color: isMember
+                                    ? context.colorScheme.primary
+                                    : context.colorScheme.onSurfaceVariant,
+                              ),
+                        onTap: isBusy
+                            ? null
+                            : () => context.read<AddToCollectionCubit>().toggle(
+                                collection.id,
+                                bookmarkId,
+                              ),
+                      );
+                    },
+                  ),
+                ),
+              const SizedBox(height: AppSpacing.lg),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/collections/presentation/widgets/collection_card.dart
+++ b/lib/features/collections/presentation/widgets/collection_card.dart
@@ -1,0 +1,86 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../../../shared/domain/collections.dart';
+import '../../../../shared/presentation/collection_visuals.dart';
+
+/// A gradient card representing a single collection.
+///
+/// Ports the visual styling of the home dashboard's former hardcoded
+/// `_CollectionCard` so the two surfaces look identical.
+class CollectionCard extends StatelessWidget {
+  const CollectionCard({
+    super.key,
+    required this.collection,
+    required this.onTap,
+    this.width = 160,
+    this.height = 104,
+  });
+
+  final CollectionSummary collection;
+  final VoidCallback onTap;
+  final double width;
+  final double height;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      clipBehavior: Clip.antiAlias,
+      color: Colors.transparent,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: Ink(
+        width: width,
+        height: height,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: collectionGradientFor(collection.color),
+          ),
+          borderRadius: BorderRadius.circular(AppRadius.lg),
+        ),
+        child: InkWell(
+          onTap: onTap,
+          child: Padding(
+            padding: const EdgeInsets.all(AppSpacing.md),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    FaIcon(
+                      collectionIconFor(collection.icon),
+                      color: Colors.white,
+                      size: AppIconSize.md,
+                    ),
+                    Text(
+                      '${collection.itemCount}',
+                      style: context.textTheme.labelLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
+                ),
+                const Spacer(),
+                Text(
+                  collection.name,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: context.textTheme.labelMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/collections/presentation/widgets/collections_list_view.dart
+++ b/lib/features/collections/presentation/widgets/collections_list_view.dart
@@ -1,0 +1,107 @@
+import 'package:app_ui/app_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+import '../../../../app/di/injection.dart';
+import '../../../../app/router.dart';
+import '../../../../core/extensions/build_context_extensions.dart';
+import '../../../../shared/domain/collections.dart';
+import '../bloc/collections_list/collections_list_bloc.dart';
+import '../bloc/collections_list/collections_list_state.dart';
+import 'collection_card.dart';
+
+/// Self-contained collections grid: provides its own [CollectionsListBloc],
+/// handles loading/error/empty states, and renders a responsive grid of
+/// [CollectionCard]s. Reused by the standalone screen and the bookmarks
+/// "Collections" tab.
+class CollectionsListView extends StatelessWidget {
+  const CollectionsListView({super.key, this.padding});
+
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) =>
+          getIt<CollectionsListBloc>()
+            ..add(const CollectionsListLoadRequested()),
+      child: _CollectionsListBody(padding: padding),
+    );
+  }
+}
+
+class _CollectionsListBody extends StatelessWidget {
+  const _CollectionsListBody({this.padding});
+
+  final EdgeInsetsGeometry? padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<CollectionsListBloc, CollectionsListState>(
+      builder: (context, state) {
+        if (state.isLoading && state.items.isEmpty) {
+          return const Center(child: AppLoading());
+        }
+        if (state.failure != null && state.items.isEmpty) {
+          return AppErrorView(
+            message: context.l10n.collectionsLoadError,
+            onRetry: () => context.read<CollectionsListBloc>().add(
+              const CollectionsListLoadRequested(),
+            ),
+          );
+        }
+        if (state.items.isEmpty) {
+          return AppEmptyView(
+            icon: FontAwesomeIcons.layerGroup,
+            title: context.l10n.collectionsEmptyTitle,
+            message: context.l10n.collectionsEmptyMessage,
+            action: AppButton(
+              label: context.l10n.collectionsCreate,
+              icon: FontAwesomeIcons.plus,
+              onPressed: () => _createCollection(context),
+            ),
+          );
+        }
+
+        return GridView.builder(
+          padding:
+              padding ??
+              const EdgeInsets.fromLTRB(
+                AppSpacing.lg,
+                AppSpacing.sm,
+                AppSpacing.lg,
+                96,
+              ),
+          gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
+            maxCrossAxisExtent: 220,
+            mainAxisExtent: 116,
+            crossAxisSpacing: AppSpacing.md,
+            mainAxisSpacing: AppSpacing.md,
+          ),
+          itemCount: state.items.length,
+          itemBuilder: (context, index) {
+            final collection = state.items[index];
+            final summary = CollectionSummary(
+              id: collection.id,
+              name: collection.name,
+              icon: collection.icon,
+              color: collection.color,
+              itemCount: collection.itemCount,
+            );
+            return CollectionCard(
+              collection: summary,
+              width: double.infinity,
+              onTap: () => CollectionDetailRoute(collection.id).push<void>(
+                context,
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _createCollection(BuildContext context) =>
+      const CollectionNewRoute().push<void>(context);
+}

--- a/lib/features/home/presentation/bloc/home_bloc.dart
+++ b/lib/features/home/presentation/bloc/home_bloc.dart
@@ -4,17 +4,19 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 
 import '../../../../shared/domain/bookmark_stats.dart';
+import '../../../../shared/domain/collections.dart';
 import 'home_state.dart';
 
 part 'home_event.dart';
 
 @injectable
 class HomeBloc extends Bloc<HomeEvent, HomeState> {
-  HomeBloc(this._bookmarkStats) : super(const HomeState()) {
+  HomeBloc(this._bookmarkStats, this._collections) : super(const HomeState()) {
     on<HomeLoadRequested>(_onLoadRequested, transformer: droppable());
   }
 
   final BookmarkStatsReader _bookmarkStats;
+  final CollectionsReader _collections;
 
   Future<void> _onLoadRequested(
     HomeLoadRequested event,
@@ -36,6 +38,13 @@ class HomeBloc extends Bloc<HomeEvent, HomeState> {
         );
       case Err(:final failure):
         emit(state.copyWith(isLoading: false, failure: failure));
+        return;
+    }
+    // Collections are a secondary concern: a failure here shouldn't block the
+    // dashboard, so we only update the row when the read succeeds.
+    final collectionsResult = await _collections();
+    if (collectionsResult case Ok(value: final collections)) {
+      emit(state.copyWith(collections: collections));
     }
   }
 }

--- a/lib/features/home/presentation/bloc/home_state.dart
+++ b/lib/features/home/presentation/bloc/home_state.dart
@@ -2,6 +2,7 @@ import 'package:architecture/architecture.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../../../../shared/domain/bookmark_stats.dart';
+import '../../../../shared/domain/collections.dart';
 
 part 'home_state.freezed.dart';
 
@@ -12,6 +13,7 @@ abstract class HomeState with _$HomeState {
     @Default(0) int recentBookmarks,
     @Default(0) int uniqueTags,
     @Default([]) List<BookmarkSummary> recentItems,
+    @Default([]) List<CollectionSummary> collections,
     @Default(false) bool isLoading,
     Failure? failure,
   }) = _HomeState;

--- a/lib/features/home/presentation/widgets/home_welcome.dart
+++ b/lib/features/home/presentation/widgets/home_welcome.dart
@@ -331,112 +331,51 @@ class _SuggestedBookmarkCard extends StatelessWidget {
 }
 
 class _FeaturedCollectionsSection extends StatelessWidget {
-  const _FeaturedCollectionsSection({required this.items});
+  const _FeaturedCollectionsSection({required this.collections});
 
-  final List<BookmarkSummary> items;
+  final List<CollectionSummary> collections;
 
   @override
   Widget build(BuildContext context) {
-    final collections = _collections(context);
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _SectionHeader(
           title: context.l10n.homeFeaturedCollections,
-          actionLabel: context.l10n.homeViewAllBookmarks,
-          onActionPressed: () => const BookmarksListRoute().push<void>(context),
+          actionLabel: collections.isEmpty
+              ? context.l10n.homeCreateCollection
+              : context.l10n.homeViewAllBookmarks,
+          onActionPressed: collections.isEmpty
+              ? () => const CollectionNewRoute().push<void>(context)
+              : () => const CollectionsListRoute().push<void>(context),
         ),
         const SizedBox(height: AppSpacing.md),
-        SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          clipBehavior: Clip.none,
-          child: Row(
-            children: [
-              for (final (index, collection) in collections.indexed) ...[
-                if (index > 0) const SizedBox(width: AppSpacing.md),
-                _CollectionCard(collection: collection),
+        if (collections.isEmpty)
+          _CollectionCreateCard(
+            onTap: () => const CollectionNewRoute().push<void>(context),
+          )
+        else
+          SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            clipBehavior: Clip.none,
+            child: Row(
+              children: [
+                for (final (index, collection) in collections.indexed) ...[
+                  if (index > 0) const SizedBox(width: AppSpacing.md),
+                  _CollectionCard(collection: collection),
+                ],
               ],
-            ],
+            ),
           ),
-        ),
       ],
     );
   }
-
-  List<_CollectionData> _collections(BuildContext context) {
-    final tagCounts = <String, int>{};
-    for (final item in items) {
-      for (final tag in item.tags) {
-        final normalized = tag.trim();
-        if (normalized.isNotEmpty) {
-          tagCounts.update(normalized, (value) => value + 1, ifAbsent: () => 1);
-        }
-      }
-    }
-
-    final tagCollections = tagCounts.entries.toList()
-      ..sort((a, b) => b.value.compareTo(a.value));
-
-    final fromTags = tagCollections.take(3).map((entry) {
-      return _CollectionData(
-        title: entry.key,
-        icon: FontAwesomeIcons.hashtag,
-        colors: [
-          context.colorScheme.primaryContainer,
-          context.colorScheme.primary,
-        ],
-      );
-    }).toList();
-
-    if (fromTags.length >= 3) return fromTags;
-
-    return [
-      ...fromTags,
-      _CollectionData(
-        title: context.l10n.homeFilterDesign,
-        icon: FontAwesomeIcons.palette,
-        colors: [
-          context.colorScheme.primary,
-          context.colorScheme.tertiary,
-        ],
-      ),
-      _CollectionData(
-        title: context.l10n.homeFilterArticles,
-        icon: FontAwesomeIcons.bookOpen,
-        colors: [
-          context.colorScheme.tertiaryContainer,
-          context.colorScheme.tertiary,
-        ],
-      ),
-      _CollectionData(
-        title: context.l10n.homeFilterTools,
-        icon: FontAwesomeIcons.screwdriverWrench,
-        colors: [
-          context.colorScheme.secondary,
-          context.colorScheme.inverseSurface,
-        ],
-      ),
-    ].take(3).toList();
-  }
-}
-
-class _CollectionData {
-  const _CollectionData({
-    required this.title,
-    required this.icon,
-    required this.colors,
-  });
-
-  final String title;
-  final FaIconData icon;
-  final List<Color> colors;
 }
 
 class _CollectionCard extends StatelessWidget {
   const _CollectionCard({required this.collection});
 
-  final _CollectionData collection;
+  final CollectionSummary collection;
 
   @override
   Widget build(BuildContext context) {
@@ -453,34 +392,93 @@ class _CollectionCard extends StatelessWidget {
           gradient: LinearGradient(
             begin: Alignment.topLeft,
             end: Alignment.bottomRight,
-            colors: collection.colors,
+            colors: collectionGradientFor(collection.color),
           ),
           borderRadius: BorderRadius.circular(AppRadius.lg),
         ),
         child: InkWell(
-          onTap: () => const BookmarksListRoute().push<void>(context),
+          onTap: () => CollectionDetailRoute(collection.id).push<void>(context),
           child: Padding(
             padding: const EdgeInsets.all(AppSpacing.md),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                FaIcon(
-                  collection.icon,
-                  color: context.colorScheme.onPrimary,
-                  size: AppIconSize.md,
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    FaIcon(
+                      collectionIconFor(collection.icon),
+                      color: Colors.white,
+                      size: AppIconSize.md,
+                    ),
+                    Text(
+                      '${collection.itemCount}',
+                      style: context.textTheme.labelLarge?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                  ],
                 ),
                 const Spacer(),
                 Text(
-                  collection.title,
+                  collection.name,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
                   style: context.textTheme.labelMedium?.copyWith(
-                    color: context.colorScheme.onPrimary,
+                    color: Colors.white,
                     fontWeight: FontWeight.w800,
                   ),
                 ),
               ],
             ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _CollectionCreateCard extends StatelessWidget {
+  const _CollectionCreateCard({required this.onTap});
+
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      clipBehavior: Clip.antiAlias,
+      color: context.colorScheme.surfaceContainerHighest,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(AppRadius.lg),
+      ),
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(AppSpacing.lg),
+          child: Row(
+            children: [
+              FaIcon(
+                FontAwesomeIcons.layerGroup,
+                color: context.colorScheme.onSurfaceVariant,
+                size: AppIconSize.md,
+              ),
+              const SizedBox(width: AppSpacing.md),
+              Expanded(
+                child: Text(
+                  context.l10n.collectionsEmptyMessage,
+                  style: context.textTheme.bodyMedium?.copyWith(
+                    color: context.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppSpacing.sm),
+              FaIcon(
+                FontAwesomeIcons.plus,
+                color: context.colorScheme.primary,
+                size: AppIconSize.sm,
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/home/presentation/widgets/home_widgets.dart
+++ b/lib/features/home/presentation/widgets/home_widgets.dart
@@ -6,6 +6,8 @@ import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import '../../../../app/router.dart';
 import '../../../../core/extensions/build_context_extensions.dart';
 import '../../../../shared/domain/bookmark_stats.dart';
+import '../../../../shared/domain/collections.dart';
+import '../../../../shared/presentation/collection_visuals.dart';
 import '../bloc/home_bloc.dart';
 import '../bloc/home_state.dart';
 part 'home_welcome.dart';
@@ -104,7 +106,7 @@ class _HomeBodyState extends State<HomeBody> {
                         ).animateFadeIn(delay: 320.ms),
                         const SizedBox(height: AppSpacing.xl),
                         _FeaturedCollectionsSection(
-                          items: state.recentItems,
+                          collections: state.collections,
                         ).animateFadeIn(delay: 380.ms),
                         const SizedBox(height: AppSpacing.xl),
                         _RecentBookmarksSection(

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -315,5 +315,54 @@
         "example": "2"
       }
     }
-  }
+  },
+  "collectionsTitle": "Collections",
+  "collectionsEmptyTitle": "No collections yet",
+  "collectionsEmptyMessage": "Group related bookmarks into collections.",
+  "collectionsLoadError": "Couldn't load your collections. Pull to refresh or try again.",
+  "collectionsCreate": "New collection",
+  "collectionsCreateTitle": "New collection",
+  "collectionsEditTitle": "Edit collection",
+  "collectionNameLabel": "Name",
+  "collectionNameHint": "e.g. Design inspiration",
+  "collectionNameRequired": "Name is required",
+  "collectionAppearanceLabel": "Icon & color",
+  "collectionSave": "Save",
+  "collectionDeleteAction": "Delete collection",
+  "collectionDeleteDialogTitle": "Delete collection?",
+  "collectionDeleteDialogMessage": "\"{name}\" will be removed. Your bookmarks stay.",
+  "@collectionDeleteDialogMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Design inspiration"
+      }
+    }
+  },
+  "collectionNotFound": "Collection not found.",
+  "collectionItemsCount": "{count, plural, =0{No bookmarks} =1{1 bookmark} other{{count} bookmarks}}",
+  "@collectionItemsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "collectionAddBookmarks": "Add bookmarks",
+  "collectionRemoveBookmark": "Remove from collection",
+  "collectionEmptyBookmarks": "No bookmarks in this collection yet.",
+  "collectionPickerEmpty": "All your bookmarks are already in this collection.",
+  "collectionPickerAddCount": "Add {count}",
+  "@collectionPickerAddCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "addToCollectionTitle": "Add to collection",
+  "addToCollectionEmpty": "You haven't created any collections yet.",
+  "homeCreateCollection": "Create collection"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1165,6 +1165,156 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'{days}d ago'**
   String timeDaysAgo(int days);
+
+  /// No description provided for @collectionsTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Collections'**
+  String get collectionsTitle;
+
+  /// No description provided for @collectionsEmptyTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'No collections yet'**
+  String get collectionsEmptyTitle;
+
+  /// No description provided for @collectionsEmptyMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'Group related bookmarks into collections.'**
+  String get collectionsEmptyMessage;
+
+  /// No description provided for @collectionsLoadError.
+  ///
+  /// In en, this message translates to:
+  /// **'Couldn\'t load your collections. Pull to refresh or try again.'**
+  String get collectionsLoadError;
+
+  /// No description provided for @collectionsCreate.
+  ///
+  /// In en, this message translates to:
+  /// **'New collection'**
+  String get collectionsCreate;
+
+  /// No description provided for @collectionsCreateTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'New collection'**
+  String get collectionsCreateTitle;
+
+  /// No description provided for @collectionsEditTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Edit collection'**
+  String get collectionsEditTitle;
+
+  /// No description provided for @collectionNameLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Name'**
+  String get collectionNameLabel;
+
+  /// No description provided for @collectionNameHint.
+  ///
+  /// In en, this message translates to:
+  /// **'e.g. Design inspiration'**
+  String get collectionNameHint;
+
+  /// No description provided for @collectionNameRequired.
+  ///
+  /// In en, this message translates to:
+  /// **'Name is required'**
+  String get collectionNameRequired;
+
+  /// No description provided for @collectionAppearanceLabel.
+  ///
+  /// In en, this message translates to:
+  /// **'Icon & color'**
+  String get collectionAppearanceLabel;
+
+  /// No description provided for @collectionSave.
+  ///
+  /// In en, this message translates to:
+  /// **'Save'**
+  String get collectionSave;
+
+  /// No description provided for @collectionDeleteAction.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete collection'**
+  String get collectionDeleteAction;
+
+  /// No description provided for @collectionDeleteDialogTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Delete collection?'**
+  String get collectionDeleteDialogTitle;
+
+  /// No description provided for @collectionDeleteDialogMessage.
+  ///
+  /// In en, this message translates to:
+  /// **'\"{name}\" will be removed. Your bookmarks stay.'**
+  String collectionDeleteDialogMessage(String name);
+
+  /// No description provided for @collectionNotFound.
+  ///
+  /// In en, this message translates to:
+  /// **'Collection not found.'**
+  String get collectionNotFound;
+
+  /// No description provided for @collectionItemsCount.
+  ///
+  /// In en, this message translates to:
+  /// **'{count, plural, =0{No bookmarks} =1{1 bookmark} other{{count} bookmarks}}'**
+  String collectionItemsCount(int count);
+
+  /// No description provided for @collectionAddBookmarks.
+  ///
+  /// In en, this message translates to:
+  /// **'Add bookmarks'**
+  String get collectionAddBookmarks;
+
+  /// No description provided for @collectionRemoveBookmark.
+  ///
+  /// In en, this message translates to:
+  /// **'Remove from collection'**
+  String get collectionRemoveBookmark;
+
+  /// No description provided for @collectionEmptyBookmarks.
+  ///
+  /// In en, this message translates to:
+  /// **'No bookmarks in this collection yet.'**
+  String get collectionEmptyBookmarks;
+
+  /// No description provided for @collectionPickerEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'All your bookmarks are already in this collection.'**
+  String get collectionPickerEmpty;
+
+  /// No description provided for @collectionPickerAddCount.
+  ///
+  /// In en, this message translates to:
+  /// **'Add {count}'**
+  String collectionPickerAddCount(int count);
+
+  /// No description provided for @addToCollectionTitle.
+  ///
+  /// In en, this message translates to:
+  /// **'Add to collection'**
+  String get addToCollectionTitle;
+
+  /// No description provided for @addToCollectionEmpty.
+  ///
+  /// In en, this message translates to:
+  /// **'You haven\'t created any collections yet.'**
+  String get addToCollectionEmpty;
+
+  /// No description provided for @homeCreateCollection.
+  ///
+  /// In en, this message translates to:
+  /// **'Create collection'**
+  String get homeCreateCollection;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -583,4 +583,96 @@ class AppLocalizationsEn extends AppLocalizations {
   String timeDaysAgo(int days) {
     return '${days}d ago';
   }
+
+  @override
+  String get collectionsTitle => 'Collections';
+
+  @override
+  String get collectionsEmptyTitle => 'No collections yet';
+
+  @override
+  String get collectionsEmptyMessage =>
+      'Group related bookmarks into collections.';
+
+  @override
+  String get collectionsLoadError =>
+      'Couldn\'t load your collections. Pull to refresh or try again.';
+
+  @override
+  String get collectionsCreate => 'New collection';
+
+  @override
+  String get collectionsCreateTitle => 'New collection';
+
+  @override
+  String get collectionsEditTitle => 'Edit collection';
+
+  @override
+  String get collectionNameLabel => 'Name';
+
+  @override
+  String get collectionNameHint => 'e.g. Design inspiration';
+
+  @override
+  String get collectionNameRequired => 'Name is required';
+
+  @override
+  String get collectionAppearanceLabel => 'Icon & color';
+
+  @override
+  String get collectionSave => 'Save';
+
+  @override
+  String get collectionDeleteAction => 'Delete collection';
+
+  @override
+  String get collectionDeleteDialogTitle => 'Delete collection?';
+
+  @override
+  String collectionDeleteDialogMessage(String name) {
+    return '\"$name\" will be removed. Your bookmarks stay.';
+  }
+
+  @override
+  String get collectionNotFound => 'Collection not found.';
+
+  @override
+  String collectionItemsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count bookmarks',
+      one: '1 bookmark',
+      zero: 'No bookmarks',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get collectionAddBookmarks => 'Add bookmarks';
+
+  @override
+  String get collectionRemoveBookmark => 'Remove from collection';
+
+  @override
+  String get collectionEmptyBookmarks => 'No bookmarks in this collection yet.';
+
+  @override
+  String get collectionPickerEmpty =>
+      'All your bookmarks are already in this collection.';
+
+  @override
+  String collectionPickerAddCount(int count) {
+    return 'Add $count';
+  }
+
+  @override
+  String get addToCollectionTitle => 'Add to collection';
+
+  @override
+  String get addToCollectionEmpty =>
+      'You haven\'t created any collections yet.';
+
+  @override
+  String get homeCreateCollection => 'Create collection';
 }

--- a/lib/l10n/app_localizations_vi.dart
+++ b/lib/l10n/app_localizations_vi.dart
@@ -584,4 +584,96 @@ class AppLocalizationsVi extends AppLocalizations {
   String timeDaysAgo(int days) {
     return '$days ngày trước';
   }
+
+  @override
+  String get collectionsTitle => 'Bộ sưu tập';
+
+  @override
+  String get collectionsEmptyTitle => 'Chưa có bộ sưu tập';
+
+  @override
+  String get collectionsEmptyMessage =>
+      'Nhóm các dấu trang liên quan vào bộ sưu tập.';
+
+  @override
+  String get collectionsLoadError =>
+      'Không tải được bộ sưu tập. Kéo để làm mới hoặc thử lại.';
+
+  @override
+  String get collectionsCreate => 'Bộ sưu tập mới';
+
+  @override
+  String get collectionsCreateTitle => 'Bộ sưu tập mới';
+
+  @override
+  String get collectionsEditTitle => 'Sửa bộ sưu tập';
+
+  @override
+  String get collectionNameLabel => 'Tên';
+
+  @override
+  String get collectionNameHint => 'ví dụ: Cảm hứng thiết kế';
+
+  @override
+  String get collectionNameRequired => 'Vui lòng nhập tên';
+
+  @override
+  String get collectionAppearanceLabel => 'Biểu tượng & màu sắc';
+
+  @override
+  String get collectionSave => 'Lưu';
+
+  @override
+  String get collectionDeleteAction => 'Xóa bộ sưu tập';
+
+  @override
+  String get collectionDeleteDialogTitle => 'Xóa bộ sưu tập?';
+
+  @override
+  String collectionDeleteDialogMessage(String name) {
+    return '\"$name\" sẽ bị xóa. Các dấu trang của bạn vẫn được giữ lại.';
+  }
+
+  @override
+  String get collectionNotFound => 'Không tìm thấy bộ sưu tập.';
+
+  @override
+  String collectionItemsCount(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: '$count dấu trang',
+      one: '1 dấu trang',
+      zero: 'Chưa có dấu trang',
+    );
+    return '$_temp0';
+  }
+
+  @override
+  String get collectionAddBookmarks => 'Thêm dấu trang';
+
+  @override
+  String get collectionRemoveBookmark => 'Xóa khỏi bộ sưu tập';
+
+  @override
+  String get collectionEmptyBookmarks =>
+      'Bộ sưu tập này chưa có dấu trang nào.';
+
+  @override
+  String get collectionPickerEmpty =>
+      'Tất cả dấu trang đã có trong bộ sưu tập này.';
+
+  @override
+  String collectionPickerAddCount(int count) {
+    return 'Thêm $count';
+  }
+
+  @override
+  String get addToCollectionTitle => 'Thêm vào bộ sưu tập';
+
+  @override
+  String get addToCollectionEmpty => 'Bạn chưa tạo bộ sưu tập nào.';
+
+  @override
+  String get homeCreateCollection => 'Tạo bộ sưu tập';
 }

--- a/lib/l10n/app_vi.arb
+++ b/lib/l10n/app_vi.arb
@@ -225,5 +225,54 @@
         "example": "2"
       }
     }
-  }
+  },
+  "collectionsTitle": "Bộ sưu tập",
+  "collectionsEmptyTitle": "Chưa có bộ sưu tập",
+  "collectionsEmptyMessage": "Nhóm các dấu trang liên quan vào bộ sưu tập.",
+  "collectionsLoadError": "Không tải được bộ sưu tập. Kéo để làm mới hoặc thử lại.",
+  "collectionsCreate": "Bộ sưu tập mới",
+  "collectionsCreateTitle": "Bộ sưu tập mới",
+  "collectionsEditTitle": "Sửa bộ sưu tập",
+  "collectionNameLabel": "Tên",
+  "collectionNameHint": "ví dụ: Cảm hứng thiết kế",
+  "collectionNameRequired": "Vui lòng nhập tên",
+  "collectionAppearanceLabel": "Biểu tượng & màu sắc",
+  "collectionSave": "Lưu",
+  "collectionDeleteAction": "Xóa bộ sưu tập",
+  "collectionDeleteDialogTitle": "Xóa bộ sưu tập?",
+  "collectionDeleteDialogMessage": "\"{name}\" sẽ bị xóa. Các dấu trang của bạn vẫn được giữ lại.",
+  "@collectionDeleteDialogMessage": {
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "Cảm hứng thiết kế"
+      }
+    }
+  },
+  "collectionNotFound": "Không tìm thấy bộ sưu tập.",
+  "collectionItemsCount": "{count, plural, =0{Chưa có dấu trang} =1{1 dấu trang} other{{count} dấu trang}}",
+  "@collectionItemsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "3"
+      }
+    }
+  },
+  "collectionAddBookmarks": "Thêm dấu trang",
+  "collectionRemoveBookmark": "Xóa khỏi bộ sưu tập",
+  "collectionEmptyBookmarks": "Bộ sưu tập này chưa có dấu trang nào.",
+  "collectionPickerEmpty": "Tất cả dấu trang đã có trong bộ sưu tập này.",
+  "collectionPickerAddCount": "Thêm {count}",
+  "@collectionPickerAddCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "2"
+      }
+    }
+  },
+  "addToCollectionTitle": "Thêm vào bộ sưu tập",
+  "addToCollectionEmpty": "Bạn chưa tạo bộ sưu tập nào.",
+  "homeCreateCollection": "Tạo bộ sưu tập"
 }

--- a/lib/objectbox-model.json
+++ b/lib/objectbox-model.json
@@ -160,10 +160,71 @@
         }
       ],
       "relations": []
+    },
+    {
+      "id": "4:6914250643421223724",
+      "lastPropertyId": "10:5607791206085802444",
+      "name": "CollectionEntity",
+      "properties": [
+        {
+          "id": "1:2023590956800309880",
+          "name": "id",
+          "type": 6,
+          "flags": 1
+        },
+        {
+          "id": "2:2727045548820643396",
+          "name": "uuid",
+          "indexId": "4:5110644076683273229",
+          "type": 9,
+          "flags": 2080
+        },
+        {
+          "id": "3:7163441175278767034",
+          "name": "name",
+          "type": 9
+        },
+        {
+          "id": "4:6568231165468057271",
+          "name": "icon",
+          "type": 9
+        },
+        {
+          "id": "5:7202019221580211710",
+          "name": "color",
+          "type": 6
+        },
+        {
+          "id": "6:8485286719118650298",
+          "name": "bookmarkIds",
+          "type": 30
+        },
+        {
+          "id": "7:7311607500392150555",
+          "name": "createdAt",
+          "type": 12
+        },
+        {
+          "id": "8:7855977241027702413",
+          "name": "updatedAt",
+          "type": 12
+        },
+        {
+          "id": "9:2362733061684217003",
+          "name": "serverUpdatedAt",
+          "type": 12
+        },
+        {
+          "id": "10:5607791206085802444",
+          "name": "syncStateCode",
+          "type": 6
+        }
+      ],
+      "relations": []
     }
   ],
-  "lastEntityId": "3:1349722681213321324",
-  "lastIndexId": "3:7678540160299865532",
+  "lastEntityId": "4:6914250643421223724",
+  "lastIndexId": "4:5110644076683273229",
   "lastRelationId": "0:0",
   "lastSequenceId": "0:0",
   "modelVersion": 5,

--- a/lib/objectbox.g.dart
+++ b/lib/objectbox.g.dart
@@ -15,6 +15,7 @@ import 'package:objectbox/objectbox.dart' as obx;
 import 'package:objectbox_flutter_libs/objectbox_flutter_libs.dart';
 
 import 'features/bookmarks/data/local/bookmark_entity.dart';
+import 'features/collections/data/local/collection_entity.dart';
 import 'features/notifications/data/local/activity_entity.dart';
 import 'features/notifications/data/local/notification_entity.dart';
 
@@ -204,6 +205,77 @@ final _entities = <obx_int.ModelEntity>[
     relations: <obx_int.ModelRelation>[],
     backlinks: <obx_int.ModelBacklink>[],
   ),
+  obx_int.ModelEntity(
+    id: const obx_int.IdUid(4, 6914250643421223724),
+    name: 'CollectionEntity',
+    lastPropertyId: const obx_int.IdUid(10, 5607791206085802444),
+    flags: 0,
+    properties: <obx_int.ModelProperty>[
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(1, 2023590956800309880),
+        name: 'id',
+        type: 6,
+        flags: 1,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(2, 2727045548820643396),
+        name: 'uuid',
+        type: 9,
+        flags: 2080,
+        indexId: const obx_int.IdUid(4, 5110644076683273229),
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(3, 7163441175278767034),
+        name: 'name',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(4, 6568231165468057271),
+        name: 'icon',
+        type: 9,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(5, 7202019221580211710),
+        name: 'color',
+        type: 6,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(6, 8485286719118650298),
+        name: 'bookmarkIds',
+        type: 30,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(7, 7311607500392150555),
+        name: 'createdAt',
+        type: 12,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(8, 7855977241027702413),
+        name: 'updatedAt',
+        type: 12,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(9, 2362733061684217003),
+        name: 'serverUpdatedAt',
+        type: 12,
+        flags: 0,
+      ),
+      obx_int.ModelProperty(
+        id: const obx_int.IdUid(10, 5607791206085802444),
+        name: 'syncStateCode',
+        type: 6,
+        flags: 0,
+      ),
+    ],
+    relations: <obx_int.ModelRelation>[],
+    backlinks: <obx_int.ModelBacklink>[],
+  ),
 ];
 
 /// Shortcut for [obx.Store.new] that passes [getObjectBoxModel] and for Flutter
@@ -249,8 +321,8 @@ obx_int.ModelDefinition getObjectBoxModel() {
     // Typically, this is done with `dart run build_runner build`.
     generatorVersion: obx_int.GeneratorVersion.v2025_12_16,
     entities: _entities,
-    lastEntityId: const obx_int.IdUid(3, 1349722681213321324),
-    lastIndexId: const obx_int.IdUid(3, 7678540160299865532),
+    lastEntityId: const obx_int.IdUid(4, 6914250643421223724),
+    lastIndexId: const obx_int.IdUid(4, 5110644076683273229),
     lastRelationId: const obx_int.IdUid(0, 0),
     lastSequenceId: const obx_int.IdUid(0, 0),
     retiredEntityUids: const [],
@@ -515,6 +587,111 @@ obx_int.ModelDefinition getObjectBoxModel() {
         return object;
       },
     ),
+    CollectionEntity: obx_int.EntityDefinition<CollectionEntity>(
+      model: _entities[3],
+      toOneRelations: (CollectionEntity object) => [],
+      toManyRelations: (CollectionEntity object) => {},
+      getId: (CollectionEntity object) => object.id,
+      setId: (CollectionEntity object, int id) {
+        object.id = id;
+      },
+      objectToFB: (CollectionEntity object, fb.Builder fbb) {
+        final uuidOffset = fbb.writeString(object.uuid);
+        final nameOffset = fbb.writeString(object.name);
+        final iconOffset = fbb.writeString(object.icon);
+        final bookmarkIdsOffset = fbb.writeList(
+          object.bookmarkIds.map(fbb.writeString).toList(growable: false),
+        );
+        fbb.startTable(11);
+        fbb.addInt64(0, object.id);
+        fbb.addOffset(1, uuidOffset);
+        fbb.addOffset(2, nameOffset);
+        fbb.addOffset(3, iconOffset);
+        fbb.addInt64(4, object.color);
+        fbb.addOffset(5, bookmarkIdsOffset);
+        fbb.addInt64(6, object.createdAt.microsecondsSinceEpoch * 1000);
+        fbb.addInt64(7, object.updatedAt.microsecondsSinceEpoch * 1000);
+        fbb.addInt64(
+          8,
+          object.serverUpdatedAt == null
+              ? null
+              : object.serverUpdatedAt!.microsecondsSinceEpoch * 1000,
+        );
+        fbb.addInt64(9, object.syncStateCode);
+        fbb.finish(fbb.endTable());
+        return object.id;
+      },
+      objectFromFB: (obx.Store store, ByteData fbData) {
+        final buffer = fb.BufferContext(fbData);
+        final rootOffset = buffer.derefObject(0);
+        final serverUpdatedAtValue = const fb.Int64Reader().vTableGetNullable(
+          buffer,
+          rootOffset,
+          20,
+        );
+        final idParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          4,
+          0,
+        );
+        final uuidParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 6, '');
+        final nameParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 8, '');
+        final iconParam = const fb.StringReader(
+          asciiOptimization: true,
+        ).vTableGet(buffer, rootOffset, 10, '');
+        final colorParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          12,
+          0,
+        );
+        final bookmarkIdsParam = const fb.ListReader<String>(
+          fb.StringReader(asciiOptimization: true),
+          lazy: false,
+        ).vTableGet(buffer, rootOffset, 14, []);
+        final createdAtParam = DateTime.fromMicrosecondsSinceEpoch(
+          (const fb.Int64Reader().vTableGet(buffer, rootOffset, 16, 0) / 1000)
+              .round(),
+          isUtc: true,
+        );
+        final updatedAtParam = DateTime.fromMicrosecondsSinceEpoch(
+          (const fb.Int64Reader().vTableGet(buffer, rootOffset, 18, 0) / 1000)
+              .round(),
+          isUtc: true,
+        );
+        final serverUpdatedAtParam = serverUpdatedAtValue == null
+            ? null
+            : DateTime.fromMicrosecondsSinceEpoch(
+                (serverUpdatedAtValue / 1000).round(),
+                isUtc: true,
+              );
+        final syncStateCodeParam = const fb.Int64Reader().vTableGet(
+          buffer,
+          rootOffset,
+          22,
+          0,
+        );
+        final object = CollectionEntity(
+          id: idParam,
+          uuid: uuidParam,
+          name: nameParam,
+          icon: iconParam,
+          color: colorParam,
+          bookmarkIds: bookmarkIdsParam,
+          createdAt: createdAtParam,
+          updatedAt: updatedAtParam,
+          serverUpdatedAt: serverUpdatedAtParam,
+          syncStateCode: syncStateCodeParam,
+        );
+
+        return object;
+      },
+    ),
   };
 
   return obx_int.ModelDefinition(model, bindings);
@@ -651,5 +828,58 @@ class NotificationEntity_ {
   /// See [NotificationEntity.pendingRead].
   static final pendingRead = obx.QueryBooleanProperty<NotificationEntity>(
     _entities[2].properties[7],
+  );
+}
+
+/// [CollectionEntity] entity fields to define ObjectBox queries.
+class CollectionEntity_ {
+  /// See [CollectionEntity.id].
+  static final id = obx.QueryIntegerProperty<CollectionEntity>(
+    _entities[3].properties[0],
+  );
+
+  /// See [CollectionEntity.uuid].
+  static final uuid = obx.QueryStringProperty<CollectionEntity>(
+    _entities[3].properties[1],
+  );
+
+  /// See [CollectionEntity.name].
+  static final name = obx.QueryStringProperty<CollectionEntity>(
+    _entities[3].properties[2],
+  );
+
+  /// See [CollectionEntity.icon].
+  static final icon = obx.QueryStringProperty<CollectionEntity>(
+    _entities[3].properties[3],
+  );
+
+  /// See [CollectionEntity.color].
+  static final color = obx.QueryIntegerProperty<CollectionEntity>(
+    _entities[3].properties[4],
+  );
+
+  /// See [CollectionEntity.bookmarkIds].
+  static final bookmarkIds = obx.QueryStringVectorProperty<CollectionEntity>(
+    _entities[3].properties[5],
+  );
+
+  /// See [CollectionEntity.createdAt].
+  static final createdAt = obx.QueryDateNanoProperty<CollectionEntity>(
+    _entities[3].properties[6],
+  );
+
+  /// See [CollectionEntity.updatedAt].
+  static final updatedAt = obx.QueryDateNanoProperty<CollectionEntity>(
+    _entities[3].properties[7],
+  );
+
+  /// See [CollectionEntity.serverUpdatedAt].
+  static final serverUpdatedAt = obx.QueryDateNanoProperty<CollectionEntity>(
+    _entities[3].properties[8],
+  );
+
+  /// See [CollectionEntity.syncStateCode].
+  static final syncStateCode = obx.QueryIntegerProperty<CollectionEntity>(
+    _entities[3].properties[9],
   );
 }

--- a/lib/shared/domain/bookmark_summaries.dart
+++ b/lib/shared/domain/bookmark_summaries.dart
@@ -1,0 +1,13 @@
+import 'package:architecture/architecture.dart';
+
+import 'bookmark_stats.dart';
+
+/// Reads every bookmark as a lightweight [BookmarkSummary].
+///
+/// Implemented by the bookmarks feature and consumed through `shared` by the
+/// collections feature, so collections can resolve its member bookmark ids and
+/// offer an "add bookmarks" picker without depending on the bookmarks domain.
+abstract class BookmarkSummariesReader
+    extends NoParamUseCase<List<BookmarkSummary>> {
+  const BookmarkSummariesReader();
+}

--- a/lib/shared/domain/collections.dart
+++ b/lib/shared/domain/collections.dart
@@ -1,0 +1,35 @@
+import 'package:architecture/architecture.dart';
+
+/// Lightweight projection of a collection for cross-feature display (e.g. the
+/// home dashboard and the bookmarks "Collections" tab), so consumers don't
+/// depend on the collections feature's `Collection` aggregate.
+class CollectionSummary {
+  const CollectionSummary({
+    required this.id,
+    required this.name,
+    required this.icon,
+    required this.color,
+    required this.itemCount,
+  });
+
+  final String id;
+  final String name;
+
+  /// Stable token mapped to an icon by the shared collection visuals (see
+  /// `collectionIconFor`). Stored as a string so it survives JSON and ObjectBox
+  /// round-trips without depending on icon-font internals.
+  final String icon;
+
+  /// ARGB color value used as the seed for the card gradient.
+  final int color;
+
+  /// Number of bookmarks in the collection.
+  final int itemCount;
+}
+
+/// Reads collection summaries. Implemented by the collections feature (which
+/// owns the data) and consumed through `shared` by `home` and `bookmarks`.
+abstract class CollectionsReader
+    extends NoParamUseCase<List<CollectionSummary>> {
+  const CollectionsReader();
+}

--- a/lib/shared/presentation/collection_visuals.dart
+++ b/lib/shared/presentation/collection_visuals.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
+/// Shared visual vocabulary for collections so both the collections feature and
+/// the home dashboard render identical icon/color cards without one feature
+/// importing the other's presentation layer.
+
+/// A selectable icon + color preset for a collection.
+class CollectionVisualOption {
+  const CollectionVisualOption({required this.icon, required this.color});
+
+  final FaIconData icon;
+  final Color color;
+
+  /// Stable token persisted on the collection, derived from the icon's code
+  /// point so it survives JSON/ObjectBox round-trips without depending on
+  /// icon-font internals.
+  String get token => icon.codePoint.toRadixString(16);
+}
+
+/// The fixed set of icon/color presets offered when creating a collection.
+const List<CollectionVisualOption> collectionPalette = [
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.layerGroup,
+    color: Color(0xFF6366F1),
+  ),
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.palette,
+    color: Color(0xFFEC4899),
+  ),
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.bookOpen,
+    color: Color(0xFF0EA5E9),
+  ),
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.screwdriverWrench,
+    color: Color(0xFF10B981),
+  ),
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.lightbulb,
+    color: Color(0xFFF59E0B),
+  ),
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.heart,
+    color: Color(0xFFEF4444),
+  ),
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.briefcase,
+    color: Color(0xFF8B5CF6),
+  ),
+  CollectionVisualOption(
+    icon: FontAwesomeIcons.graduationCap,
+    color: Color(0xFF14B8A6),
+  ),
+];
+
+final Map<String, FaIconData> _iconsByToken = {
+  for (final option in collectionPalette) option.token: option.icon,
+};
+
+/// Resolves a persisted icon `token` back to a `FaIconData`, falling back to a
+/// generic collection icon for unknown tokens.
+FaIconData collectionIconFor(String token) =>
+    _iconsByToken[token] ?? FontAwesomeIcons.layerGroup;
+
+/// Builds the two-stop gradient for a collection card from its seed [color].
+List<Color> collectionGradientFor(int color) {
+  final seed = Color(color);
+  final darker = Color.lerp(seed, Colors.black, 0.28) ?? seed;
+  return [seed, darker];
+}

--- a/test/architecture/feature_boundaries_test.dart
+++ b/test/architecture/feature_boundaries_test.dart
@@ -39,6 +39,15 @@ const _allowedCrossFeatureImports = <String, Set<String>>{
     'auth/presentation/bloc/delete_account_cubit.dart',
     'auth/presentation/bloc/delete_account_state.dart',
   },
+  // `bookmarks` surfaces two collections capabilities (single consumer each):
+  // the "add to collection" sheet on the bookmark detail screen, and the
+  // collections list embedded in the bookmarks "Collections" tab. Home reads
+  // collections through the shared `CollectionsReader` contract instead, so
+  // bookmarks remains the only consumer of these presentation widgets.
+  'bookmarks': {
+    'collections/presentation/widgets/add_to_collection_sheet.dart',
+    'collections/presentation/widgets/collections_list_view.dart',
+  },
 };
 
 void main() {

--- a/test/features/bookmarks/domain/services/bookmark_summaries_service_test.dart
+++ b/test/features/bookmarks/domain/services/bookmark_summaries_service_test.dart
@@ -1,0 +1,43 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/bookmarks/domain/entities/bookmark.dart';
+import 'package:flutter_starter_template/features/bookmarks/domain/services/bookmark_summaries_service.dart';
+import 'package:flutter_starter_template/shared/domain/bookmark_stats.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../../../test_utils.dart';
+
+void main() {
+  late MockListBookmarks list;
+  late BookmarkSummariesService service;
+
+  setUp(() {
+    list = MockListBookmarks();
+    service = BookmarkSummariesService(list);
+  });
+
+  test('maps bookmarks to summaries', () async {
+    final bookmark = Bookmark(
+      id: 'b-1',
+      title: 'Flutter',
+      url: 'https://flutter.dev',
+      description: 'desc',
+      tags: const ['dev'],
+      createdAt: DateTime(2025),
+      updatedAt: DateTime(2025),
+    );
+    when(() => list()).thenAnswer((_) async => Ok([bookmark]));
+
+    final result = await service();
+
+    final summary = (result as Ok<List<BookmarkSummary>>).value.single;
+    expect(summary.id, 'b-1');
+    expect(summary.title, 'Flutter');
+    expect(summary.tags, ['dev']);
+  });
+
+  test('propagates failure', () async {
+    when(() => list()).thenAnswer((_) async => const Err(UnknownFailure('x')));
+
+    expect(await service(), isA<Err<List<BookmarkSummary>>>());
+  });
+}

--- a/test/features/bookmarks/presentation/widgets/bookmarks_grid_test.dart
+++ b/test/features/bookmarks/presentation/widgets/bookmarks_grid_test.dart
@@ -1,14 +1,22 @@
+import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_starter_template/app/di/injection.dart';
 import 'package:flutter_starter_template/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_bloc.dart';
 import 'package:flutter_starter_template/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_state.dart';
 import 'package:flutter_starter_template/features/bookmarks/presentation/widgets/bookmarks_list_widgets.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collections_list/collections_list_bloc.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collections_list/collections_list_state.dart';
 import 'package:flutter_starter_template/l10n/app_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../../../test_utils.dart';
 
 class MockBookmarksListBloc extends Mock implements BookmarksListBloc {}
+
+class MockCollectionsListBloc
+    extends MockBloc<CollectionsListEvent, CollectionsListState>
+    implements CollectionsListBloc {}
 
 void main() {
   late MockBookmarksListBloc listBloc;
@@ -18,7 +26,15 @@ void main() {
     final state = BookmarksListState(items: [testBookmark, testBookmark2]);
     when(() => listBloc.state).thenReturn(state);
     when(() => listBloc.stream).thenAnswer((_) => Stream.value(state));
+
+    // The Collections tab embeds the collections feature's list view, which
+    // resolves its bloc from getIt. Register an empty one.
+    final collectionsBloc = MockCollectionsListBloc();
+    when(() => collectionsBloc.state).thenReturn(const CollectionsListState());
+    getIt.registerFactory<CollectionsListBloc>(() => collectionsBloc);
   });
+
+  tearDown(getIt.reset);
 
   Future<void> pumpList(WidgetTester tester, double width) async {
     tester.view.physicalSize = Size(width, 900);
@@ -66,15 +82,15 @@ void main() {
       expect(find.text('Collections'), findsOneWidget);
     });
 
-    testWidgets('Collections tab shows the coming-soon placeholder', (
-      tester,
-    ) async {
+    testWidgets('Collections tab shows the collections list', (tester) async {
       await pumpList(tester, 500);
 
       await tester.tap(find.text('Collections'));
       await tester.pump(const Duration(milliseconds: 300));
 
-      expect(find.text('Collections coming soon'), findsOneWidget);
+      // With no collections, the embedded collections view shows its empty
+      // state instead of the bookmarks grid.
+      expect(find.text('No collections yet'), findsOneWidget);
       expect(find.text('Flutter'), findsNothing);
     });
 

--- a/test/features/collections/collections_test_helpers.dart
+++ b/test/features/collections/collections_test_helpers.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_starter_template/features/collections/domain/entities/collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/repositories/collections_repository.dart';
+import 'package:flutter_starter_template/features/collections/domain/services/collections_sync_controller.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/create_collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/delete_collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/get_collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/list_collections.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/list_local_collections.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/update_collection.dart';
+import 'package:flutter_starter_template/shared/domain/bookmark_stats.dart';
+import 'package:flutter_starter_template/shared/domain/bookmark_summaries.dart';
+import 'package:test_utils/test_utils.dart';
+
+class MockCollectionsRepository extends Mock implements CollectionsRepository {}
+
+class MockListCollections extends Mock implements ListCollections {}
+
+class MockListLocalCollections extends Mock implements ListLocalCollections {}
+
+class MockGetCollection extends Mock implements GetCollection {}
+
+class MockCreateCollection extends Mock implements CreateCollection {}
+
+class MockUpdateCollection extends Mock implements UpdateCollection {}
+
+class MockDeleteCollection extends Mock implements DeleteCollection {}
+
+class MockCollectionsSyncController extends Mock
+    implements CollectionsSyncController {}
+
+class MockBookmarkSummariesReader extends Mock
+    implements BookmarkSummariesReader {}
+
+class FakeCollectionInput extends Fake implements CollectionInput {}
+
+class FakeUpdateCollectionParams extends Fake
+    implements UpdateCollectionParams {}
+
+Collection buildCollection({
+  String id = 'c-1',
+  String name = 'Design',
+  String icon = 'f5fd',
+  int color = 0xFF6366F1,
+  List<String> bookmarkIds = const ['b-1'],
+}) => Collection(
+  id: id,
+  name: name,
+  icon: icon,
+  color: color,
+  bookmarkIds: bookmarkIds,
+  createdAt: DateTime(2025),
+  updatedAt: DateTime(2025),
+);
+
+BookmarkSummary buildSummary({String id = 'b-1', String title = 'Flutter'}) =>
+    BookmarkSummary(
+      id: id,
+      title: title,
+      url: 'https://flutter.dev',
+      description: '',
+      tags: const [],
+    );

--- a/test/features/collections/data/repositories/collections_repository_impl_test.dart
+++ b/test/features/collections/data/repositories/collections_repository_impl_test.dart
@@ -1,0 +1,183 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/collections/data/local/collection_entity.dart';
+import 'package:flutter_starter_template/features/collections/data/local/collections_local_data_source.dart';
+import 'package:flutter_starter_template/features/collections/data/repositories/collections_repository_impl.dart';
+import 'package:flutter_starter_template/features/collections/domain/entities/collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/services/collections_sync_controller.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+import 'package:uuid/uuid.dart';
+
+class MockCollectionsLocalDataSource extends Mock
+    implements CollectionsLocalDataSource {}
+
+class MockCollectionsSyncController extends Mock
+    implements CollectionsSyncController {}
+
+class MockUuid extends Mock implements Uuid {}
+
+class FakeCollectionEntity extends Fake implements CollectionEntity {}
+
+void main() {
+  late MockCollectionsLocalDataSource mockLocal;
+  late MockCollectionsSyncController mockSync;
+  late MockUuid mockUuid;
+  late CollectionsRepositoryImpl repository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeCollectionEntity());
+  });
+
+  final now = DateTime(2025, 6, 1, 12, 0, 0, 0, 0);
+
+  CollectionEntity createEntity({
+    int id = 1,
+    String uuid = 'c-1',
+    String name = 'Design',
+    String icon = 'f5fd',
+    int color = 0xFF6366F1,
+    List<String> bookmarkIds = const ['b-1'],
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    int syncStateCode = 0, // synced
+  }) {
+    return CollectionEntity(
+      id: id,
+      uuid: uuid,
+      name: name,
+      icon: icon,
+      color: color,
+      bookmarkIds: List.of(bookmarkIds),
+      createdAt: createdAt ?? now,
+      updatedAt: updatedAt ?? now,
+      syncStateCode: syncStateCode,
+    );
+  }
+
+  setUp(() {
+    mockLocal = MockCollectionsLocalDataSource();
+    mockSync = MockCollectionsSyncController();
+    mockUuid = MockUuid();
+    when(() => mockSync.sync()).thenAnswer((_) async {});
+    repository = CollectionsRepositoryImpl(mockLocal, mockSync, mockUuid);
+  });
+
+  group('list', () {
+    test(
+      'returns collections mapped from entities and triggers sync',
+      () async {
+        when(
+          () => mockLocal.listVisible(),
+        ).thenAnswer((_) async => [createEntity()]);
+
+        final result = await repository.list();
+
+        final ok = result as Ok<List<Collection>>;
+        expect(ok.value.single.id, 'c-1');
+        expect(ok.value.single.itemCount, 1);
+        verify(() => mockSync.sync()).called(1);
+      },
+    );
+  });
+
+  group('create', () {
+    test('normalizes name + dedupes ids and marks pendingCreate', () async {
+      when(() => mockUuid.v4()).thenReturn('new-uuid');
+      when(() => mockLocal.putNew(any())).thenAnswer(
+        (invocation) async =>
+            invocation.positionalArguments[0] as CollectionEntity,
+      );
+
+      final result = await repository.create(
+        const CollectionInput(
+          name: '  Reading  ',
+          icon: 'f02d',
+          color: 0xFF0EA5E9,
+          bookmarkIds: ['  b-1  ', 'b-1', '  b-2  '],
+        ),
+      );
+
+      final ok = result as Ok<Collection>;
+      expect(ok.value.id, 'new-uuid');
+      expect(ok.value.name, 'Reading');
+      expect(ok.value.bookmarkIds, ['b-1', 'b-2']);
+      expect(ok.value.isPendingSync, isTrue);
+
+      final captured =
+          verify(() => mockLocal.putNew(captureAny())).captured.single
+              as CollectionEntity;
+      expect(captured.syncState, SyncState.pendingCreate);
+      verify(() => mockSync.sync()).called(1);
+    });
+  });
+
+  group('update', () {
+    const input = CollectionInput(
+      name: 'Updated',
+      icon: 'f02d',
+      color: 0xFF10B981,
+      bookmarkIds: ['b-9'],
+    );
+
+    test('transitions synced to pendingUpdate', () async {
+      final entity = createEntity();
+      when(() => mockLocal.getByUuid('c-1')).thenAnswer((_) async => entity);
+      when(() => mockLocal.put(any())).thenAnswer((_) async {});
+
+      final result = await repository.update('c-1', input);
+
+      final ok = result as Ok<Collection>;
+      expect(ok.value.name, 'Updated');
+      expect(ok.value.bookmarkIds, ['b-9']);
+      expect(entity.syncState, SyncState.pendingUpdate);
+      verify(() => mockSync.sync()).called(1);
+    });
+
+    test('keeps pendingCreate when updating pendingCreate', () async {
+      final entity = createEntity(syncStateCode: SyncState.pendingCreate.code);
+      when(() => mockLocal.getByUuid('c-1')).thenAnswer((_) async => entity);
+      when(() => mockLocal.put(any())).thenAnswer((_) async {});
+
+      await repository.update('c-1', input);
+
+      expect(entity.syncState, SyncState.pendingCreate);
+    });
+
+    test('returns NotFoundFailure when missing', () async {
+      when(() => mockLocal.getByUuid('c-1')).thenAnswer((_) async => null);
+
+      final result = await repository.update('c-1', input);
+
+      expect(result, isA<Err<Collection>>());
+    });
+  });
+
+  group('delete', () {
+    test('hard deletes pendingCreate without sync', () async {
+      final entity = createEntity(
+        id: 42,
+        syncStateCode: SyncState.pendingCreate.code,
+      );
+      when(() => mockLocal.getByUuid('c-1')).thenAnswer((_) async => entity);
+      when(() => mockLocal.hardDelete(42)).thenAnswer((_) async {});
+
+      final result = await repository.delete('c-1');
+
+      expect(result, isA<Ok<void>>());
+      verify(() => mockLocal.hardDelete(42)).called(1);
+      verifyNever(() => mockSync.sync());
+    });
+
+    test('marks synced as pendingDelete and triggers sync', () async {
+      final entity = createEntity();
+      when(() => mockLocal.getByUuid('c-1')).thenAnswer((_) async => entity);
+      when(() => mockLocal.put(any())).thenAnswer((_) async {});
+
+      final result = await repository.delete('c-1');
+
+      expect(result, isA<Ok<void>>());
+      expect(entity.syncState, SyncState.pendingDelete);
+      verify(() => mockSync.sync()).called(1);
+    });
+  });
+}

--- a/test/features/collections/data/sync/collections_pull_reconciler_test.dart
+++ b/test/features/collections/data/sync/collections_pull_reconciler_test.dart
@@ -1,0 +1,117 @@
+import 'package:flutter_starter_template/features/collections/data/datasources/collections_remote_data_source.dart';
+import 'package:flutter_starter_template/features/collections/data/local/collection_entity.dart';
+import 'package:flutter_starter_template/features/collections/data/local/collections_local_data_source.dart';
+import 'package:flutter_starter_template/features/collections/data/models/collection_dto.dart';
+import 'package:flutter_starter_template/features/collections/data/sync/collections_pull_reconciler.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+class MockCollectionsRemoteDataSource extends Mock
+    implements CollectionsRemoteDataSource {}
+
+class MockCollectionsLocalDataSource extends Mock
+    implements CollectionsLocalDataSource {}
+
+class FakeCollectionEntity extends Fake implements CollectionEntity {}
+
+void main() {
+  late MockCollectionsRemoteDataSource remote;
+  late MockCollectionsLocalDataSource local;
+  late CollectionsPullReconciler reconciler;
+
+  setUpAll(() => registerFallbackValue(FakeCollectionEntity()));
+
+  final t0 = DateTime.utc(2025, 1, 1);
+  final t1 = DateTime.utc(2025, 2, 1);
+
+  CollectionDto dto(String id, {DateTime? updatedAt, String name = 'Server'}) =>
+      CollectionDto(
+        id: id,
+        name: name,
+        icon: 'f5fd',
+        color: 0xFF6366F1,
+        bookmarkIds: const ['b-1'],
+        createdAt: t0,
+        updatedAt: updatedAt ?? t0,
+      );
+
+  CollectionEntity entity({
+    required String uuid,
+    required DateTime updatedAt,
+    int syncStateCode = 0,
+    String name = 'Local',
+  }) => CollectionEntity(
+    id: uuid.hashCode,
+    uuid: uuid,
+    name: name,
+    icon: 'f5fd',
+    color: 0xFF6366F1,
+    bookmarkIds: const ['b-1'],
+    createdAt: t0,
+    updatedAt: updatedAt,
+    syncStateCode: syncStateCode,
+  );
+
+  setUp(() {
+    remote = MockCollectionsRemoteDataSource();
+    local = MockCollectionsLocalDataSource();
+    when(() => local.put(any())).thenAnswer((_) async {});
+    when(() => local.hardDelete(any())).thenAnswer((_) async {});
+    reconciler = CollectionsPullReconciler(local, remote);
+  });
+
+  test('inserts server-only collections as synced', () async {
+    when(() => remote.list()).thenAnswer((_) async => [dto('c-1')]);
+    when(() => local.listAll()).thenAnswer((_) async => []);
+
+    await reconciler.pull();
+
+    final captured =
+        verify(() => local.put(captureAny())).captured.single
+            as CollectionEntity;
+    expect(captured.uuid, 'c-1');
+    expect(captured.syncState, SyncState.synced);
+  });
+
+  test(
+    'updates local synced row when server is newer (last-write-wins)',
+    () async {
+      final local0 = entity(uuid: 'c-1', updatedAt: t0);
+      when(() => remote.list()).thenAnswer(
+        (_) async => [dto('c-1', updatedAt: t1, name: 'Newer')],
+      );
+      when(() => local.listAll()).thenAnswer((_) async => [local0]);
+
+      await reconciler.pull();
+
+      expect(local0.name, 'Newer');
+      verify(() => local.put(local0)).called(1);
+    },
+  );
+
+  test('skips locally pending rows during reconcile', () async {
+    final pending = entity(
+      uuid: 'c-1',
+      updatedAt: t0,
+      syncStateCode: SyncState.pendingUpdate.code,
+    );
+    when(() => remote.list()).thenAnswer(
+      (_) async => [dto('c-1', updatedAt: t1)],
+    );
+    when(() => local.listAll()).thenAnswer((_) async => [pending]);
+
+    await reconciler.pull();
+
+    verifyNever(() => local.put(any()));
+  });
+
+  test('removes local synced rows the server no longer has', () async {
+    final orphan = entity(uuid: 'c-9', updatedAt: t0);
+    when(() => remote.list()).thenAnswer((_) async => []);
+    when(() => local.listAll()).thenAnswer((_) async => [orphan]);
+
+    await reconciler.pull();
+
+    verify(() => local.hardDelete(orphan.id)).called(1);
+  });
+}

--- a/test/features/collections/data/sync/collections_push_queue_test.dart
+++ b/test/features/collections/data/sync/collections_push_queue_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter_starter_template/features/collections/data/datasources/collections_remote_data_source.dart';
+import 'package:flutter_starter_template/features/collections/data/local/collection_entity.dart';
+import 'package:flutter_starter_template/features/collections/data/local/collections_local_data_source.dart';
+import 'package:flutter_starter_template/features/collections/data/models/collection_dto.dart';
+import 'package:flutter_starter_template/features/collections/data/models/collection_request.dart';
+import 'package:flutter_starter_template/features/collections/data/sync/collections_push_queue.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+class MockCollectionsRemoteDataSource extends Mock
+    implements CollectionsRemoteDataSource {}
+
+class MockCollectionsLocalDataSource extends Mock
+    implements CollectionsLocalDataSource {}
+
+class FakeCollectionEntity extends Fake implements CollectionEntity {}
+
+class FakeCollectionRequest extends Fake implements CollectionRequest {}
+
+void main() {
+  late MockCollectionsRemoteDataSource remote;
+  late MockCollectionsLocalDataSource local;
+  late CollectionsPushQueue queue;
+
+  setUpAll(() {
+    registerFallbackValue(FakeCollectionEntity());
+    registerFallbackValue(FakeCollectionRequest());
+  });
+
+  final t0 = DateTime.utc(2025);
+
+  CollectionEntity row({required int syncStateCode, int id = 1}) =>
+      CollectionEntity(
+        id: id,
+        uuid: 'c-1',
+        name: 'Design',
+        icon: 'f5fd',
+        color: 0xFF6366F1,
+        bookmarkIds: const ['b-1'],
+        createdAt: t0,
+        updatedAt: t0,
+        syncStateCode: syncStateCode,
+      );
+
+  CollectionDto dto() => CollectionDto(
+    id: 'c-1',
+    name: 'Design',
+    icon: 'f5fd',
+    color: 0xFF6366F1,
+    bookmarkIds: const ['b-1'],
+    createdAt: t0,
+    updatedAt: t0,
+  );
+
+  setUp(() {
+    remote = MockCollectionsRemoteDataSource();
+    local = MockCollectionsLocalDataSource();
+    when(() => local.put(any())).thenAnswer((_) async {});
+    when(() => local.hardDelete(any())).thenAnswer((_) async {});
+    queue = CollectionsPushQueue(local, remote);
+  });
+
+  test('pushes a pendingCreate row and marks it synced', () async {
+    final entity = row(syncStateCode: SyncState.pendingCreate.code);
+    when(() => local.listPending()).thenAnswer((_) async => [entity]);
+    when(() => remote.create(any())).thenAnswer((_) async => dto());
+
+    final hadFailure = await queue.push();
+
+    expect(hadFailure, isFalse);
+    expect(entity.syncState, SyncState.synced);
+    verify(() => remote.create(any())).called(1);
+  });
+
+  test('pushes a pendingDelete row then hard-deletes locally', () async {
+    final entity = row(syncStateCode: SyncState.pendingDelete.code, id: 7);
+    when(() => local.listPending()).thenAnswer((_) async => [entity]);
+    when(() => remote.delete('c-1')).thenAnswer((_) async {});
+
+    final hadFailure = await queue.push();
+
+    expect(hadFailure, isFalse);
+    verify(() => local.hardDelete(7)).called(1);
+  });
+
+  test('reports failure when a row throws', () async {
+    final entity = row(syncStateCode: SyncState.pendingUpdate.code);
+    when(() => local.listPending()).thenAnswer((_) async => [entity]);
+    when(() => remote.update(any(), any())).thenThrow(Exception('network'));
+
+    final hadFailure = await queue.push();
+
+    expect(hadFailure, isTrue);
+    expect(entity.syncState, SyncState.pendingUpdate);
+  });
+}

--- a/test/features/collections/domain/services/collections_summary_service_test.dart
+++ b/test/features/collections/domain/services/collections_summary_service_test.dart
@@ -1,0 +1,39 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/collections/domain/services/collections_summary_service.dart';
+import 'package:flutter_starter_template/shared/domain/collections.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+void main() {
+  late MockListCollections list;
+  late CollectionsSummaryService service;
+
+  setUp(() {
+    list = MockListCollections();
+    service = CollectionsSummaryService(list);
+  });
+
+  test('maps collections to summaries with item counts', () async {
+    when(() => list()).thenAnswer(
+      (_) async => Ok([
+        buildCollection(bookmarkIds: ['b-1', 'b-2']),
+      ]),
+    );
+
+    final result = await service();
+
+    final summary = (result as Ok<List<CollectionSummary>>).value.single;
+    expect(summary.id, 'c-1');
+    expect(summary.itemCount, 2);
+  });
+
+  test('propagates failure', () async {
+    when(() => list()).thenAnswer((_) async => const Err(UnknownFailure('x')));
+
+    final result = await service();
+
+    expect(result, isA<Err<List<CollectionSummary>>>());
+  });
+}

--- a/test/features/collections/domain/usecases/collection_usecases_test.dart
+++ b/test/features/collections/domain/usecases/collection_usecases_test.dart
@@ -1,0 +1,72 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/collections/domain/entities/collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/delete_collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/get_collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/list_collections.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/list_local_collections.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/update_collection.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+void main() {
+  late MockCollectionsRepository repository;
+
+  setUpAll(() => registerFallbackValue(FakeCollectionInput()));
+
+  setUp(() {
+    repository = MockCollectionsRepository();
+  });
+
+  test('ListCollections delegates to repository.list', () async {
+    when(
+      () => repository.list(),
+    ).thenAnswer((_) async => Ok([buildCollection()]));
+
+    final result = await ListCollections(repository)();
+
+    expect((result as Ok<List<Collection>>).value, hasLength(1));
+    verify(() => repository.list()).called(1);
+  });
+
+  test('ListLocalCollections delegates to repository.listLocal', () async {
+    when(() => repository.listLocal()).thenAnswer((_) async => const Ok([]));
+
+    await ListLocalCollections(repository)();
+
+    verify(() => repository.listLocal()).called(1);
+  });
+
+  test('GetCollection delegates to repository.get', () async {
+    when(
+      () => repository.get('c-1'),
+    ).thenAnswer((_) async => Ok(buildCollection()));
+
+    final result = await GetCollection(repository)('c-1');
+
+    expect((result as Ok<Collection>).value.id, 'c-1');
+  });
+
+  test('UpdateCollection validates before delegating', () async {
+    final result = await UpdateCollection(repository)(
+      const UpdateCollectionParams(
+        id: 'c-1',
+        input: CollectionInput(name: '  ', icon: 'f5fd', color: 0xFF6366F1),
+      ),
+    );
+
+    expect((result as Err<Collection>).failure, isA<ValidationFailure>());
+    verifyNever(() => repository.update(any(), any()));
+  });
+
+  test('DeleteCollection delegates to repository.delete', () async {
+    when(
+      () => repository.delete('c-1'),
+    ).thenAnswer((_) async => const Ok(null));
+
+    await DeleteCollection(repository)('c-1');
+
+    verify(() => repository.delete('c-1')).called(1);
+  });
+}

--- a/test/features/collections/domain/usecases/create_collection_test.dart
+++ b/test/features/collections/domain/usecases/create_collection_test.dart
@@ -1,0 +1,54 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/collections/domain/entities/collection.dart';
+import 'package:flutter_starter_template/features/collections/domain/repositories/collections_repository.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/create_collection.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+class MockCollectionsRepository extends Mock implements CollectionsRepository {}
+
+class FakeCollectionInput extends Fake implements CollectionInput {}
+
+void main() {
+  late MockCollectionsRepository repository;
+  late CreateCollection useCase;
+
+  setUpAll(() => registerFallbackValue(FakeCollectionInput()));
+
+  setUp(() {
+    repository = MockCollectionsRepository();
+    useCase = CreateCollection(repository);
+  });
+
+  test('rejects a blank name without touching the repository', () async {
+    final result = await useCase(
+      const CollectionInput(name: '   ', icon: 'f5fd', color: 0xFF6366F1),
+    );
+
+    expect(result, isA<Err<Collection>>());
+    expect((result as Err<Collection>).failure, isA<ValidationFailure>());
+    verifyNever(() => repository.create(any()));
+  });
+
+  test('delegates to the repository for a valid input', () async {
+    final collection = Collection(
+      id: 'c-1',
+      name: 'Design',
+      icon: 'f5fd',
+      color: 0xFF6366F1,
+      bookmarkIds: const [],
+      createdAt: DateTime(2025),
+      updatedAt: DateTime(2025),
+    );
+    when(
+      () => repository.create(any()),
+    ).thenAnswer((_) async => Ok(collection));
+
+    final result = await useCase(
+      const CollectionInput(name: 'Design', icon: 'f5fd', color: 0xFF6366F1),
+    );
+
+    expect((result as Ok<Collection>).value.name, 'Design');
+    verify(() => repository.create(any())).called(1);
+  });
+}

--- a/test/features/collections/presentation/bloc/add_to_collection_cubit_test.dart
+++ b/test/features/collections/presentation/bloc/add_to_collection_cubit_test.dart
@@ -1,0 +1,78 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/update_collection.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/add_to_collection/add_to_collection_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+void main() {
+  late MockListCollections list;
+  late MockUpdateCollection update;
+  late AddToCollectionCubit cubit;
+
+  setUpAll(() {
+    registerFallbackValue(FakeUpdateCollectionParams());
+  });
+
+  setUp(() {
+    list = MockListCollections();
+    update = MockUpdateCollection();
+    cubit = AddToCollectionCubit(list, update);
+  });
+
+  tearDown(() => cubit.close());
+
+  test('load marks collections that already contain the bookmark', () async {
+    when(() => list()).thenAnswer(
+      (_) async => Ok([
+        buildCollection(id: 'c-1', bookmarkIds: ['b-1']),
+        buildCollection(id: 'c-2', bookmarkIds: ['x']),
+      ]),
+    );
+
+    await cubit.load('b-1');
+
+    expect(cubit.state.memberOf, {'c-1'});
+  });
+
+  test('toggle adds the bookmark to a collection it is not in', () async {
+    when(() => list()).thenAnswer(
+      (_) async => Ok([
+        buildCollection(id: 'c-2', bookmarkIds: ['x']),
+      ]),
+    );
+    when(() => update(any())).thenAnswer(
+      (_) async => Ok(buildCollection(id: 'c-2', bookmarkIds: ['x', 'b-1'])),
+    );
+
+    await cubit.load('b-1');
+    await cubit.toggle('c-2', 'b-1');
+
+    final params =
+        verify(() => update(captureAny())).captured.single
+            as UpdateCollectionParams;
+    expect(params.input.bookmarkIds, ['x', 'b-1']);
+    expect(cubit.state.memberOf, {'c-2'});
+  });
+
+  test('toggle removes the bookmark from a collection it is in', () async {
+    when(() => list()).thenAnswer(
+      (_) async => Ok([
+        buildCollection(id: 'c-1', bookmarkIds: ['b-1', 'y']),
+      ]),
+    );
+    when(() => update(any())).thenAnswer(
+      (_) async => Ok(buildCollection(id: 'c-1', bookmarkIds: ['y'])),
+    );
+
+    await cubit.load('b-1');
+    await cubit.toggle('c-1', 'b-1');
+
+    final params =
+        verify(() => update(captureAny())).captured.single
+            as UpdateCollectionParams;
+    expect(params.input.bookmarkIds, ['y']);
+    expect(cubit.state.memberOf, isEmpty);
+  });
+}

--- a/test/features/collections/presentation/bloc/collection_detail_cubit_test.dart
+++ b/test/features/collections/presentation/bloc/collection_detail_cubit_test.dart
@@ -1,0 +1,111 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/update_collection.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collection_detail/collection_detail_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+void main() {
+  late MockGetCollection get;
+  late MockUpdateCollection update;
+  late MockDeleteCollection delete;
+  late MockBookmarkSummariesReader summaries;
+  late CollectionDetailCubit cubit;
+
+  setUpAll(() {
+    registerFallbackValue(FakeUpdateCollectionParams());
+  });
+
+  setUp(() {
+    get = MockGetCollection();
+    update = MockUpdateCollection();
+    delete = MockDeleteCollection();
+    summaries = MockBookmarkSummariesReader();
+    cubit = CollectionDetailCubit(get, update, delete, summaries);
+  });
+
+  tearDown(() => cubit.close());
+
+  test('load resolves members from bookmark summaries', () async {
+    when(() => get('c-1')).thenAnswer(
+      (_) async => Ok(buildCollection(bookmarkIds: ['b-1', 'b-2'])),
+    );
+    when(() => summaries()).thenAnswer(
+      (_) async => Ok([
+        buildSummary(id: 'b-1', title: 'One'),
+        buildSummary(id: 'b-3', title: 'Three'),
+      ]),
+    );
+
+    await cubit.load('c-1');
+
+    expect(cubit.state.collection, isNotNull);
+    // Only b-1 resolves; b-2 has no summary and is dropped.
+    expect(cubit.state.members.map((m) => m.id), ['b-1']);
+    expect(cubit.state.candidates.map((c) => c.id), ['b-3']);
+  });
+
+  test('load surfaces failure when the collection is missing', () async {
+    when(
+      () => get('c-1'),
+    ).thenAnswer((_) async => const Err(NotFoundFailure('nope')));
+
+    await cubit.load('c-1');
+
+    expect(cubit.state.failure, isA<NotFoundFailure>());
+    expect(cubit.state.collection, isNull);
+  });
+
+  test('addBookmarks unions ids and persists', () async {
+    when(() => get('c-1')).thenAnswer(
+      (_) async => Ok(buildCollection(bookmarkIds: ['b-1'])),
+    );
+    when(() => summaries()).thenAnswer(
+      (_) async => Ok([buildSummary(id: 'b-1'), buildSummary(id: 'b-2')]),
+    );
+    when(() => update(any())).thenAnswer(
+      (_) async => Ok(buildCollection(bookmarkIds: ['b-1', 'b-2'])),
+    );
+
+    await cubit.load('c-1');
+    await cubit.addBookmarks({'b-2'});
+
+    final params =
+        verify(() => update(captureAny())).captured.single
+            as UpdateCollectionParams;
+    expect(params.input.bookmarkIds, ['b-1', 'b-2']);
+    expect(cubit.state.members.map((m) => m.id), ['b-1', 'b-2']);
+  });
+
+  test('removeBookmark drops the id and persists', () async {
+    when(() => get('c-1')).thenAnswer(
+      (_) async => Ok(buildCollection(bookmarkIds: ['b-1', 'b-2'])),
+    );
+    when(() => summaries()).thenAnswer(
+      (_) async => Ok([buildSummary(id: 'b-1'), buildSummary(id: 'b-2')]),
+    );
+    when(() => update(any())).thenAnswer(
+      (_) async => Ok(buildCollection(bookmarkIds: ['b-1'])),
+    );
+
+    await cubit.load('c-1');
+    await cubit.removeBookmark('b-2');
+
+    final params =
+        verify(() => update(captureAny())).captured.single
+            as UpdateCollectionParams;
+    expect(params.input.bookmarkIds, ['b-1']);
+  });
+
+  test('delete flips deleted on success', () async {
+    when(() => get('c-1')).thenAnswer((_) async => Ok(buildCollection()));
+    when(() => summaries()).thenAnswer((_) async => const Ok([]));
+    when(() => delete('c-1')).thenAnswer((_) async => const Ok(null));
+
+    await cubit.load('c-1');
+    await cubit.delete();
+
+    expect(cubit.state.deleted, isTrue);
+  });
+}

--- a/test/features/collections/presentation/bloc/collection_form_cubit_test.dart
+++ b/test/features/collections/presentation/bloc/collection_form_cubit_test.dart
@@ -1,0 +1,74 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter_starter_template/features/collections/domain/usecases/update_collection.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collection_form/collection_form_cubit.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+void main() {
+  late MockCreateCollection create;
+  late MockUpdateCollection update;
+  late MockGetCollection get;
+  late CollectionFormCubit cubit;
+
+  setUpAll(() {
+    registerFallbackValue(FakeCollectionInput());
+    registerFallbackValue(FakeUpdateCollectionParams());
+  });
+
+  setUp(() {
+    create = MockCreateCollection();
+    update = MockUpdateCollection();
+    get = MockGetCollection();
+    cubit = CollectionFormCubit(create, update, get);
+  });
+
+  tearDown(() => cubit.close());
+
+  test('loadForEdit hydrates the initial collection', () async {
+    when(() => get('c-1')).thenAnswer((_) async => Ok(buildCollection()));
+
+    await cubit.loadForEdit('c-1');
+
+    expect(cubit.state.initial?.id, 'c-1');
+    expect(cubit.state.isEditing, isTrue);
+  });
+
+  test('submit creates a new collection when not editing', () async {
+    when(() => create(any())).thenAnswer((_) async => Ok(buildCollection()));
+
+    await cubit.submit(name: 'Design', icon: 'f5fd', color: 0xFF6366F1);
+
+    expect(cubit.state.saved, isTrue);
+    verify(() => create(any())).called(1);
+    verifyNever(() => update(any()));
+  });
+
+  test('submit updates and preserves membership when editing', () async {
+    when(() => get('c-1')).thenAnswer(
+      (_) async => Ok(buildCollection(bookmarkIds: ['b-1', 'b-2'])),
+    );
+    when(() => update(any())).thenAnswer((_) async => Ok(buildCollection()));
+
+    await cubit.loadForEdit('c-1');
+    await cubit.submit(name: 'New name', icon: 'f02d', color: 0xFF10B981);
+
+    final params =
+        verify(() => update(captureAny())).captured.single
+            as UpdateCollectionParams;
+    expect(params.input.bookmarkIds, ['b-1', 'b-2']);
+    expect(cubit.state.saved, isTrue);
+  });
+
+  test('submit surfaces failure', () async {
+    when(
+      () => create(any()),
+    ).thenAnswer((_) async => const Err(ValidationFailure('bad')));
+
+    await cubit.submit(name: '', icon: 'f5fd', color: 0xFF6366F1);
+
+    expect(cubit.state.saved, isFalse);
+    expect(cubit.state.failure, isA<ValidationFailure>());
+  });
+}

--- a/test/features/collections/presentation/bloc/collections_list_bloc_test.dart
+++ b/test/features/collections/presentation/bloc/collections_list_bloc_test.dart
@@ -1,0 +1,79 @@
+import 'dart:async';
+
+import 'package:architecture/architecture.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_starter_template/features/collections/domain/services/collections_sync_controller.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collections_list/collections_list_bloc.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collections_list/collections_list_state.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+void main() {
+  late MockListCollections list;
+  late MockListLocalCollections listLocal;
+  late MockDeleteCollection delete;
+  late MockCollectionsSyncController sync;
+  late StreamController<CollectionsSyncStatus> statusController;
+
+  setUp(() {
+    list = MockListCollections();
+    listLocal = MockListLocalCollections();
+    delete = MockDeleteCollection();
+    sync = MockCollectionsSyncController();
+    statusController = StreamController<CollectionsSyncStatus>.broadcast();
+    when(() => sync.statusStream).thenAnswer((_) => statusController.stream);
+  });
+
+  tearDown(() => statusController.close());
+
+  CollectionsListBloc build() =>
+      CollectionsListBloc(list, listLocal, delete, sync);
+
+  blocTest<CollectionsListBloc, CollectionsListState>(
+    'emits loaded items on load',
+    setUp: () => when(() => list()).thenAnswer(
+      (_) async => Ok([buildCollection()]),
+    ),
+    build: build,
+    act: (bloc) => bloc.add(const CollectionsListLoadRequested()),
+    expect: () => [
+      const CollectionsListState(isLoading: true),
+      isA<CollectionsListState>()
+          .having((s) => s.isLoading, 'isLoading', false)
+          .having((s) => s.items.length, 'items', 1),
+    ],
+  );
+
+  blocTest<CollectionsListBloc, CollectionsListState>(
+    'stores failure when load fails',
+    setUp: () => when(
+      () => list(),
+    ).thenAnswer((_) async => const Err(UnknownFailure('boom'))),
+    build: build,
+    act: (bloc) => bloc.add(const CollectionsListLoadRequested()),
+    expect: () => [
+      const CollectionsListState(isLoading: true),
+      isA<CollectionsListState>().having(
+        (s) => s.failure,
+        'failure',
+        isA<UnknownFailure>(),
+      ),
+    ],
+  );
+
+  blocTest<CollectionsListBloc, CollectionsListState>(
+    'delete reloads from local on success',
+    setUp: () {
+      when(() => delete('c-1')).thenAnswer((_) async => const Ok(null));
+      when(() => listLocal()).thenAnswer((_) async => const Ok([]));
+    },
+    build: build,
+    act: (bloc) => bloc.add(const CollectionsListDeleteRequested('c-1')),
+    verify: (_) {
+      verify(() => delete('c-1')).called(1);
+      verify(() => listLocal()).called(1);
+    },
+  );
+}

--- a/test/features/collections/presentation/screens/collection_detail_screen_test.dart
+++ b/test/features/collections/presentation/screens/collection_detail_screen_test.dart
@@ -1,0 +1,74 @@
+import 'package:architecture/architecture.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_starter_template/app/di/injection.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collection_detail/collection_detail_cubit.dart';
+import 'package:flutter_starter_template/features/collections/presentation/screens/collection_detail_screen.dart';
+import 'package:flutter_starter_template/l10n/app_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+void main() {
+  late MockGetCollection get;
+  late MockUpdateCollection update;
+  late MockDeleteCollection delete;
+  late MockBookmarkSummariesReader summaries;
+
+  setUp(() {
+    get = MockGetCollection();
+    update = MockUpdateCollection();
+    delete = MockDeleteCollection();
+    summaries = MockBookmarkSummariesReader();
+    getIt.registerFactory<CollectionDetailCubit>(
+      () => CollectionDetailCubit(get, update, delete, summaries),
+    );
+  });
+
+  tearDown(getIt.reset);
+
+  Future<void> pump(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: CollectionDetailScreen(id: 'c-1'),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('renders the collection name and member bookmarks', (
+    tester,
+  ) async {
+    when(() => get('c-1')).thenAnswer(
+      (_) async => Ok(buildCollection(name: 'Design', bookmarkIds: ['b-1'])),
+    );
+    when(() => summaries()).thenAnswer(
+      (_) async => Ok([buildSummary(id: 'b-1', title: 'Flutter docs')]),
+    );
+
+    await pump(tester);
+    await tester.pump();
+
+    expect(find.text('Design'), findsOneWidget);
+    expect(find.text('Flutter docs'), findsOneWidget);
+  });
+
+  testWidgets('shows the empty state when there are no members', (
+    tester,
+  ) async {
+    when(
+      () => get('c-1'),
+    ).thenAnswer((_) async => Ok(buildCollection(bookmarkIds: [])));
+    when(() => summaries()).thenAnswer((_) async => const Ok([]));
+
+    await pump(tester);
+    await tester.pump();
+
+    expect(
+      find.text('No bookmarks in this collection yet.'),
+      findsOneWidget,
+    );
+  });
+}

--- a/test/features/collections/presentation/widgets/collections_list_view_test.dart
+++ b/test/features/collections/presentation/widgets/collections_list_view_test.dart
@@ -1,0 +1,62 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_starter_template/app/di/injection.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collections_list/collections_list_bloc.dart';
+import 'package:flutter_starter_template/features/collections/presentation/bloc/collections_list/collections_list_state.dart';
+import 'package:flutter_starter_template/features/collections/presentation/widgets/collections_list_view.dart';
+import 'package:flutter_starter_template/l10n/app_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+
+import '../../collections_test_helpers.dart';
+
+class MockCollectionsListBloc
+    extends MockBloc<CollectionsListEvent, CollectionsListState>
+    implements CollectionsListBloc {}
+
+void main() {
+  late MockCollectionsListBloc bloc;
+
+  setUp(() {
+    bloc = MockCollectionsListBloc();
+    getIt.registerFactory<CollectionsListBloc>(() => bloc);
+  });
+
+  tearDown(getIt.reset);
+
+  Future<void> pump(WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: Scaffold(body: CollectionsListView()),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('renders a card per collection', (tester) async {
+    when(() => bloc.state).thenReturn(
+      CollectionsListState(
+        items: [
+          buildCollection(id: 'c-1', name: 'Design', bookmarkIds: ['b-1']),
+          buildCollection(id: 'c-2', name: 'Reading', bookmarkIds: []),
+        ],
+      ),
+    );
+
+    await pump(tester);
+
+    expect(find.text('Design'), findsOneWidget);
+    expect(find.text('Reading'), findsOneWidget);
+  });
+
+  testWidgets('renders the empty state with a create action', (tester) async {
+    when(() => bloc.state).thenReturn(const CollectionsListState());
+
+    await pump(tester);
+
+    expect(find.text('No collections yet'), findsOneWidget);
+    expect(find.text('New collection'), findsOneWidget);
+  });
+}

--- a/test/features/home/presentation/bloc/home_bloc_test.dart
+++ b/test/features/home/presentation/bloc/home_bloc_test.dart
@@ -1,13 +1,14 @@
 import 'package:architecture/architecture.dart';
 import 'package:flutter_starter_template/features/home/presentation/bloc/home_bloc.dart';
 import 'package:flutter_starter_template/shared/domain/bookmark_stats.dart';
+import 'package:flutter_starter_template/shared/domain/collections.dart';
 import 'package:flutter_test/flutter_test.dart';
 import '../../../../test_utils.dart';
 
 void main() {
   group('HomeBloc', () {
     test('initial state is default', () async {
-      final bloc = HomeBloc(MockBookmarkStatsReader());
+      final bloc = HomeBloc(MockBookmarkStatsReader(), _emptyCollections());
 
       expect(bloc.state.totalBookmarks, 0);
       expect(bloc.state.recentBookmarks, 0);
@@ -33,7 +34,7 @@ void main() {
           ),
         ],
       );
-      final bloc = HomeBloc(_reader(const Ok(stats)));
+      final bloc = HomeBloc(_reader(const Ok(stats)), _emptyCollections());
 
       bloc.add(const HomeLoadRequested());
       await bloc.stream.firstWhere((state) => !state.isLoading);
@@ -47,7 +48,10 @@ void main() {
     });
 
     test('handles empty stats', () async {
-      final bloc = HomeBloc(_reader(const Ok(BookmarkStats())));
+      final bloc = HomeBloc(
+        _reader(const Ok(BookmarkStats())),
+        _emptyCollections(),
+      );
       bloc.add(const HomeLoadRequested());
       await bloc.stream.firstWhere((state) => !state.isLoading);
 
@@ -59,7 +63,7 @@ void main() {
 
     test('stores failure when stats load fails', () async {
       const failure = UnknownFailure('Failed');
-      final bloc = HomeBloc(_reader(const Err(failure)));
+      final bloc = HomeBloc(_reader(const Err(failure)), _emptyCollections());
 
       bloc.add(const HomeLoadRequested());
       await bloc.stream.firstWhere((state) => !state.isLoading);
@@ -75,5 +79,13 @@ void main() {
 MockBookmarkStatsReader _reader(Result<BookmarkStats> result) {
   final reader = MockBookmarkStatsReader();
   when(reader.call).thenAnswer((_) async => result);
+  return reader;
+}
+
+MockCollectionsReader _emptyCollections() {
+  final reader = MockCollectionsReader();
+  when(reader.call).thenAnswer(
+    (_) async => const Ok<List<CollectionSummary>>([]),
+  );
   return reader;
 }

--- a/test/shared/presentation/collection_visuals_test.dart
+++ b/test/shared/presentation/collection_visuals_test.dart
@@ -21,6 +21,9 @@ void main() {
 
     expect(gradient, hasLength(2));
     expect(gradient.first, const Color(0xFF6366F1));
-    expect(gradient.last, isNot(equals(gradient.first)));
+    expect(
+      gradient.last.computeLuminance(),
+      lessThan(gradient.first.computeLuminance()),
+    );
   });
 }

--- a/test/shared/presentation/collection_visuals_test.dart
+++ b/test/shared/presentation/collection_visuals_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_starter_template/shared/presentation/collection_visuals.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('palette tokens are unique and round-trip to their icons', () {
+    final tokens = collectionPalette.map((o) => o.token).toList();
+    expect(tokens.toSet().length, tokens.length);
+
+    for (final option in collectionPalette) {
+      expect(collectionIconFor(option.token), option.icon);
+    }
+  });
+
+  test('collectionIconFor falls back for unknown tokens', () {
+    expect(collectionIconFor('not-a-token'), isNotNull);
+  });
+
+  test('collectionGradientFor returns two stops darker than the seed', () {
+    final gradient = collectionGradientFor(0xFF6366F1);
+
+    expect(gradient, hasLength(2));
+    expect(gradient.first, const Color(0xFF6366F1));
+    expect(gradient.last, isNot(equals(gradient.first)));
+  });
+}

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -14,11 +14,13 @@ import 'package:flutter_starter_template/features/bookmarks/domain/usecases/get_
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_bookmarks.dart';
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/list_local_bookmarks.dart';
 import 'package:flutter_starter_template/features/bookmarks/domain/usecases/update_bookmark.dart';
+import 'package:flutter_starter_template/features/collections/domain/services/collections_sync_controller.dart';
 import 'package:flutter_starter_template/features/notifications/domain/services/notifications_sync_controller.dart';
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_bloc.dart';
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_state.dart';
 import 'package:flutter_starter_template/shared/domain/activity_notifier.dart';
 import 'package:flutter_starter_template/shared/domain/bookmark_stats.dart';
+import 'package:flutter_starter_template/shared/domain/collections.dart';
 import 'package:flutter_starter_template/shared/domain/entities/auth_user.dart';
 import 'package:flutter_starter_template/shared/domain/session.dart';
 import 'package:test_utils/test_utils.dart';
@@ -44,6 +46,11 @@ class MockAuthRepository extends Mock implements AuthRepository {}
 class MockListBookmarks extends Mock implements ListBookmarks {}
 
 class MockBookmarkStatsReader extends Mock implements BookmarkStatsReader {}
+
+class MockCollectionsReader extends Mock implements CollectionsReader {}
+
+class MockCollectionsSyncController extends Mock
+    implements CollectionsSyncController {}
 
 class MockListLocalBookmarks extends Mock implements ListLocalBookmarks {}
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_starter_template/features/home/presentation/bloc/home_bl
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_bloc.dart';
 import 'package:flutter_starter_template/features/notifications/presentation/bloc/notifications_state.dart';
 import 'package:flutter_starter_template/shared/domain/bookmark_stats.dart';
+import 'package:flutter_starter_template/shared/domain/collections.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:storage/storage.dart';
 import 'package:theme/theme.dart';
@@ -21,6 +22,7 @@ import 'test_utils.dart';
 void main() {
   late StreamController<BookmarksSyncStatus> syncStatusController;
   late MockBookmarksSyncController sync;
+  late MockCollectionsSyncController collectionsSync;
   late MockNotificationsSyncController notificationsSync;
   late MockAnalyticsService analytics;
   late AuthBloc authBloc;
@@ -58,6 +60,11 @@ void main() {
     when(() => sync.stop()).thenAnswer((_) async {});
     when(() => sync.sync()).thenAnswer((_) async {});
 
+    collectionsSync = MockCollectionsSyncController();
+    when(() => collectionsSync.start()).thenAnswer((_) async {});
+    when(() => collectionsSync.stop()).thenAnswer((_) async {});
+    when(() => collectionsSync.sync()).thenAnswer((_) async {});
+
     notificationsSync = MockNotificationsSyncController();
     when(
       () => notificationsSync.onSynced,
@@ -71,6 +78,11 @@ void main() {
       bookmarkStats.call,
     ).thenAnswer((_) async => const Ok(BookmarkStats()));
 
+    final collectionsReader = MockCollectionsReader();
+    when(
+      collectionsReader.call,
+    ).thenAnswer((_) async => const Ok<List<CollectionSummary>>([]));
+
     authBloc = AuthBloc(
       signIn: signIn,
       register: MockRegister(),
@@ -81,7 +93,7 @@ void main() {
     themeBloc = ThemeBloc(await SharedPreferences.getInstance(), analytics);
 
     getIt.registerFactory<HomeBloc>(() {
-      final bloc = HomeBloc(bookmarkStats);
+      final bloc = HomeBloc(bookmarkStats, collectionsReader);
       homeBloc = bloc;
       return bloc;
     });
@@ -108,6 +120,7 @@ void main() {
         authBloc: authBloc,
         themeBloc: themeBloc,
         bookmarksSync: sync,
+        collectionsSync: collectionsSync,
         notificationsSync: notificationsSync,
         navigatorObservers: const [],
         videoPlayerService: MockVideoPlayerService(),


### PR DESCRIPTION
## Context

The home dashboard's **Featured Collections** row was cosmetic — it derived chips from bookmark tags and fell back to hardcoded "Design / Articles / Tools" cards, with every card just opening the full bookmarks list. The bookmarks list also had a **Collections** tab showing a "coming soon" placeholder. This turns both into a real, offline-first **Collections** feature (explicit-folders model: users create named collections and add/remove bookmarks).

## What's included

**New `lib/features/collections/`** — full offline-first module mirroring `bookmarks`:
- **domain**: `Collection`/`CollectionInput`, repository interface, use cases (list/listLocal/get/create/update/delete + validation), sync controller contract, and `CollectionsSummaryService` (implements the shared `CollectionsReader`).
- **data**: ObjectBox `CollectionEntity`, local data source, Freezed DTO/request, Retrofit `/api/collections` client, offline-first repository impl, and sync service + push queue + last-write-wins pull reconciler.
- **presentation**: collections list view/screen, create/edit form (icon + color picker), detail screen (member bookmarks, add/remove, delete), and an "add to collection" sheet.

**Shared contracts** (`lib/shared/`): `CollectionsReader`, `BookmarkSummariesReader` (+ bookmarks-side impl), and `collection_visuals.dart` so home and collections render identical cards without crossing the feature boundary.

**Wiring**: routes (`/collections`, `/collections/new`, `/collections/:id`, `/collections/:id/edit`); sync lifecycle start/stop in `app.dart`; DI auto-registered via build_runner.

**Mock surfaces now real**:
- Home "Featured Collections" reads real collections via `CollectionsReader` (with a "create collection" CTA when empty).
- Bookmarks "Collections" tab embeds the live collections list (single-consumer capability; home uses the shared reader, so bookmarks stays the only consumer).
- Bookmark detail gained an "Add to collection" action.

## Testing
- `fvm flutter analyze` → no issues.
- `fvm flutter test` → all passing (added repo offline-first, pull-reconciler last-write-wins, and create-validation tests; updated home/widget/integration tests and the feature-boundary allowlist).
- build_runner regenerated objectbox/freezed/retrofit/go_router/injectable/l10n.

## Notes
- Assumes a `/api/collections` endpoint following the bookmarks convention. If absent, the app stays fully functional offline-first (pending rows retry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Collections feature: create, edit, delete, browse, and organize bookmarks with collection cards, detail and form screens, and dedicated routes.
  * Add/remove bookmarks via "Add to collection" sheet and multi-select add-bookmarks sheet.
  * Home dashboard surfaces featured collections and a Collections screen with navigation.

* **Sync**
  * Background collections sync service running for authenticated sessions, with status reporting and resilient push/pull behavior.

* **Localization**
  * English and Vietnamese strings for all collection flows.

* **Tests**
  * Extensive unit, widget, and integration coverage for collections and sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->