### PR TITLE
fix(ui): add bottom padding to clear floating bottom bar

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c4628397-996b-4606-8f0d-bc0efdf99b22","pid":69876,"procStart":"Thu Jun  4 02:29:17 2026","acquiredAt":1780550223897}

--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ Thumbs.db
 # user-global ~/.config/git/ignore so the rules travel with the repo)
 # -------------------------------------------------------------------------
 .claude/settings.local.json
+.claude/scheduled_tasks.lock
 .cursor/
 
 # -------------------------------------------------------------------------

--- a/lib/features/notifications/presentation/widgets/notifications_lists.dart
+++ b/lib/features/notifications/presentation/widgets/notifications_lists.dart
@@ -1,5 +1,8 @@
 part of 'notifications_widgets.dart';
 
+/// Extra bottom padding so list content clears the floating bottom bar.
+const double _listBottomInset = 96;
+
 class _NotificationsList extends StatelessWidget {
   const _NotificationsList({required this.notifications});
 
@@ -14,7 +17,12 @@ class _NotificationsList extends StatelessWidget {
       onRefresh: () => _refresh(context),
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          _listBottomInset,
+        ),
         children: [
           if (notifications.isEmpty)
             _TabEmptyState(
@@ -100,7 +108,12 @@ class _ActivitiesList extends StatelessWidget {
       onRefresh: () => _refresh(context),
       child: ListView(
         physics: const AlwaysScrollableScrollPhysics(),
-        padding: const EdgeInsets.all(AppSpacing.lg),
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.lg,
+          AppSpacing.lg,
+          AppSpacing.lg,
+          _listBottomInset,
+        ),
         children: [
           _SectionHeader(title: context.l10n.notificationsActivitySection),
           const SizedBox(height: AppSpacing.sm),

--- a/lib/features/profile/presentation/widgets/profile_widgets.dart
+++ b/lib/features/profile/presentation/widgets/profile_widgets.dart
@@ -20,6 +20,9 @@ part 'profile_about.dart';
 class ProfileBody extends StatelessWidget {
   const ProfileBody({super.key});
 
+  /// Extra bottom padding so content clears the floating bottom bar.
+  static const double _bottomInset = 96;
+
   void _onDeleteAccountState(BuildContext context, DeleteAccountState state) {
     switch (state) {
       case DeleteAccountSuccess():
@@ -50,7 +53,7 @@ class ProfileBody extends StatelessWidget {
             AppSpacing.xl,
             AppSpacing.lg,
             AppSpacing.xl,
-            AppSpacing.xxxl,
+            _bottomInset,
           ),
           children: [
             const _ProfileHeader().animateSlideDown(),


### PR DESCRIPTION
## Summary
- Notifications (`_NotificationsList`, `_ActivitiesList`) and Profile lists only had 16-32dp of bottom padding, so the last items were partially hidden behind the floating bottom bar (~88dp tall on compact screens).
- Bumped both to 96dp bottom inset, matching the bookmarks grid which already accounted for the bar's footprint.

## Test plan
- [ ] Run the app on a compact-width device/emulator, scroll Notifications (both tabs) and Profile to the end, confirm the last item/button is fully visible above the floating bottom bar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted list and profile view spacing so notification and profile content is no longer obscured by the floating bottom bar.
* **Chores**
  * Updated ignore rules to exclude a new local scheduler lock file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->