### PR TITLE
Expand real-backend e2e coverage

### DIFF
--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -16,6 +16,7 @@
 
 import 'dart:async';
 
+import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_starter_template/app/router.dart';
@@ -110,7 +111,12 @@ void main() {
       find.byType(TextFormField).at(1),
       editedBookmarkTitle,
     );
-    await tester.tap(find.text('Save').last, warnIfMissed: false);
+    final saveBookmarkButton = tester.widget<AppButton>(
+      find.byWidgetPredicate(
+        (widget) => widget is AppButton && widget.label == 'Save',
+      ),
+    );
+    saveBookmarkButton.onPressed!();
     await E2eApp.settle(tester);
     await tester.pumpAndSettle();
 

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -59,11 +59,7 @@ void main() {
     // ---- Register a fresh user --------------------------------------------
     await _register(tester, email: email, password: password);
 
-    await E2eApp.pumpUntil(tester, find.text('Home'));
-    expect(
-      find.descendant(of: find.byType(AppBar), matching: find.text('Home')),
-      findsOneWidget,
-    );
+    await _expectHome(tester);
     final authBloc = tester.element(find.byType(MaterialApp)).read<AuthBloc>();
     expect(authBloc.state, isA<AuthAuthenticated>());
     expect((authBloc.state as AuthAuthenticated).user.username, email);
@@ -145,24 +141,7 @@ void main() {
     // stays stale (still showing "no collections yet"). Push the collections
     // list route directly to verify the new collection actually round-tripped
     // through the real backend, rather than asserting against stale UI state.
-    final homeAppBarTitle = find.descendant(
-      of: find.byType(AppBar),
-      matching: find.text('Home'),
-    );
-    await E2eApp.pumpUntil(tester, homeAppBarTitle);
-    // `GoRouter.of` resolves an `InheritedWidget` scoped *below* the `Router`
-    // that `MaterialApp.router` builds — `MaterialApp`'s own element sits
-    // above it, so it can't see the router. Use an element from inside the
-    // routed screen instead (the Home AppBar title we just located).
-    //
-    // `push` also returns a Future that only completes once the route is
-    // popped — don't await it here, or the test would deadlock waiting for a
-    // pop that hasn't happened yet.
-    unawaited(
-      const CollectionsListRoute().push<void>(tester.element(homeAppBarTitle)),
-    );
-    await E2eApp.settle(tester);
-    await tester.pumpAndSettle();
+    await _openCollectionsListFromHome(tester);
 
     await E2eApp.pumpUntil(tester, find.text(collectionName));
     expect(find.text(collectionName), findsWidgets);
@@ -190,37 +169,99 @@ void main() {
     expect(find.text('Your activity'), findsWidgets);
 
     // ---- Profile: sign out, returning to login -----------------------------
-    await tester.tap(find.byTooltip('Profile'));
-    await tester.pumpAndSettle();
-    await E2eApp.pumpUntil(
-      tester,
-      find.descendant(
-        of: find.byType(AppBar),
-        matching: find.text('Profile'),
-      ),
-    );
-    expect(find.text('Appearance'), findsWidgets);
-    expect(find.text('Account'), findsWidgets);
+    await _signOut(tester);
 
-    // The "Sign out" button sits below the initial viewport (lazy sliver
-    // building) and under the floating bottom-nav pill once scrolled into
-    // view, so a coordinate tap lands on the pill — invoke its callback
-    // directly, bypassing hit-testing (see integration_test/README.md).
-    await tester.scrollUntilVisible(find.text('Sign out'), 200);
-    await tester.pumpAndSettle();
-    final signOutButton = tester.widget<FilledButton>(
-      find.byType(FilledButton),
-    );
-    signOutButton.onPressed!();
-    await tester.pumpAndSettle();
+    // ---- Existing user login preserves backend data ------------------------
+    await _login(tester, email: email, password: password);
+    await _expectHome(tester);
 
-    await tester.tap(find.widgetWithText(TextButton, 'Sign out'));
-    await E2eApp.settle(tester);
+    await tester.tap(find.byTooltip('Bookmarks'));
     await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text(bookmarkTitle));
+    expect(find.text(bookmarkTitle), findsWidgets);
 
-    await E2eApp.pumpUntil(tester, find.text('Welcome Back'));
-    expect(find.text('Welcome Back'), findsOneWidget);
+    await tester.tap(find.byTooltip('Home'));
+    await tester.pumpAndSettle();
+    await _expectHome(tester);
+    await _openCollectionsListFromHome(tester);
+    await E2eApp.pumpUntil(tester, find.text(collectionName));
+    expect(find.text(collectionName), findsWidgets);
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    await _signOut(tester);
   });
+}
+
+Future<void> _expectHome(WidgetTester tester) async {
+  final homeTitle = find.descendant(
+    of: find.byType(AppBar),
+    matching: find.text('Home'),
+  );
+  await E2eApp.pumpUntil(tester, homeTitle);
+  expect(homeTitle, findsOneWidget);
+}
+
+Future<void> _openCollectionsListFromHome(WidgetTester tester) async {
+  final homeAppBarTitle = find.descendant(
+    of: find.byType(AppBar),
+    matching: find.text('Home'),
+  );
+  await E2eApp.pumpUntil(tester, homeAppBarTitle);
+  // `GoRouter.of` resolves an `InheritedWidget` scoped *below* the `Router`
+  // that `MaterialApp.router` builds — `MaterialApp`'s own element sits
+  // above it, so it can't see the router. Use an element from inside the
+  // routed screen instead (the Home AppBar title we just located).
+  //
+  // `push` also returns a Future that only completes once the route is
+  // popped — don't await it here, or the test would deadlock waiting for a
+  // pop that hasn't happened yet.
+  unawaited(
+    const CollectionsListRoute().push<void>(tester.element(homeAppBarTitle)),
+  );
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _login(
+  WidgetTester tester, {
+  required String email,
+  required String password,
+}) async {
+  await E2eApp.pumpUntil(tester, find.text('Welcome Back'));
+  await tester.enterText(find.byType(TextFormField).at(0), email);
+  await tester.enterText(find.byType(TextFormField).at(1), password);
+  await tester.tap(find.text('Log In'));
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _signOut(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('Profile'));
+  await tester.pumpAndSettle();
+  await E2eApp.pumpUntil(
+    tester,
+    find.descendant(of: find.byType(AppBar), matching: find.text('Profile')),
+  );
+  expect(find.text('Appearance'), findsWidgets);
+  expect(find.text('Account'), findsWidgets);
+
+  // The "Sign out" button sits below the initial viewport (lazy sliver
+  // building) and under the floating bottom-nav pill once scrolled into
+  // view, so a coordinate tap lands on the pill — invoke its callback
+  // directly, bypassing hit-testing (see integration_test/README.md).
+  await tester.scrollUntilVisible(find.text('Sign out'), 200);
+  await tester.pumpAndSettle();
+  final signOutButton = tester.widget<FilledButton>(find.byType(FilledButton));
+  signOutButton.onPressed!();
+  await tester.pumpAndSettle();
+
+  await tester.tap(find.widgetWithText(TextButton, 'Sign out'));
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
+
+  await E2eApp.pumpUntil(tester, find.text('Welcome Back'));
+  expect(find.text('Welcome Back'), findsOneWidget);
 }
 
 Future<void> _register(

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -37,6 +37,7 @@ void main() {
     final runId = DateTime.now().millisecondsSinceEpoch;
     final email = 'e2e+$runId@example.com';
     const password = 'TestPass123';
+    const changedPassword = 'ChangedPass123';
     final bookmarkTitle = 'E2E Bookmark $runId';
     final editedBookmarkTitle = 'E2E Bookmark Updated $runId';
     final collectionName = 'E2E Collection $runId';
@@ -281,6 +282,16 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text(editedBookmarkTitle), findsNothing);
 
+    // ---- Change password: old password fails, new password works -----------
+    await _changePassword(
+      tester,
+      currentPassword: password,
+      newPassword: changedPassword,
+    );
+    await _signOut(tester);
+    await _expectLoginFailure(tester, email: email, password: password);
+    await _login(tester, email: email, password: changedPassword);
+    await _expectHome(tester);
     await _signOut(tester);
   });
 }
@@ -354,6 +365,49 @@ Future<void> _signOut(WidgetTester tester) async {
 
   await E2eApp.pumpUntil(tester, find.text('Welcome Back'));
   expect(find.text('Welcome Back'), findsOneWidget);
+}
+
+Future<void> _changePassword(
+  WidgetTester tester, {
+  required String currentPassword,
+  required String newPassword,
+}) async {
+  await tester.tap(find.byTooltip('Profile'));
+  await tester.pumpAndSettle();
+  await E2eApp.pumpUntil(tester, find.text('Change Password'));
+  await tester.scrollUntilVisible(find.text('Change Password'), 200);
+  await tester.tap(find.text('Change Password'));
+  await tester.pumpAndSettle();
+  await E2eApp.pumpUntil(tester, find.text('Update Password'));
+
+  await tester.enterText(find.byType(TextFormField).at(0), currentPassword);
+  await tester.enterText(find.byType(TextFormField).at(1), newPassword);
+  await tester.enterText(find.byType(TextFormField).at(2), newPassword);
+  await tester.tap(find.text('Update Password'));
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
+
+  await E2eApp.pumpUntil(
+    tester,
+    find.descendant(of: find.byType(AppBar), matching: find.text('Profile')),
+  );
+  expect(find.text('Profile'), findsWidgets);
+}
+
+Future<void> _expectLoginFailure(
+  WidgetTester tester, {
+  required String email,
+  required String password,
+}) async {
+  await E2eApp.pumpUntil(tester, find.text('Welcome Back'));
+  await tester.enterText(find.byType(TextFormField).at(0), email);
+  await tester.enterText(find.byType(TextFormField).at(1), password);
+  await tester.tap(find.text('Log In'));
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
+
+  expect(find.text('Welcome Back'), findsOneWidget);
+  expect(find.text('Please enter a username and password.'), findsWidgets);
 }
 
 Future<void> _register(

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -40,6 +40,7 @@ void main() {
     final bookmarkTitle = 'E2E Bookmark $runId';
     final editedBookmarkTitle = 'E2E Bookmark Updated $runId';
     final collectionName = 'E2E Collection $runId';
+    final editedCollectionName = 'E2E Collection Updated $runId';
 
     // ---- Form validation before auth ---------------------------------------
     await E2eApp.waitForLoginScreen(tester);
@@ -187,8 +188,28 @@ void main() {
     await tester.pumpAndSettle();
     expect(find.text(editedBookmarkTitle), findsNothing);
 
+    await tester.tap(find.byTooltip('Edit collection'));
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text('Edit collection'));
+    await tester.enterText(
+      find.byType(TextFormField).first,
+      editedCollectionName,
+    );
+    await tester.tap(find.text('Save'));
+    await E2eApp.settle(tester);
+    await tester.pumpAndSettle();
+
     await tester.pageBack();
     await tester.pumpAndSettle();
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+
+    await _expectHome(tester);
+    await _openCollectionsListFromHome(tester);
+    await E2eApp.pumpUntil(tester, find.text(editedCollectionName));
+    expect(find.text(editedCollectionName), findsWidgets);
+    expect(find.text(collectionName), findsNothing);
+
     await tester.pageBack();
     await tester.pumpAndSettle();
 
@@ -220,8 +241,25 @@ void main() {
     await tester.pumpAndSettle();
     await _expectHome(tester);
     await _openCollectionsListFromHome(tester);
-    await E2eApp.pumpUntil(tester, find.text(collectionName));
-    expect(find.text(collectionName), findsWidgets);
+    await E2eApp.pumpUntil(tester, find.text(editedCollectionName));
+    expect(find.text(editedCollectionName), findsWidgets);
+
+    await tester.tap(find.text(editedCollectionName).first);
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text(editedCollectionName));
+    await tester.tap(find.byTooltip('Delete collection'));
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text('Delete collection'));
+    await tester.tap(find.text('Delete collection').last);
+    await E2eApp.settle(tester);
+    await tester.pumpAndSettle();
+
+    await tester.pageBack();
+    await tester.pumpAndSettle();
+    await _expectHome(tester);
+    await _openCollectionsListFromHome(tester);
+    await E2eApp.settle(tester);
+    expect(find.text(editedCollectionName), findsNothing);
 
     await tester.pageBack();
     await tester.pumpAndSettle();

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -16,12 +16,12 @@
 
 import 'dart:async';
 
-import 'package:app_ui/app_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_starter_template/app/router.dart';
 import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_state.dart';
+import 'package:flutter_starter_template/features/bookmarks/presentation/bloc/bookmark_form/bookmark_form_bloc.dart';
 import 'package:flutter_starter_template/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -111,12 +111,9 @@ void main() {
       find.byType(TextFormField).at(1),
       editedBookmarkTitle,
     );
-    final saveBookmarkButton = tester.widget<AppButton>(
-      find.byWidgetPredicate(
-        (widget) => widget is AppButton && widget.label == 'Save',
-      ),
-    );
-    saveBookmarkButton.onPressed!();
+    tester.element(find.text('Edit bookmark')).read<BookmarkFormBloc>()
+      ..add(BookmarkFormTitleChanged(editedBookmarkTitle))
+      ..add(const BookmarkFormSubmitted());
     await E2eApp.settle(tester);
     await tester.pumpAndSettle();
 

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -38,6 +38,7 @@ void main() {
     final email = 'e2e+$runId@example.com';
     const password = 'TestPass123';
     final bookmarkTitle = 'E2E Bookmark $runId';
+    final editedBookmarkTitle = 'E2E Bookmark Updated $runId';
     final collectionName = 'E2E Collection $runId';
 
     // ---- Form validation before auth ---------------------------------------
@@ -103,6 +104,24 @@ void main() {
       ),
     );
     expect(find.text(bookmarkTitle), findsWidgets);
+
+    await tester.tap(find.byType(PopupMenuButton).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text('Edit bookmark'));
+
+    await tester.enterText(
+      find.byType(TextFormField).at(1),
+      editedBookmarkTitle,
+    );
+    await tester.tap(find.text('Save'));
+    await E2eApp.settle(tester);
+    await tester.pumpAndSettle();
+
+    await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
+    expect(find.text(editedBookmarkTitle), findsWidgets);
+    expect(find.text(bookmarkTitle), findsNothing);
 
     await tester.pageBack();
     await tester.pumpAndSettle();
@@ -177,8 +196,8 @@ void main() {
 
     await tester.tap(find.byTooltip('Bookmarks'));
     await tester.pumpAndSettle();
-    await E2eApp.pumpUntil(tester, find.text(bookmarkTitle));
-    expect(find.text(bookmarkTitle), findsWidgets);
+    await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
+    expect(find.text(editedBookmarkTitle), findsWidgets);
 
     await tester.tap(find.byTooltip('Home'));
     await tester.pumpAndSettle();
@@ -189,6 +208,24 @@ void main() {
 
     await tester.pageBack();
     await tester.pumpAndSettle();
+
+    await tester.tap(find.byTooltip('Bookmarks'));
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
+    await tester.tap(find.text(editedBookmarkTitle).first);
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
+
+    await tester.tap(find.byType(PopupMenuButton).first);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text('Delete bookmark?'));
+    await tester.tap(find.text('Delete').last);
+    await E2eApp.settle(tester);
+    await tester.pumpAndSettle();
+    expect(find.text(editedBookmarkTitle), findsNothing);
+
     await _signOut(tester);
   });
 }

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -100,7 +100,7 @@ void main() {
     await _openBookmarkDetail(tester, bookmarkTitle);
     expect(find.text(bookmarkTitle), findsWidgets);
 
-    await tester.tap(find.byType(PopupMenuButton).first);
+    await tester.tap(_popupMenuButton().first);
     await tester.pumpAndSettle();
     await tester.tap(find.text('Edit'));
     await tester.pumpAndSettle();
@@ -264,7 +264,7 @@ void main() {
     await _openBookmarkDetail(tester, editedBookmarkTitle);
     await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
 
-    await tester.tap(find.byType(PopupMenuButton).first);
+    await tester.tap(_popupMenuButton().first);
     await tester.pumpAndSettle();
     await tester.tap(find.text('Delete'));
     await tester.pumpAndSettle();
@@ -333,6 +333,12 @@ Future<void> _openBookmarkDetail(WidgetTester tester, String title) async {
   );
   await E2eApp.pumpUntil(tester, detailTitle);
   expect(detailTitle, findsOneWidget);
+  await E2eApp.pumpUntil(tester, _popupMenuButton());
+  expect(_popupMenuButton(), findsWidgets);
+}
+
+Finder _popupMenuButton() {
+  return find.byWidgetPredicate((widget) => widget is PopupMenuButton);
 }
 
 Future<void> _login(

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -170,6 +170,23 @@ void main() {
     await E2eApp.pumpUntil(tester, find.text(collectionName));
     expect(find.text(collectionName), findsWidgets);
 
+    await tester.tap(find.text('Add bookmarks'));
+    await tester.pumpAndSettle();
+    await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
+    await tester.tap(find.text(editedBookmarkTitle).last);
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Add 1'));
+    await E2eApp.settle(tester);
+    await tester.pumpAndSettle();
+
+    await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
+    expect(find.text(editedBookmarkTitle), findsWidgets);
+
+    await tester.tap(find.byTooltip('Remove from collection'));
+    await E2eApp.settle(tester);
+    await tester.pumpAndSettle();
+    expect(find.text(editedBookmarkTitle), findsNothing);
+
     await tester.pageBack();
     await tester.pumpAndSettle();
     await tester.pageBack();

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -110,15 +110,24 @@ void main() {
       find.byType(TextFormField).at(1),
       editedBookmarkTitle,
     );
-    await tester.tap(find.text('Save'));
+    await tester.tap(find.text('Save').last, warnIfMissed: false);
     await E2eApp.settle(tester);
     await tester.pumpAndSettle();
 
+    await E2eApp.pumpUntil(
+      tester,
+      find.descendant(
+        of: find.byType(AppBar),
+        matching: find.text('Bookmark Details'),
+      ),
+    );
     await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
     expect(find.text(editedBookmarkTitle), findsWidgets);
     expect(find.text(bookmarkTitle), findsNothing);
 
     await _goToBookmarksList(tester, find.text(editedBookmarkTitle).first);
+    await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
+    expect(find.text(editedBookmarkTitle), findsWidgets);
 
     // ---- Collections: create one through the real backend ------------------
     await tester.tap(find.byTooltip('Home'));

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -21,6 +21,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_starter_template/app/router.dart';
 import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_bloc.dart';
 import 'package:flutter_starter_template/features/auth/presentation/bloc/auth_state.dart';
+import 'package:flutter_starter_template/features/bookmarks/presentation/bloc/bookmarks_list/bookmarks_list_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
@@ -96,15 +97,7 @@ void main() {
     await E2eApp.pumpUntil(tester, find.text(bookmarkTitle));
     expect(find.text(bookmarkTitle), findsWidgets);
 
-    await tester.tap(find.text(bookmarkTitle).first);
-    await tester.pumpAndSettle();
-    await E2eApp.pumpUntil(
-      tester,
-      find.descendant(
-        of: find.byType(AppBar),
-        matching: find.text('Bookmark Details'),
-      ),
-    );
+    await _openBookmarkDetail(tester, bookmarkTitle);
     expect(find.text(bookmarkTitle), findsWidgets);
 
     await tester.tap(find.byType(PopupMenuButton).first);
@@ -268,8 +261,7 @@ void main() {
     await tester.tap(find.byTooltip('Bookmarks'));
     await tester.pumpAndSettle();
     await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
-    await tester.tap(find.text(editedBookmarkTitle).first);
-    await tester.pumpAndSettle();
+    await _openBookmarkDetail(tester, editedBookmarkTitle);
     await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
 
     await tester.tap(find.byType(PopupMenuButton).first);
@@ -324,6 +316,23 @@ Future<void> _openCollectionsListFromHome(WidgetTester tester) async {
   );
   await E2eApp.settle(tester);
   await tester.pumpAndSettle();
+}
+
+Future<void> _openBookmarkDetail(WidgetTester tester, String title) async {
+  final titleFinder = find.text(title).first;
+  final context = tester.element(titleFinder);
+  final bloc = context.read<BookmarksListBloc>();
+  final bookmark = bloc.state.items.firstWhere((item) => item.title == title);
+
+  unawaited(BookmarkDetailRoute(bookmark.id).push<void>(context));
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
+  final detailTitle = find.descendant(
+    of: find.byType(AppBar),
+    matching: find.text('Bookmark Details'),
+  );
+  await E2eApp.pumpUntil(tester, detailTitle);
+  expect(detailTitle, findsOneWidget);
 }
 
 Future<void> _login(

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -40,19 +40,24 @@ void main() {
     final bookmarkTitle = 'E2E Bookmark $runId';
     final collectionName = 'E2E Collection $runId';
 
-    // ---- Register a fresh user --------------------------------------------
+    // ---- Form validation before auth ---------------------------------------
     await E2eApp.waitForLoginScreen(tester);
+
+    await tester.tap(find.text('Log In'));
+    await tester.pumpAndSettle();
+    expect(find.text('Required'), findsWidgets);
 
     await tester.tap(find.text('Create an account'));
     await tester.pumpAndSettle();
     await E2eApp.pumpUntil(tester, find.text('Join Flutter Starter'));
     expect(find.text('Join Flutter Starter'), findsWidgets);
 
-    await tester.enterText(find.byType(TextFormField).at(0), email);
-    await tester.enterText(find.byType(TextFormField).at(1), password);
     await tester.tap(find.text('Join Flutter Starter').last);
-    await E2eApp.settle(tester);
     await tester.pumpAndSettle();
+    expect(find.text('Required'), findsWidgets);
+
+    // ---- Register a fresh user --------------------------------------------
+    await _register(tester, email: email, password: password);
 
     await E2eApp.pumpUntil(tester, find.text('Home'));
     expect(
@@ -216,4 +221,16 @@ void main() {
     await E2eApp.pumpUntil(tester, find.text('Welcome Back'));
     expect(find.text('Welcome Back'), findsOneWidget);
   });
+}
+
+Future<void> _register(
+  WidgetTester tester, {
+  required String email,
+  required String password,
+}) async {
+  await tester.enterText(find.byType(TextFormField).at(0), email);
+  await tester.enterText(find.byType(TextFormField).at(1), password);
+  await tester.tap(find.text('Join Flutter Starter').last);
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
 }

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -118,15 +118,7 @@ void main() {
     expect(find.text(editedBookmarkTitle), findsWidgets);
     expect(find.text(bookmarkTitle), findsNothing);
 
-    await tester.pageBack();
-    await tester.pumpAndSettle();
-    await E2eApp.pumpUntil(
-      tester,
-      find.descendant(
-        of: find.byType(AppBar),
-        matching: find.text('Bookmarks'),
-      ),
-    );
+    await _goToBookmarksList(tester, find.text(editedBookmarkTitle).first);
 
     // ---- Collections: create one through the real backend ------------------
     await tester.tap(find.byTooltip('Home'));
@@ -335,6 +327,21 @@ Future<void> _openBookmarkDetail(WidgetTester tester, String title) async {
   expect(detailTitle, findsOneWidget);
   await E2eApp.pumpUntil(tester, _popupMenuButton());
   expect(_popupMenuButton(), findsWidgets);
+}
+
+Future<void> _goToBookmarksList(
+  WidgetTester tester,
+  Finder contextFinder,
+) async {
+  const BookmarksListRoute().go(tester.element(contextFinder));
+  await E2eApp.settle(tester);
+  await tester.pumpAndSettle();
+  final bookmarksTitle = find.descendant(
+    of: find.byType(AppBar),
+    matching: find.text('Bookmarks'),
+  );
+  await E2eApp.pumpUntil(tester, bookmarksTitle);
+  expect(bookmarksTitle, findsOneWidget);
 }
 
 Finder _popupMenuButton() {

--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -228,16 +228,14 @@ void main() {
 
     // ---- Existing user login preserves backend data ------------------------
     await _login(tester, email: email, password: password);
-    await _expectHome(tester);
+    await _goHome(tester);
 
     await tester.tap(find.byTooltip('Bookmarks'));
     await tester.pumpAndSettle();
     await E2eApp.pumpUntil(tester, find.text(editedBookmarkTitle));
     expect(find.text(editedBookmarkTitle), findsWidgets);
 
-    await tester.tap(find.byTooltip('Home'));
-    await tester.pumpAndSettle();
-    await _expectHome(tester);
+    await _goHome(tester);
     await _openCollectionsListFromHome(tester);
     await E2eApp.pumpUntil(tester, find.text(editedCollectionName));
     expect(find.text(editedCollectionName), findsWidgets);
@@ -287,7 +285,7 @@ void main() {
     await _signOut(tester);
     await _expectLoginFailure(tester, email: email, password: password);
     await _login(tester, email: email, password: changedPassword);
-    await _expectHome(tester);
+    await _goHome(tester);
     await _signOut(tester);
   });
 }
@@ -299,6 +297,12 @@ Future<void> _expectHome(WidgetTester tester) async {
   );
   await E2eApp.pumpUntil(tester, homeTitle);
   expect(homeTitle, findsOneWidget);
+}
+
+Future<void> _goHome(WidgetTester tester) async {
+  await tester.tap(find.byTooltip('Home'));
+  await tester.pumpAndSettle();
+  await _expectHome(tester);
 }
 
 Future<void> _openCollectionsListFromHome(WidgetTester tester) async {


### PR DESCRIPTION
Summary:
- Extend the real-backend e2e journey with auth form validation and relogin persistence checks.
- Cover bookmark update/delete, collection membership/update/delete, and password-change flows.
- Add e2e helpers for typed-route navigation and stable real-device interactions.

Tests:
- fvm flutter analyze
- tool/run_e2e.sh F5749062-5E2D-4683-A6AE-FA25356EC149
- pre-push build_runner/format/analyze checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end test coverage for bookmark and collection management, including creation, editing, and deletion flows
  * Added validation testing for password change functionality and data persistence across user sessions
  * Enhanced form validation and UI state verification assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->