### PR TITLE
docs: remove screenshots heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ To enable seamless local development and testing, this template is paired with a
 <br>
 
 - [✨ What's Inside](#-whats-inside)
-- [📸 Screenshots](#-screenshots)
 - [🧬 Architecture](#-architecture)
   - [📁 Feature Slice (Clean Architecture)](#-feature-slice-clean-architecture)
 - [🚀 Quick Start](#-quick-start)
@@ -92,8 +91,6 @@ To enable seamless local development and testing, this template is paired with a
 ---
 
 <br>
-
-## 📸 Screenshots
 
 <p align="center">
   <img src="doc/screenshots/app_cover_thumbnail.png" alt="Flutter Starter Template app demo" width="800">


### PR DESCRIPTION
Summary:
- Remove the standalone screenshots heading from the README.
- Remove the matching table-of-contents entry.

Validation:
- Pre-push build_runner/format/analyze checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified README structure by removing redundant section formatting in the Screenshots area, streamlining the document layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->