### PR TITLE
chore: prepare v1.0.0 stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,16 @@
 name: Release
 
 # Builds and uploads mobile releases via Fastlane: iOS → TestFlight,
-# Android → Google Play. Triggered by pushing a version tag (e.g. v1.2.0) or
-# manually with a chosen flavor/platform.
+# Android → Google Play. Triggered manually with a chosen flavor/platform.
+#
+# This is a template repo, so the store-deploy is opt-in: run it from the
+# Actions tab (workflow_dispatch) once you have configured the secrets and
+# variables listed under each job's `env:` (Settings → Secrets and variables →
+# Actions). To restore tag-triggered releases in a project built from this
+# template, add a `push: tags: ['v*']` entry below.
 #
 # This workflow only does the CI plumbing; the lane logic lives in
-# ios/fastlane/Fastfile and android/fastlane/Fastfile. It expects the secrets
-# and variables listed under each job's `env:` to be configured in the repo
-# (Settings → Secrets and variables → Actions). See the fastlane READMEs.
+# ios/fastlane/Fastfile and android/fastlane/Fastfile. See the fastlane READMEs.
 
 on:
   workflow_dispatch:
@@ -22,9 +25,6 @@ on:
         type: choice
         options: [both, ios, android]
         default: both
-  push:
-    tags:
-      - 'v*'
 
 env:
   # Keep in sync with .fvmrc (3.44.0). CI installs the SDK directly, so the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this template are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2026-06-08
+
+First stable release of the Flutter starter template.
+
+### Added
+
+- **Project foundation** — Flutter SDK pinned to 3.44.0 via FVM, lints via
+  `very_good_analysis`, and a feature-first `core` / `ui` / `shared` / `features`
+  layout (see `CLAUDE.md`).
+- **State management & routing** — `flutter_bloc` (+ `bloc_concurrency`) for app
+  state and `go_router` for declarative navigation.
+- **Dependency injection** — `injectable`/`get_it` wiring, including the
+  per-package micro-DI pattern.
+- **Workspace packages** — extracted into `packages/`: `analytics`,
+  `app_platform`, `app_ui`, `architecture`, `config`, `network`, `storage`,
+  `sync`, `theme`, plus `test_utils`.
+- **Features** — `splash`, `auth`, `home`, `profile`, `bookmarks`,
+  `collections`, and `notifications`, with a shared `Session` contract for
+  app-wide auth state.
+- **Theming & design system** — centralized light/dark `ThemeData` with a
+  `ThemeBloc` toggle and the `app_ui` design-system widgets.
+- **Local persistence** — ObjectBox storage with tracked schema bindings.
+- **Flavors** — `dev` / `staging` / `prod` build flavors driven by
+  `--dart-define-from-file env/<flavor>.json`.
+- **Firebase** — integration with Crashlytics and analytics (CocoaPods on iOS;
+  SPM disabled, see `CLAUDE.md`).
+- **Internationalization** — `flutter_localizations` + `intl` with ARB-based
+  localizations.
+- **CI/CD** — GitHub Actions for analyze/test with coverage gating (`ci.yml`),
+  CodeQL (`codeql.yml`), and a manual-dispatch Fastlane release pipeline
+  (`release.yml`) for TestFlight and Google Play.
+- **Tooling** — Dart & CodeGraph MCP servers and vendored agent skills.
+
+[1.0.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary

Prepares the template's first stable release (`v1.0.0`).

- Add `CHANGELOG.md` with a `1.0.0` entry summarizing the template's feature set.
- Make `release.yml` **manual-only**: drop the `push: tags: ['v*']` trigger so tagging the template repo does not fire a store-upload run that would fail without store secrets. The full Fastlane pipeline stays available via `workflow_dispatch`, and a comment documents how downstream projects can re-enable tag-triggered releases.

## Why

This is a template repo, so "stable version" means a source release (tag + GitHub Release), not a store deployment. The tag trigger had to go first so cutting `v1.0.0` doesn't leave a red ❌ run on the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CHANGELOG documenting initial release version 1.0.0 with all features and project foundations.

* **Chores**
  * Modified release workflow configuration to require manual activation instead of automatic tag-triggered deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->