### PR TITLE
feat(tooling): add one-shot bootstrap CLI (tool/setup.sh)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ harmless.
 ## Common commands
 
 ```bash
+./tool/setup.sh                              # one-shot bootstrap of a fresh clone (idempotent)
 fvm flutter pub get                          # install dependencies
 fvm flutter run                              # run on the default device (debug)
 fvm flutter run --profile                    # profile mode

--- a/README.md
+++ b/README.md
@@ -217,17 +217,39 @@ feature/
 
 ### ⚡ Install & Generate
 
+> 🧩 **Starting a new project?** Click **Use this template** on GitHub to spin
+> up your own repo, then clone it. To explore the template itself, clone
+> directly.
+
 ```bash
 # --recurse-submodules pulls the companion Go backend (a git submodule)
 git clone --recurse-submodules https://github.com/kido-luci/flutter-starter-template.git
 cd flutter-starter-template
 
-fvm flutter pub get
-fvm dart run build_runner build --delete-conflicting-outputs
+# One-shot bootstrap: submodules, FVM SDK, disable SPM (macOS), pub get,
+# code generation, backend deps, and the pre-push hook. Idempotent.
+./tool/setup.sh
 ```
 
-> 💡 **Already cloned without submodules?** Run
-> `git submodule update --init --recursive` to fetch the backend.
+> 💡 **Already cloned without submodules?** `tool/setup.sh` runs
+> `git submodule update --init --recursive` for you. Re-run the script anytime
+> your tree needs a refresh; pass `--help` to see flags (`--no-codegen`,
+> `--no-hooks`, `--no-backend`).
+
+<details>
+<summary><b>⚙️ Prefer to run the steps manually?</b></summary>
+<br>
+
+`tool/setup.sh` simply chains these:
+
+```bash
+fvm flutter pub get
+fvm dart run build_runner build --delete-conflicting-outputs
+fvm flutter config --no-enable-swift-package-manager   # macOS only — see below
+git config core.hooksPath .githooks                    # enable the pre-push gate
+```
+
+</details>
 
 ### 🍎 iOS one-time setup
 
@@ -236,7 +258,8 @@ iOS 15.0 deployment target, but Flutter 3.44.0 hardcodes the SPM-generated
 package to 13.0, and two plugins (`permission_handler_apple`,
 `objectbox_flutter_libs`) don't support SPM yet. This setting lives in a
 machine-global Flutter config (`~/.config/flutter/settings`), so **every new
-machine and CI runner must run it once** before the first iOS build:
+machine and CI runner must run it once** before the first iOS build.
+`tool/setup.sh` already does this on macOS; to run it by hand:
 
 ```bash
 fvm flutter config --no-enable-swift-package-manager
@@ -450,9 +473,10 @@ cd android && bundle exec fastlane beta flavor:prod   # → Google Play
 - **Build numbers** auto‑increment (lane arg → `BUILD_NUMBER` → git commit
   count) so repeated uploads are never rejected.
 - **CI** — [`.github/workflows/release.yml`](.github/workflows/release.yml) runs
-  both lanes on a `v*` tag push or manual dispatch (macOS for iOS, Linux for
+  both lanes on **manual dispatch** (Actions → Release; macOS for iOS, Linux for
   Android), restoring the git‑ignored Firebase configs and signing assets from
-  repository secrets.
+  repository secrets. To fire releases from a `v*` tag instead, add a
+  `push: tags: ['v*']` trigger to that workflow.
 
 Setup steps and the full list of required secrets live in
 [`ios/fastlane/README.md`](ios/fastlane/README.md) and

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+#
+# One-shot bootstrap: takes a fresh clone of this template to a compile-ready,
+# runnable state. Idempotent — safe to re-run anytime your tree needs a refresh.
+#
+# It chains the steps documented in the README Quick Start and the iOS one-time
+# setup note: submodules, FVM SDK, disabling Swift Package Manager (macOS),
+# dependencies, code generation, backend deps, and the pre-push hook.
+#
+# Usage: tool/setup.sh [options]
+#   --no-hooks      Don't enable the .githooks pre-push gate (enabled by default).
+#   --no-codegen    Skip build_runner (dep-only refresh).
+#   --no-backend    Skip fetching Go backend dependencies.
+#   -h, --help      Show this help and exit.
+#
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+backend_dir="$repo_root/simple_backend_server"
+
+# --- options ----------------------------------------------------------------
+enable_hooks=1
+run_codegen=1
+setup_backend=1
+
+usage() {
+  # Print the comment header above (between the shebang and `set -euo`).
+  sed -n '3,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --no-hooks) enable_hooks=0 ;;
+    --no-codegen) run_codegen=0 ;;
+    --no-backend) setup_backend=0 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "✖ Unknown option: $1" >&2
+      echo "  Run 'tool/setup.sh --help' for usage." >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+cd "$repo_root"
+
+# Prefer the FVM-pinned SDK (this repo pins Flutter via .fvmrc); fall back to a
+# plain toolchain if FVM is not installed. Mirrors .githooks/pre-push.
+if command -v fvm >/dev/null 2>&1; then
+  has_fvm=1
+  dart() { fvm dart "$@"; }
+  flutter() { fvm flutter "$@"; }
+else
+  has_fvm=0
+fi
+
+# --- 1. preflight / doctor --------------------------------------------------
+echo "▶ setup: checking required tooling…"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "✖ git not found in PATH. Install git and retry." >&2
+  exit 1
+fi
+
+if ! command -v dart >/dev/null 2>&1 || ! command -v flutter >/dev/null 2>&1; then
+  echo "✖ Missing required tooling: dart/flutter not found in PATH." >&2
+  echo "  Install FVM (recommended — https://fvm.app) or the Flutter SDK," >&2
+  echo "  then retry. This template pins Flutter $(cat .fvmrc | grep -o '[0-9.]*') via .fvmrc." >&2
+  exit 1
+fi
+
+if [[ "$has_fvm" -eq 0 ]]; then
+  echo "  ⚠ fvm not found — using the Flutter SDK on PATH. Versions may differ" >&2
+  echo "    from the pinned .fvmrc ($(cat .fvmrc | grep -o '[0-9.]*'))." >&2
+fi
+
+if ! command -v go >/dev/null 2>&1; then
+  echo "  ⚠ go not found — the companion backend won't run until Go is installed." >&2
+fi
+if ! command -v node >/dev/null 2>&1; then
+  echo "  ⚠ node not found — only needed for the optional firebase MCP server." >&2
+fi
+echo "✓ tooling OK"
+
+# --- 2. submodules ----------------------------------------------------------
+echo "▶ setup: syncing git submodules (backend)…"
+git submodule update --init --recursive
+echo "✓ submodules ready"
+
+# --- 3. FVM SDK -------------------------------------------------------------
+if [[ "$has_fvm" -eq 1 ]]; then
+  if [[ ! -d "$repo_root/.fvm/flutter_sdk" ]]; then
+    echo "▶ setup: installing the pinned Flutter SDK (fvm install)…"
+    fvm install
+    echo "✓ Flutter SDK installed"
+  else
+    echo "✓ Flutter SDK already installed (.fvm/flutter_sdk)"
+  fi
+fi
+
+# --- 4. iOS one-time: disable Swift Package Manager (macOS only) ------------
+# Firebase needs an iOS 15 deployment target, but Flutter 3.44 hardcodes the
+# SPM-generated package to 13.0 and two plugins lack SPM support — so this
+# project must build via CocoaPods. The setting is machine-global, so every
+# machine runs it once. See CLAUDE.md.
+if [[ "$(uname)" == "Darwin" ]]; then
+  echo "▶ setup: disabling Swift Package Manager (CocoaPods required on iOS)…"
+  flutter config --no-enable-swift-package-manager >/dev/null
+  echo "✓ SPM disabled"
+fi
+
+# --- 5. dependencies --------------------------------------------------------
+echo "▶ setup: installing Dart/Flutter dependencies (pub get)…"
+flutter pub get
+echo "✓ dependencies installed"
+
+# --- 6. code generation -----------------------------------------------------
+# Generated files (*.g.dart, *.freezed.dart, etc.) are git-ignored, so a fresh
+# clone won't compile until they're produced.
+if [[ "$run_codegen" -eq 1 ]]; then
+  echo "▶ setup: generating code (build_runner)…"
+  dart run build_runner build --delete-conflicting-outputs
+  echo "✓ code generated"
+else
+  echo "• skipping code generation (--no-codegen) — the tree won't compile" \
+    "until you run build_runner."
+fi
+
+# --- 7. backend dependencies ------------------------------------------------
+if [[ "$setup_backend" -eq 1 ]]; then
+  if command -v go >/dev/null 2>&1 && [[ -f "$backend_dir/go.mod" ]]; then
+    echo "▶ setup: fetching backend Go dependencies…"
+    (cd "$backend_dir" && go mod download)
+    echo "✓ backend dependencies ready"
+  else
+    echo "• skipping backend deps (go missing or submodule empty)."
+  fi
+fi
+
+# --- 8. git hooks (opt-in, default on) --------------------------------------
+if [[ "$enable_hooks" -eq 1 ]]; then
+  current_hooks_path="$(git config --get core.hooksPath || true)"
+  if [[ "$current_hooks_path" != ".githooks" ]]; then
+    echo "▶ setup: enabling the pre-push hook (git config core.hooksPath)…"
+    git config core.hooksPath .githooks
+    echo "✓ pre-push hook enabled (bypass once with: git push --no-verify)"
+  else
+    echo "✓ pre-push hook already enabled"
+  fi
+fi
+
+# --- 9. Firebase reminder ---------------------------------------------------
+if [[ ! -f "$repo_root/android/app/google-services.json" ]] ||
+  [[ ! -f "$repo_root/ios/Runner/GoogleService-Info.plist" ]]; then
+  echo "• Firebase config is git-ignored and missing. The app builds with"
+  echo "  placeholders, but for real Firebase run 'flutterfire configure' and"
+  echo "  drop google-services.json / GoogleService-Info.plist into place."
+fi
+
+# --- 10. summary ------------------------------------------------------------
+fvm_prefix=""
+[[ "$has_fvm" -eq 1 ]] && fvm_prefix="fvm "
+cat <<EOF
+
+✓ Setup complete. Next steps:
+
+  # start the local backend (in another terminal)
+  cd simple_backend_server && go run .        # → http://localhost:8080
+
+  # run the app
+  ${fvm_prefix}flutter run
+
+EOF


### PR DESCRIPTION
## Summary

Adds a one-command bootstrap so a fresh clone reaches a compile-ready, runnable state without manually chaining the Quick Start steps. Part of the v1.0.0 follow-up; true template/rename support is deferred to the next stable version.

## What's included

- **`tool/setup.sh`** — idempotent bootstrap matching the existing `tool/*.sh` / `.githooks/pre-push` conventions (FVM-with-fallback, `command -v` preflight, `▶/✓/✖` messaging). Steps:
  1. Preflight doctor (hard-fail on missing git/Dart toolchain; warn-only on `go`/`node`)
  2. `git submodule update --init --recursive`
  3. `fvm install` (only if SDK not materialized)
  4. Disable SPM (macOS only, guarded)
  5. `flutter pub get`
  6. `build_runner build`
  7. backend `go mod download`
  8. enable the `.githooks` pre-push gate
  9. Firebase-config reminder (non-fatal)
  10. summary + next steps
  - Flags: `--no-hooks`, `--no-codegen`, `--no-backend`, `-h/--help`.
- **README** — Quick Start leads with `./tool/setup.sh`; manual steps kept in a collapsible fallback. Also fixes the release-trigger note to reflect the now manual-only release workflow.
- **CLAUDE.md** — adds the script to Common commands.

## Verification

- `bash -n` syntax check clean; `--help` renders.
- Full end-to-end run passed **idempotently** (detected hook already enabled, fetched backend deps, ran codegen).
- `flutter analyze` → No issues found (pre-push gate passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated one-shot bootstrap script to prepare fresh clones for local development

* **Documentation**
  * Updated Quick Start instructions with enhanced guidance for project setup, cloning, iOS configuration, and CI/CD workflows
  * Clarified manual setup steps and platform-specific requirements
  * Expanded release CI documentation with tag-based release trigger instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->