### PR TITLE
docs: note the bootstrap CLI in the v1.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ First stable release of the Flutter starter template.
 - **CI/CD** — GitHub Actions for analyze/test with coverage gating (`ci.yml`),
   CodeQL (`codeql.yml`), and a manual-dispatch Fastlane release pipeline
   (`release.yml`) for TestFlight and Google Play.
+- **Bootstrap CLI** — `tool/setup.sh`, a one-command idempotent setup
+  (submodules, FVM SDK, SPM disable on macOS, `pub get`, code generation,
+  backend deps, and the pre-push hook).
 - **Tooling** — Dart & CodeGraph MCP servers and vendored agent skills.
 
 [1.0.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.0.0


### PR DESCRIPTION
Adds the `tool/setup.sh` bootstrap CLI to the v1.0.0 changelog entry so the
release record matches what ships in the tag (the tag is being re-cut to
include the CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)