### PR TITLE
fix(docs): make top Sponsor badge scroll to the Support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   </picture>
   <a href="https://github.com/kido-luci/flutter-starter-template/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge"></a>
   <a href="https://luci-studio.com"><img alt="Luci" src="https://img.shields.io/badge/built_by-Luci_Studio-FF6B6B?style=for-the-badge&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiPjxyZWN0IHg9IjMiIHk9IjMiIHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgcng9IjIiIHJ5PSIyIi8+PGNpcmNsZSBjeD0iOSIgY3k9IjkiIHI9IjIiLz48bGluZSB4MT0iMTIuMSIgeTE9IjkuMSIgeDI9IjE1IiB5Mj0iMTUiLz48L3N2Zz4="></a>
-  <a href="#-support"><img alt="Sponsor" src="https://img.shields.io/badge/💖-Sponsor-EA4AAA?style=for-the-badge"></a>
+  <a href="#support"><img alt="Sponsor" src="https://img.shields.io/badge/💖-Sponsor-EA4AAA?style=for-the-badge"></a>
 </p>
 
 <p align="center">
@@ -839,6 +839,8 @@ localized strings.
 ---
 
 <br>
+
+<a id="support"></a>
 
 ## ❤️ Support
 


### PR DESCRIPTION
## Problem
Clicking the **💖 Sponsor** badge at the top of the README only appended `#-support` to the URL without scrolling to the Support section.

## Cause
The `## ❤️ Support` heading uses the `❤️` emoji, whose trailing variation selector (U+FE0F) is left in GitHub's auto-generated heading slug. The real anchor therefore isn't `-support`, so the badge's `href="#-support"` never matched any element.

## Fix
- Add an explicit `<a id="support"></a>` anchor immediately before the heading.
- Point the badge at `#support`.

This is robust regardless of emoji-slug quirks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the broken "Sponsor" badge link navigation in documentation, ensuring it now correctly directs to the Support section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->