### PR TITLE
feat(tooling): add flutter-starter-template-cli scaffold tool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "simple_backend_server"]
 	path = simple_backend_server
 	url = https://github.com/kido-luci/flutter-starter-template-simple-backend
+[submodule "tool/cli"]
+	path = tool/cli
+	url = https://github.com/kido-luci/flutter-starter-template-cli.git

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -215,7 +215,7 @@ abstract class AppLocalizations {
   /// No description provided for @registerAppBarTitle.
   ///
   /// In en, this message translates to:
-  /// **'RegisterUseCase'**
+  /// **'Register'**
   String get registerAppBarTitle;
 
   /// No description provided for @registerHeadline.

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -67,7 +67,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get loginSocialUnavailable => 'Social sign-in isn\'t configured yet.';
 
   @override
-  String get registerAppBarTitle => 'RegisterUseCase';
+  String get registerAppBarTitle => 'Register';
 
   @override
   String get registerHeadline => 'Join Flutter Starter';


### PR DESCRIPTION
## Summary

- Adds [`flutter-starter-template-cli`](https://github.com/kido-luci/flutter-starter-template-cli) as a git submodule at `tool/cli/` — a Dart CLI (`fst`) that clones this template and renames every identifier for a new project
- Fixes a stale `registerAppBarTitle` l10n string (`'RegisterUseCase'` → `'Register'`)

## What `fst create` does

1. Prompts for display name, Dart package name, bundle ID, and organisation
2. Clones the template with `--recurse-submodules --depth=1` and detaches from upstream remote
3. Rewrites all identifiers across `pubspec.yaml`, `build.gradle.kts`, `project.pbxproj`, `Info.plist`, and all `lib/` imports
4. Moves `MainActivity.kt` to the correct package directory path
5. Runs `tool/setup.sh --no-hooks` (pub get + codegen)

## CLI repo

`tool/cli` is a standalone pub.dev package with:
- CI on Dart stable + beta + publish dry-run (required status checks)
- CD publish to pub.dev via OIDC on `v*` tags
- Branch protection matching this repo

> **Depends on**: [flutter-starter-template-cli#1](https://github.com/kido-luci/flutter-starter-template-cli/pull/1) (dart format fix) merging first so the submodule pointer is clean.

## Test plan

- [ ] `git submodule update --init tool/cli` materialises the CLI package
- [ ] `cd tool/cli && dart pub get && dart test` — 9 tests pass
- [ ] `dart run tool/cli/bin/fst.dart create` prompts correctly and scaffolds a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated the register screen app bar text from **“RegisterUseCase”** to **“Register”** (English localization).

* **Chores**
  * Updated the referenced commit for the **CLI tool** git submodule in the project configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->