### PR TITLE
refactor: extraction follow-ups — self-contained splash asset, drop app freezed, rank feature packages

### DIFF
--- a/packages/features/splash/lib/src/presentation/widgets/splash_widgets.dart
+++ b/packages/features/splash/lib/src/presentation/widgets/splash_widgets.dart
@@ -29,6 +29,7 @@ class SplashContent extends StatelessWidget {
               ),
               child: Image.asset(
                 'assets/icons/logo.png',
+                package: 'feature_splash',
                 width: 72,
                 height: 72,
                 fit: BoxFit.cover,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -875,7 +875,7 @@ packages:
     source: hosted
     version: "11.0.0"
   freezed:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: freezed
       sha256: f23ea33b3863f119b58ed1b586e881a46bd28715ddcc4dbc33104524e3434131

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -155,10 +155,6 @@ dev_dependencies:
   # from @injectable annotations.
   injectable_generator: ^3.0.2
 
-  # Generates immutable classes, copyWith, equality, and union/sealed
-  # variants from @freezed annotations.
-  freezed: ^3.2.5
-
   # Generates type-safe references to assets and fonts declared below
   # (output: lib/gen/assets.gen.dart). Use e.g. Assets.images.logo instead
   # of raw 'assets/images/logo.png' strings.

--- a/test/architecture/feature_boundaries_test.dart
+++ b/test/architecture/feature_boundaries_test.dart
@@ -15,9 +15,10 @@
 // the contract to `shared_*` and remove the entry (the staleness test below
 // will remind you if a whitelisted edge disappears).
 //
-// This complements `package_layering_test`, which only ranks the top-level
-// `packages/` and does not recurse into `packages/features/*`; this scan is
-// what keeps the feature packages from depending on one another.
+// This complements `package_layering_test`: that test ranks the feature
+// packages and enforces their dependency *direction* (a feature may only
+// depend on strictly lower layers), while this scan enforces the *capability
+// allowlist* — which specific feature-to-feature edges are permitted at all.
 //
 // A pure file-scan test on purpose: no third-party dependency, runs inside the
 // normal `fvm flutter test` / CI flow, and can't break when the analyzer or

--- a/test/architecture/package_layering_test.dart
+++ b/test/architecture/package_layering_test.dart
@@ -47,6 +47,18 @@ const _layers = <String, int>{
   'theme': 2, // -> analytics, architecture
   // 3 — shared test harness, sits on top of what it provides fakes for.
   'test_utils': 3, // -> analytics, app_platform, storage
+  // 4 — base feature packages: the top runtime layer (only the app composes
+  //     them), each depending on no sibling feature.
+  'feature_auth': 4,
+  'feature_collections': 4,
+  'feature_home': 4,
+  'feature_notifications': 4,
+  'feature_splash': 4,
+  // 5 — feature packages that surface a single sibling's capability; each
+  //     depends on exactly one lower feature (the capability provider). The
+  //     allowed edges are documented in feature_boundaries_test.
+  'feature_bookmarks': 5, // -> feature_collections
+  'feature_profile': 5, // -> feature_auth
 };
 
 void main() {
@@ -113,15 +125,29 @@ void main() {
 }
 
 /// Maps each workspace package name to the lines of its `pubspec.yaml`.
+///
+/// Descends one extra level into container directories that have no pubspec of
+/// their own (e.g. `packages/features/`), so the nested feature packages are
+/// ranked and checked like every other workspace package.
 Map<String, List<String>> _discoverPackages(Directory packagesDir) {
   final result = <String, List<String>>{};
-  for (final entity in packagesDir.listSync()) {
-    if (entity is! Directory) continue;
-    final pubspec = File('${entity.path}/pubspec.yaml');
-    if (!pubspec.existsSync()) continue;
+
+  void add(Directory dir) {
+    final pubspec = File('${dir.path}/pubspec.yaml');
+    if (!pubspec.existsSync()) return;
     final lines = pubspec.readAsLinesSync();
     final name = _packageName(lines);
     if (name != null) result[name] = lines;
+  }
+
+  for (final entity in packagesDir.listSync()) {
+    if (entity is! Directory) continue;
+    if (File('${entity.path}/pubspec.yaml').existsSync()) {
+      add(entity);
+    } else {
+      // Container directory (e.g. packages/features/) — descend one level.
+      entity.listSync().whereType<Directory>().forEach(add);
+    }
   }
   return result;
 }


### PR DESCRIPTION
Follow-up cleanups on top of #124 (the feature-package extraction). Stacked on `refactor/finish-feature-extraction` so the diff shows only these three fixes; retarget to `main` once #124 merges.

Each commit is independently green: `dart analyze` clean across the workspace, a clean root `build_runner build`, and all 226 tests pass.

## Fixes

**`fix(splash)` — self-contained logo asset**
Splash referenced `Image.asset('assets/icons/logo.png')` with a bare path, which silently relied on the *host app* bundling that asset. Qualified it with `package: 'feature_splash'` so it resolves the package's own vendored copy — matching what `feature_auth` already does. The package is now self-contained.

**`chore(app)` — drop the unused `freezed` dev-dependency**
After home/profile moved into their feature packages, the app declares no `@freezed` types, so the app-level `freezed` generator was dead weight. Removed it. The feature packages keep their own `freezed` dev-dep and run their own codegen. **Verified empirically**: a clean root `dart run build_runner build --delete-conflicting-outputs` succeeds (no freezed builder needed at the app level), and the full analyze + 226-test suite pass. `freezed_annotation` (runtime) is retained.

**`test(arch)` — rank feature packages in the layering guardrail**
`package_layering_test` only scanned top-level `packages/`, leaving the nested `packages/features/*` packages unranked and direction-unchecked (a documented gap). It now descends one level into container dirs without their own pubspec, so feature packages are discovered and checked like any other. Ranking: base features at layer 4, the two capability consumers (`bookmarks → collections`, `profile → auth`) at layer 5 — so a wrong-way feature dependency is caught.

## Notes for the reviewer
- The fourth item I flagged (a "dead generated `Assets.icons.logo` accessor") turned out to be a **non-issue**: `lib/gen/assets.gen.dart` is git-ignored (locally generated, never committed), so there's nothing in the repo to clean up — the real fix was the self-containment one above.
- The layering change is **proven non-vacuous**: temporarily mis-ranking `feature_bookmarks` below `feature_collections` makes the test fail with `feature_bookmarks (layer 3) -> feature_collections (layer 4) [upward]`, and it passes again once restored.
- `package_layering_test` and `feature_boundaries_test` are now complementary: layering enforces dependency *direction* for feature packages; boundaries enforces the *capability allowlist* (which specific feature→feature edges are permitted at all). The cross-reference comment is updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)