### PR TITLE
chore(release): 1.2.0 — document the package extraction, refresh README, restore orphaned fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,64 @@ All notable changes to this template are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-06-17
+
+Completes the move to a fully package-based architecture. Every feature now
+lives in its own workspace package; the root app (`lib/`) holds no feature code.
+
+### Changed
+
+- **Feature packages** — `home`, `profile`, and `splash` extracted from
+  `lib/features/` into `packages/features/`, joining `auth`, `notifications`,
+  `bookmarks`, and `collections`. `lib/features/` is removed and the app is now
+  a pure composition root (routing, DI, Firebase bootstrap).
+- **Splash decoupling** — the splash screen no longer reaches into app routing.
+  It restores the session and hands control back through an `onRestored`
+  callback the app wires, and resolves its logo against its own package asset
+  bundle so the package is self-contained.
+- **App shell** — the three per-feature sync wrappers collapsed into one
+  closure-based adapter, and the `bookmarks → collections` capability imports
+  are annotated as the documented single-consumer exception.
+
+### Added
+
+- **Architecture guardrails for feature packages** — `package_layering_test`
+  now ranks and direction-checks the nested `packages/features/*` packages, and
+  `feature_boundaries_test` enforces the cross-feature capability allowlist
+  (`bookmarks → collections`, `profile → auth`) at the package level.
+
+### Removed
+
+- Unused app-level `freezed` dev-dependency — the app declares no `@freezed`
+  types (feature packages keep their own generator).
+
+## [1.1.0] - 2026-06-17
+
+Began the move to a package-based architecture and hardened CI.
+
+### Added
+
+- **Feature packages** — `auth`, `notifications`, `bookmarks`, and `collections`
+  extracted into `packages/features/`, with prerequisite packages
+  `shared_contracts` (cross-feature domain projections and reader interfaces),
+  `shared_ui` (the app-wide `Session`/`SessionScope` and shared widgets),
+  `database` (centralized ObjectBox entities and bindings), and `localization`
+  (ARB sources + gen-l10n `AppLocalizations`).
+- **CI build smoke-tests** — Android and iOS debug builds, an l10n guard,
+  lockfile enforcement, golden tests, and Codecov coverage reporting.
+- **Scaffold CLI** — a `flutter-starter-template-cli` tool for generating new
+  projects from the template.
+
+### Changed
+
+- Removed the `lib/shared/` shim layer in favor of the `shared_contracts` /
+  `shared_ui` packages, and pruned app-level dependencies now owned by packages.
+- Aligned per-package DI module naming to `<Name>PackageModule`.
+
+### Removed
+
+- `lib/shared/` (replaced by the `shared_contracts` and `shared_ui` packages).
+
 ## [1.0.0] - 2026-06-08
 
 First stable release of the Flutter starter template.
@@ -41,4 +99,6 @@ First stable release of the Flutter starter template.
   backend deps, and the pre-push hook).
 - **Tooling** — Dart & CodeGraph MCP servers and vendored agent skills.
 
+[1.2.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.2.0
+[1.1.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.1.0
 [1.0.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -115,22 +115,16 @@ To enable seamless local development and testing, this template is paired with a
 │   ├── app/
 │   │   ├── app.dart                  # MaterialApp.router + providers + SessionScope
 │   │   ├── router.dart               # TypedGoRoute + auth redirect
+│   │   ├── features.dart             # Optional-feature registry (sync controllers)
 │   │   ├── di/                       # App-level get_it + injectable wiring
 │   │   └── widgets/                  # App-level shell widgets
 │   ├── core/
-│   │   ├── data/database/            # ObjectBox app-store bootstrap
-│   │   ├── data/sync/                # App-level sync wiring/adapters
-│   │   ├── di/                       # get_it + injectable app graph
+│   │   ├── data/database/            # ObjectBox app-store bootstrap (@preResolve)
+│   │   ├── data/sync/                # App-level sync cursor store
+│   │   ├── di/                       # App-wide service module (Uuid, …)
 │   │   ├── extensions/               # App-specific convenience extensions
 │   │   └── platform/firebase/        # App bootstrap for Firebase services
-│   ├── features/                     # App-only feature slices
-│   │   ├── auth/                     # Sign-in, sign-out, session restore
-│   │   ├── home/                     # Home dashboard
-│   │   ├── notifications/            # Notification & activity feed (data + presentation)
-│   │   ├── profile/                  # User info + account actions
-│   │   └── splash/                   # Session restoration gate
-│   ├── gen/                          # flutter_gen asset references
-│   └── shared/                       # App-level shared domain/presentation contracts
+│   └── gen/                          # flutter_gen asset references
 ├── packages/                         # Dart Pub Workspace members
 │   ├── architecture/                 # Failure, Result, UseCase primitives
 │   ├── network/                      # Dio, Retrofit, retry/performance interceptors
@@ -140,26 +134,32 @@ To enable seamless local development and testing, this template is paired with a
 │   ├── analytics/                    # Analytics service + route observer
 │   ├── app_platform/                 # Camera, picker, permissions, notifications, share
 │   ├── sync/                         # Reusable offline-first sync engine (scheduler + delta CRUD)
+│   ├── sync_connectivity_plus/       # connectivity_plus adapter for the sync engine
 │   ├── theme/                        # ThemeBloc and persisted theme state
 │   ├── app_ui/                       # Design system, theme, layout, reusable widgets
 │   ├── shared_ui/                    # Cross-feature presentation contracts (Session/SessionScope) + shared widgets
 │   ├── shared_contracts/             # Cross-feature domain contracts & reader interfaces
 │   ├── localization/                 # ARB sources + gen-l10n AppLocalizations + context.l10n
-│   ├── feature_notifications/        # Notifications domain layer (entities, contracts, use cases)
-│   ├── features/
-│   │   ├── bookmarks/                # Bookmarks feature — data/domain/presentation package
-│   │   └── collections/             # Collections feature — data/domain/presentation package
-│   └── test_utils/                   # Shared mocks, images, and mocktail export
-├── test/                             # Root app tests only
+│   ├── test_utils/                   # Shared mocks, images, and mocktail export
+│   └── features/                     # Self-contained feature packages (data/domain/presentation)
+│       ├── auth/                     # Sign-in, sign-out, session restore
+│       ├── splash/                   # Session restoration gate (presentation only)
+│       ├── home/                     # Home dashboard (presentation only)
+│       ├── profile/                  # User info + account actions
+│       ├── notifications/            # Notification & activity feed
+│       ├── bookmarks/                # Bookmarks — offline-first CRUD
+│       └── collections/             # Collections — offline-first CRUD
+├── test/                             # Root app + feature tests
 └── integration_test/                 # Device/emulator integration tests
 ```
 
-The repository uses Dart Pub Workspaces. The root package is the assembled
-Flutter app — the composition root: routing, DI composition, app-only features
-(`auth`, `home`, `notifications`, `profile`, `splash`), and Firebase bootstrap
-stay there. Reusable infrastructure and self-contained feature slices live in
-`packages/` and are consumed through package entry points such as
-`package:network/network.dart`.
+The repository uses Dart Pub Workspaces. The root package (`lib/`) is the
+assembled Flutter app — a thin composition root: routing, DI composition,
+optional-feature wiring, and Firebase bootstrap. It owns no feature code.
+Every feature lives as a self-contained package under `packages/features/`, and
+reusable infrastructure lives in `packages/`, both consumed through package
+entry points such as `package:network/network.dart` and
+`package:feature_home/feature_home.dart`.
 
 Workspace packages own their third-party implementation details. For example,
 the root app depends on `network`, not directly on `dio` or `retrofit`;
@@ -167,15 +167,20 @@ the root app depends on `network`, not directly on `dio` or `retrofit`;
 keeps platform, storage, analytics, theme, and UI dependencies versioned in one
 place and avoids root-package dependency conflicts.
 
-Larger features have graduated out of `lib/` into their own packages:
-`features/bookmarks` and `features/collections` are self-contained
-data/domain/presentation slices, while `feature_notifications` extracts the
-notifications domain layer. Genuinely cross-feature contracts live in
-`shared_contracts` (domain projections and reader interfaces) and `shared_ui`
-(the app-wide `Session`/`SessionScope` and shared widgets), promoted only on the
-rule of three. ObjectBox entities and the generated bindings are centralized in
-the `database` package, and localization (ARB sources + gen-l10n) lives in
-`localization`, shared by the app shell and every feature package.
+Every feature is a `feature_<name>` package under `packages/features/` with its
+own `data/domain/presentation` layers and a micro-package DI module
+(`Feature<Name>PackageModule`) the app wires at composition time. Data-less
+features such as `home` and `splash` ship only a presentation layer. Genuinely
+cross-feature contracts live in `shared_contracts` (domain projections and
+reader interfaces) and `shared_ui` (the app-wide `Session`/`SessionScope` and
+shared widgets), promoted only on the rule of three. A feature may not import
+another feature except through a documented single-consumer **capability**
+(e.g. `bookmarks` embeds two `collections` widgets, `profile` surfaces `auth`'s
+delete-account flow); both rules are enforced by the architecture guardrail
+tests under `test/architecture/`. ObjectBox entities and the generated bindings
+are centralized in the `database` package, and localization (ARB sources +
+gen-l10n) lives in `localization`, shared by the app shell and every feature
+package.
 
 All shared UI lives in `packages/app_ui` and is consumed through
 `package:app_ui/app_ui.dart`; add new generic widgets there. Package-owned tests
@@ -220,21 +225,31 @@ graph TD
   database --> sync
 ```
 
-**3. Feature packages** — what each feature depends on. `bookmarks` also reuses
-two capabilities from `collections`, so it depends on it directly.
+**3. Feature packages** — every feature is a package under `packages/features/`.
+The only feature→feature edges are the two documented capabilities: `bookmarks`
+reuses two `collections` widgets, and `profile` surfaces `auth`'s delete-account
+flow. Infra edges are summarized per feature.
 
 ```mermaid
 graph TD
+  auth["features/auth"]
+  splash["features/splash"]
+  home["features/home"]
+  profile["features/profile"]
+  notifications["features/notifications"]
   bookmarks["features/bookmarks"]
   collections["features/collections"]
-  feature_notifications["feature_notifications"]
 
+  profile --> auth
   bookmarks --> collections
-  bookmarks --> network & database & sync & analytics & app_platform & app_ui
-  bookmarks --> shared_ui & shared_contracts & localization & architecture
-  collections --> network & database & sync & app_ui
-  collections --> shared_ui & shared_contracts & localization & architecture
-  feature_notifications --> architecture
+
+  auth --> network & storage & analytics & config
+  bookmarks --> network & database & sync & analytics & app_platform
+  collections --> network & database & sync
+  notifications --> network & database & sync
+  home --> shared_contracts
+  profile --> analytics & theme
+  splash --> shared_ui & app_ui & localization
 ```
 
 **External dependency encapsulation** — each infrastructure package owns its
@@ -294,19 +309,30 @@ graph TB
 
 ### 📁 Feature Slice (Clean Architecture)
 
+Each feature package keeps its layers under `lib/src/`, with a barrel
+(`lib/feature_<name>.dart`) exporting only the public surface (DI module, domain,
+screens, capability widgets). Data-less features (`home`, `splash`) ship only
+`presentation/`.
+
 ```
-feature/
-├── data/
-│   ├── datasources/        Remote (Retrofit) + Local (ObjectBox / secure storage)
-│   ├── models/             Freezed DTOs with toDomain() mappers
-│   └── repositories/       Concrete implementations
-├── domain/
-│   ├── entities/           Pure Dart classes — zero framework deps
-│   ├── repositories/       Abstract interfaces
-│   └── usecases/           Single‑purpose, injectable
-└── presentation/
-    ├── bloc/               Bloc + freezed state
-    └── screens/            Stateless/Stateful widgets
+packages/features/<name>/
+├── lib/
+│   ├── feature_<name>.dart      Public barrel (DI module, domain, screens)
+│   └── src/
+│       ├── data/
+│       │   ├── datasources/     Remote (Retrofit) + Local (ObjectBox / secure storage)
+│       │   ├── models/          Freezed DTOs with toDomain() mappers
+│       │   └── repositories/    Concrete implementations
+│       ├── domain/
+│       │   ├── entities/        Pure Dart classes — zero framework deps
+│       │   ├── repositories/    Abstract interfaces
+│       │   └── usecases/        Single‑purpose, injectable
+│       ├── presentation/
+│       │   ├── bloc/            Bloc + freezed state
+│       │   └── screens/         Stateless/Stateful widgets
+│       ├── di.dart              @InjectableInit.microPackage() anchor
+│       └── locator.dart         Shared GetIt instance
+└── pubspec.yaml                 name: feature_<name>, resolution: workspace
 ```
 
 <br>
@@ -610,7 +636,7 @@ that reuses only the scheduler.
 The full model — the shared engine, local‑first writes, the scheduler, and
 push/pull with revision‑based delta sync, tombstones, and conflict detection —
 is documented in
-[`lib/features/README.md`](lib/features/README.md#-offlinefirst-sync).
+[`packages/features/README.md`](packages/features/README.md#-offlinefirst-sync).
 
 <br>
 

--- a/packages/features/splash/lib/src/presentation/widgets/splash_widgets.dart
+++ b/packages/features/splash/lib/src/presentation/widgets/splash_widgets.dart
@@ -29,6 +29,7 @@ class SplashContent extends StatelessWidget {
               ),
               child: Image.asset(
                 'assets/icons/logo.png',
+                package: 'feature_splash',
                 width: 72,
                 height: 72,
                 fit: BoxFit.cover,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -875,7 +875,7 @@ packages:
     source: hosted
     version: "11.0.0"
   freezed:
-    dependency: "direct dev"
+    dependency: transitive
     description:
       name: freezed
       sha256: f23ea33b3863f119b58ed1b586e881a46bd28715ddcc4dbc33104524e3434131

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 1.2.0+1
 
 environment:
   sdk: ^3.12.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -155,10 +155,6 @@ dev_dependencies:
   # from @injectable annotations.
   injectable_generator: ^3.0.2
 
-  # Generates immutable classes, copyWith, equality, and union/sealed
-  # variants from @freezed annotations.
-  freezed: ^3.2.5
-
   # Generates type-safe references to assets and fonts declared below
   # (output: lib/gen/assets.gen.dart). Use e.g. Assets.images.logo instead
   # of raw 'assets/images/logo.png' strings.

--- a/test/architecture/feature_boundaries_test.dart
+++ b/test/architecture/feature_boundaries_test.dart
@@ -15,9 +15,10 @@
 // the contract to `shared_*` and remove the entry (the staleness test below
 // will remind you if a whitelisted edge disappears).
 //
-// This complements `package_layering_test`, which only ranks the top-level
-// `packages/` and does not recurse into `packages/features/*`; this scan is
-// what keeps the feature packages from depending on one another.
+// This complements `package_layering_test`: that test ranks the feature
+// packages and enforces their dependency *direction* (a feature may only
+// depend on strictly lower layers), while this scan enforces the *capability
+// allowlist* — which specific feature-to-feature edges are permitted at all.
 //
 // A pure file-scan test on purpose: no third-party dependency, runs inside the
 // normal `fvm flutter test` / CI flow, and can't break when the analyzer or

--- a/test/architecture/package_layering_test.dart
+++ b/test/architecture/package_layering_test.dart
@@ -47,6 +47,18 @@ const _layers = <String, int>{
   'theme': 2, // -> analytics, architecture
   // 3 — shared test harness, sits on top of what it provides fakes for.
   'test_utils': 3, // -> analytics, app_platform, storage
+  // 4 — base feature packages: the top runtime layer (only the app composes
+  //     them), each depending on no sibling feature.
+  'feature_auth': 4,
+  'feature_collections': 4,
+  'feature_home': 4,
+  'feature_notifications': 4,
+  'feature_splash': 4,
+  // 5 — feature packages that surface a single sibling's capability; each
+  //     depends on exactly one lower feature (the capability provider). The
+  //     allowed edges are documented in feature_boundaries_test.
+  'feature_bookmarks': 5, // -> feature_collections
+  'feature_profile': 5, // -> feature_auth
 };
 
 void main() {
@@ -113,15 +125,29 @@ void main() {
 }
 
 /// Maps each workspace package name to the lines of its `pubspec.yaml`.
+///
+/// Descends one extra level into container directories that have no pubspec of
+/// their own (e.g. `packages/features/`), so the nested feature packages are
+/// ranked and checked like every other workspace package.
 Map<String, List<String>> _discoverPackages(Directory packagesDir) {
   final result = <String, List<String>>{};
-  for (final entity in packagesDir.listSync()) {
-    if (entity is! Directory) continue;
-    final pubspec = File('${entity.path}/pubspec.yaml');
-    if (!pubspec.existsSync()) continue;
+
+  void add(Directory dir) {
+    final pubspec = File('${dir.path}/pubspec.yaml');
+    if (!pubspec.existsSync()) return;
     final lines = pubspec.readAsLinesSync();
     final name = _packageName(lines);
     if (name != null) result[name] = lines;
+  }
+
+  for (final entity in packagesDir.listSync()) {
+    if (entity is! Directory) continue;
+    if (File('${entity.path}/pubspec.yaml').existsSync()) {
+      add(entity);
+    } else {
+      // Container directory (e.g. packages/features/) — descend one level.
+      entity.listSync().whereType<Directory>().forEach(add);
+    }
   }
   return result;
 }


### PR DESCRIPTION
Prepares the **1.2.0** release: version bump, CHANGELOG backfill, and a README refresh — and **restores three fixes that never reached `main`**.

## ⚠️ Important: orphaned commits restored
PR #125 (splash self-contained asset, dropped app `freezed`, feature-package layering ranks) was merged into the `refactor/finish-feature-extraction` branch **after** that branch had already squash-merged to `main` via #124 — so its three commits never landed on `main`. This branch cherry-picks them back (`c4c0d43`, `ce5ab45`, `4e7c766`) so they ship with the release. Verified each still applies cleanly and the suite passes.

## What's in this PR

**Restored fixes (cherry-picked from #125)**
- `fix(splash)` — splash logo resolves against `package: 'feature_splash'` (self-contained).
- `chore(app)` — drop the unused app-level `freezed` dev-dep (app has no `@freezed` types; verified with a clean root `build_runner`).
- `test(arch)` — `package_layering_test` now ranks and direction-checks the nested `packages/features/*` packages.

**Release prep**
- **Version** → `1.2.0+1`. `pubspec.yaml` was still `1.0.0+1` even though `v1.1.0` was already tagged, so the version was two releases behind reality.
- **CHANGELOG** — backfilled a `[1.1.0]` entry (the start of the package extraction: auth/notifications/bookmarks/collections + prerequisite packages, CI build smoke-tests, the scaffold CLI, `lib/shared` removal) and added `[1.2.0]` (finishing home/profile/splash, the guardrail repoint, the self-contained splash asset, the dropped `freezed`).
- **README** — the Architecture section was stale (showed `lib/features/`, `lib/shared/`, a standalone `feature_notifications`, and only bookmarks/collections under `packages/features/`). Updated the directory tree, the prose, the feature-package dependency graph, and the feature-slice layout to the current package-based reality; repointed the offline-sync doc link to `packages/features/README.md`.

## Verification
- `dart analyze` — clean across the whole workspace.
- `dart run build_runner build --delete-conflicting-outputs` — clean (confirms the `freezed` removal works off `main`).
- `flutter test` — 226/226 pass.

## After merge
Tag `v1.2.0` on the merge commit so the CHANGELOG links resolve. (A `v1.1.0` tag already exists at #123; this just documents it retroactively.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)