### PR TITLE
refactor(features): narrow public barrels to the consumed surface

### DIFF
--- a/packages/features/bookmarks/lib/feature_bookmarks.dart
+++ b/packages/features/bookmarks/lib/feature_bookmarks.dart
@@ -2,21 +2,15 @@
 ///
 /// The host app wires `FeatureBookmarksPackageModule` via
 /// `externalPackageModulesBefore`, mounts the exported screens in its router,
-/// and drives background sync through `BookmarksSyncController`. The domain
-/// layer (entities, use cases, contracts) is exported as the feature's public
-/// API; data and presentation internals stay private.
+/// and drives background sync through `BookmarksSyncController`. Only the
+/// `Bookmark` entity is exported from the domain layer; repositories and use
+/// cases are internal, resolved through dependency injection. Data and
+/// presentation internals stay private.
 library;
 
 export 'src/di.module.dart' show FeatureBookmarksPackageModule;
 export 'src/domain/entities/bookmark.dart';
-export 'src/domain/repositories/bookmarks_repository.dart';
 export 'src/domain/services/bookmarks_sync_controller.dart';
-export 'src/domain/usecases/create_bookmark.dart';
-export 'src/domain/usecases/delete_bookmark.dart';
-export 'src/domain/usecases/get_bookmark.dart';
-export 'src/domain/usecases/list_bookmarks.dart';
-export 'src/domain/usecases/list_local_bookmarks.dart';
-export 'src/domain/usecases/update_bookmark.dart';
 export 'src/presentation/bookmarks_routes.dart';
 export 'src/presentation/screens/bookmark_detail_screen.dart';
 export 'src/presentation/screens/bookmark_form_screen.dart';

--- a/packages/features/bookmarks/test/support.dart
+++ b/packages/features/bookmarks/test/support.dart
@@ -1,4 +1,10 @@
 import 'package:feature_bookmarks/feature_bookmarks.dart';
+import 'package:feature_bookmarks/src/domain/usecases/create_bookmark.dart';
+import 'package:feature_bookmarks/src/domain/usecases/delete_bookmark.dart';
+import 'package:feature_bookmarks/src/domain/usecases/get_bookmark.dart';
+import 'package:feature_bookmarks/src/domain/usecases/list_bookmarks.dart';
+import 'package:feature_bookmarks/src/domain/usecases/list_local_bookmarks.dart';
+import 'package:feature_bookmarks/src/domain/usecases/update_bookmark.dart';
 import 'package:test_utils/test_utils.dart';
 
 export 'package:test_utils/test_utils.dart';

--- a/packages/features/collections/lib/feature_collections.dart
+++ b/packages/features/collections/lib/feature_collections.dart
@@ -4,20 +4,15 @@
 /// `externalPackageModulesBefore`, mounts the exported screens in its router,
 /// and drives background sync through `CollectionsSyncController`. The bookmarks
 /// feature consumes the two exported capability widgets (`CollectionsListView`
-/// and `AddToCollectionSheet`). The domain layer is exported as the feature's
-/// public API; data and presentation internals stay private.
+/// and `AddToCollectionSheet`). Only the `Collection` entity is exported from
+/// the domain layer; repositories and use cases are internal, resolved through
+/// dependency injection. Data and the remaining presentation internals stay
+/// private.
 library;
 
 export 'src/di.module.dart' show FeatureCollectionsPackageModule;
 export 'src/domain/entities/collection.dart';
-export 'src/domain/repositories/collections_repository.dart';
 export 'src/domain/services/collections_sync_controller.dart';
-export 'src/domain/usecases/create_collection.dart';
-export 'src/domain/usecases/delete_collection.dart';
-export 'src/domain/usecases/get_collection.dart';
-export 'src/domain/usecases/list_collections.dart';
-export 'src/domain/usecases/list_local_collections.dart';
-export 'src/domain/usecases/update_collection.dart';
 export 'src/presentation/collections_routes.dart';
 export 'src/presentation/screens/collection_detail_screen.dart';
 export 'src/presentation/screens/collection_form_screen.dart';

--- a/packages/features/notifications/lib/feature_notifications.dart
+++ b/packages/features/notifications/lib/feature_notifications.dart
@@ -2,20 +2,17 @@
 ///
 /// The host app wires `FeatureNotificationsPackageModule` via
 /// `externalPackageModulesBefore`, mounts the exported screen in its router,
-/// and drives background sync through `NotificationsSyncController`. The
-/// domain layer (entities, use cases, contracts) is exported as the feature's
-/// public API; data and presentation internals stay private.
+/// and drives background sync through `NotificationsSyncController`. The domain
+/// entities surfaced by `NotificationsState` are exported; repositories and use
+/// cases are internal, resolved through dependency injection. Data and the
+/// remaining presentation internals stay private.
 library;
 
 export 'src/di.module.dart' show FeatureNotificationsPackageModule;
 export 'src/domain/entities/app_notification.dart';
 export 'src/domain/entities/notifications_feed.dart';
 export 'src/domain/entities/user_activity.dart';
-export 'src/domain/repositories/notifications_repository.dart';
 export 'src/domain/services/notifications_sync_controller.dart';
-export 'src/domain/usecases/get_notifications_feed.dart';
-export 'src/domain/usecases/get_notifications_feed_local.dart';
-export 'src/domain/usecases/mark_notification_read.dart';
 export 'src/presentation/bloc/notifications_bloc.dart';
 export 'src/presentation/bloc/notifications_state.dart';
 export 'src/presentation/notifications_routes.dart';

--- a/packages/features/notifications/test/domain/usecases/notifications_usecases_test.dart
+++ b/packages/features/notifications/test/domain/usecases/notifications_usecases_test.dart
@@ -1,5 +1,8 @@
 import 'package:architecture/architecture.dart';
 import 'package:feature_notifications/feature_notifications.dart';
+import 'package:feature_notifications/src/domain/repositories/notifications_repository.dart';
+import 'package:feature_notifications/src/domain/usecases/get_notifications_feed.dart';
+import 'package:feature_notifications/src/domain/usecases/mark_notification_read.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../support.dart';

--- a/packages/features/notifications/test/presentation/bloc/notifications_bloc_test.dart
+++ b/packages/features/notifications/test/presentation/bloc/notifications_bloc_test.dart
@@ -1,6 +1,9 @@
 import 'package:architecture/architecture.dart';
 import 'package:bloc_test/bloc_test.dart';
 import 'package:feature_notifications/feature_notifications.dart';
+import 'package:feature_notifications/src/domain/usecases/get_notifications_feed.dart';
+import 'package:feature_notifications/src/domain/usecases/get_notifications_feed_local.dart';
+import 'package:feature_notifications/src/domain/usecases/mark_notification_read.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../support.dart';


### PR DESCRIPTION
## What

Group 1 of the structure review: tighten the public API of the three sync/CRUD feature packages (`bookmarks`, `collections`, `notifications`), which were re-exporting their **entire domain layer** — every repository and use case — as public API.

## Why

A consumer audit of every file that imports these barrels shows the only external consumers are the app shell (`lib/app/*`) plus the one documented cross-feature edge (`bookmarks → collections`). Across all of them, the names actually referenced are:

- `FeatureXPackageModule` (DI wiring)
- the sync controllers (`features.dart`)
- the entities, blocs/state, screens, routes, and the two collections capability widgets

The **repositories and use cases are never named outside their own package** — they're constructed and resolved entirely through dependency injection. They were pure dead public surface that widened each feature's contract and invited accidental coupling.

## Change

- Removed **18 exports** (1 repository + 6 use cases from bookmarks & collections; 1 repository + 3 use cases from notifications).
- Kept everything the app shell genuinely consumes.
- Updated each barrel's doc comment to state that repositories/use cases are internal.
- The handful of in-package tests that reached those types *through the barrel* now import them via `package:feature_x/src/...` — the exact convention the `collections` tests already follow (so this also makes the three features consistent).

## Verification

- `fvm flutter analyze` → **No issues found**
- `bookmarks`, `collections`, `notifications` package tests → **all pass**
- Root app suite, incl. `package_layering_test` + `feature_boundaries_test` → **all pass**

No production code or behavior changed — exports only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined internal APIs for Bookmarks, Collections, and Notifications features by limiting public exports to core entities and system modules. Implementation details remain internal.

* **Tests**
  * Updated test import paths to align with refined API structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->