### PR TITLE
refactor(routing): contribute non-shell routes through the feature seam

### DIFF
--- a/integration_test/e2e_test.dart
+++ b/integration_test/e2e_test.dart
@@ -18,12 +18,15 @@ import 'dart:async';
 
 import 'package:feature_auth/src/presentation/bloc/auth_bloc.dart';
 import 'package:feature_auth/src/presentation/bloc/auth_state.dart';
+import 'package:feature_bookmarks/feature_bookmarks.dart';
 import 'package:feature_bookmarks/src/presentation/bloc/bookmark_form/bookmark_form_bloc.dart';
 import 'package:feature_bookmarks/src/presentation/bloc/bookmarks_list/bookmarks_list_bloc.dart';
+import 'package:feature_collections/feature_collections.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_starter_template/app/router.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
 import 'package:integration_test/integration_test.dart';
 
 import 'support/e2e_app.dart';
@@ -320,7 +323,7 @@ Future<void> _openCollectionsListFromHome(WidgetTester tester) async {
   // popped — don't await it here, or the test would deadlock waiting for a
   // pop that hasn't happened yet.
   unawaited(
-    const CollectionsListRoute().push<void>(tester.element(homeAppBarTitle)),
+    tester.element(homeAppBarTitle).push<void>(CollectionsRoutes.list),
   );
   await E2eApp.settle(tester);
   await tester.pumpAndSettle();
@@ -332,7 +335,7 @@ Future<void> _openBookmarkDetail(WidgetTester tester, String title) async {
   final bloc = context.read<BookmarksListBloc>();
   final bookmark = bloc.state.items.firstWhere((item) => item.title == title);
 
-  unawaited(BookmarkDetailRoute(bookmark.id).push<void>(context));
+  unawaited(context.push<void>(BookmarksRoutes.detail(bookmark.id)));
   await E2eApp.settle(tester);
   await tester.pumpAndSettle();
   final detailTitle = find.descendant(

--- a/integration_test/screenshots_test.dart
+++ b/integration_test/screenshots_test.dart
@@ -30,12 +30,13 @@
 
 import 'dart:async';
 
+import 'package:feature_auth/feature_auth.dart';
+import 'package:feature_bookmarks/feature_bookmarks.dart';
 import 'package:feature_bookmarks/src/presentation/bloc/bookmarks_list/bookmarks_list_bloc.dart';
 import 'package:feature_home/feature_home.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_starter_template/app/router.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
 import 'package:integration_test/integration_test.dart';
@@ -102,9 +103,9 @@ void main() {
     await tester.pumpAndSettle();
     await shot('register');
     // Back to login without registering (the demo account already exists).
-    const LoginRoute().go(
-      tester.element(find.text('Join Flutter Starter').first),
-    );
+    tester
+        .element(find.text('Join Flutter Starter').first)
+        .go(AuthRoutes.login);
     await E2eApp.settle(tester);
     await tester.pumpAndSettle();
 
@@ -155,7 +156,9 @@ void main() {
     // rely on finding its title text in the lazy list).
     final first = bmBloc.state.items.first;
     unawaited(
-      BookmarkDetailRoute(first.id).push<void>(tester.element(bookmarksTitle)),
+      tester
+          .element(bookmarksTitle)
+          .push<void>(BookmarksRoutes.detail(first.id)),
     );
     await E2eApp.settle(tester);
     await tester.pumpAndSettle();

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -59,13 +59,18 @@ class _AppState extends State<App> {
     _authBloc = widget.authBloc ?? getIt<AuthBloc>();
     _themeBloc = widget.themeBloc ?? getIt<ThemeBloc>();
     _session = widget.session ?? AuthSession(_authBloc);
+    final features = widget.features ?? enabledFeatures;
     final result = buildRouterWithDeepLink(
       _authBloc,
+      featureRoutes: [
+        ...authRoutes,
+        for (final f in features) ...f.routes,
+      ],
       observers: widget.navigatorObservers ?? [getIt<AnalyticsRouteObserver>()],
     );
     _router = result.router;
     _deepLink = result.deepLink;
-    _syncControllers = (widget.features ?? enabledFeatures)
+    _syncControllers = features
         .map((f) => f.syncController)
         .whereType<FeatureSyncController>()
         .toList(growable: false);

--- a/lib/app/feature_module.dart
+++ b/lib/app/feature_module.dart
@@ -1,3 +1,5 @@
+import 'package:go_router/go_router.dart';
+
 /// Lifecycle interface for an optional feature's background sync.
 abstract interface class FeatureSyncController {
   Future<void> start();
@@ -10,4 +12,9 @@ abstract class FeatureModule {
 
   /// The feature's sync controller, or null if it has no background sync.
   FeatureSyncController? get syncController => null;
+
+  /// The feature's non-shell routes, mounted by the app router.
+  ///
+  /// Empty for features that only contribute a shell tab (e.g. notifications).
+  Iterable<RouteBase> get routes => const [];
 }

--- a/lib/app/features.dart
+++ b/lib/app/features.dart
@@ -1,6 +1,7 @@
 import 'package:feature_bookmarks/feature_bookmarks.dart';
 import 'package:feature_collections/feature_collections.dart';
 import 'package:feature_notifications/feature_notifications.dart';
+import 'package:go_router/go_router.dart';
 
 import 'di/injection.dart';
 import 'feature_module.dart';
@@ -22,6 +23,9 @@ final class _BookmarksModule extends FeatureModule {
     final ctrl = getIt<BookmarksSyncController>();
     return _FeatureSync(onStart: ctrl.start, onStop: ctrl.stop);
   }
+
+  @override
+  Iterable<RouteBase> get routes => bookmarksRoutes;
 }
 
 final class _CollectionsModule extends FeatureModule {
@@ -32,6 +36,9 @@ final class _CollectionsModule extends FeatureModule {
     final ctrl = getIt<CollectionsSyncController>();
     return _FeatureSync(onStart: ctrl.start, onStop: ctrl.stop);
   }
+
+  @override
+  Iterable<RouteBase> get routes => collectionsRoutes;
 }
 
 final class _NotificationsModule extends FeatureModule {

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:feature_auth/feature_auth.dart';
 import 'package:feature_bookmarks/feature_bookmarks.dart';
-import 'package:feature_collections/feature_collections.dart';
 import 'package:feature_home/feature_home.dart';
 import 'package:feature_notifications/feature_notifications.dart';
 import 'package:feature_profile/feature_profile.dart';
@@ -13,20 +12,6 @@ import 'package:go_router/go_router.dart';
 import 'widgets/app_shell.dart';
 
 part 'router.g.dart';
-
-/// Route data for showing [BookmarkFormScreen] outside the app shell.
-///
-/// The absolute path keeps the create flow free of persistent shell navigation.
-@TypedGoRoute<BookmarkNewRoute>(path: '/bookmarks/new', name: 'bookmark_new')
-class BookmarkNewRoute extends GoRouteData with $BookmarkNewRoute {
-  /// Creates a [BookmarkNewRoute].
-  const BookmarkNewRoute();
-
-  /// Builds the bookmark creation screen.
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const BookmarkFormScreen();
-}
 
 @TypedStatefulShellRoute<AppShellRouteData>(
   branches: <TypedStatefulShellBranch<StatefulShellBranchData>>[
@@ -138,117 +123,12 @@ class ChangePasswordRoute extends GoRouteData with $ChangePasswordRoute {
       const ChangePasswordScreen();
 }
 
-@TypedGoRoute<LoginRoute>(path: '/login', name: 'login')
-class LoginRoute extends GoRouteData with $LoginRoute {
-  const LoginRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const LoginScreen();
-}
-
-@TypedGoRoute<RegisterRoute>(path: '/register', name: 'register')
-class RegisterRoute extends GoRouteData with $RegisterRoute {
-  const RegisterRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const RegisterScreen();
-}
-
 class BookmarksListRoute extends GoRouteData with $BookmarksListRoute {
   const BookmarksListRoute();
 
   @override
   Widget build(BuildContext context, GoRouterState state) =>
       const BookmarksListScreen();
-}
-
-/// Route data for the bookmark detail, declared outside the app shell so the
-/// detail screen presents full-screen without the persistent bottom navigation
-/// bar (mirrors [BookmarkNewRoute]).
-@TypedGoRoute<BookmarkDetailRoute>(
-  path: '/bookmarks/:id',
-  name: 'bookmark_detail',
-)
-class BookmarkDetailRoute extends GoRouteData with $BookmarkDetailRoute {
-  const BookmarkDetailRoute(this.id);
-
-  final String id;
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      BookmarkDetailScreen(id: id);
-}
-
-/// Route data for editing a bookmark, declared outside the app shell so the
-/// edit form presents full-screen without the persistent bottom navigation bar.
-@TypedGoRoute<BookmarkEditRoute>(
-  path: '/bookmarks/:id/edit',
-  name: 'bookmark_edit',
-)
-class BookmarkEditRoute extends GoRouteData with $BookmarkEditRoute {
-  const BookmarkEditRoute(this.id);
-
-  final String id;
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      BookmarkFormScreen(id: id);
-}
-
-/// Route data for the standalone collections browser.
-@TypedGoRoute<CollectionsListRoute>(path: '/collections', name: 'collections')
-class CollectionsListRoute extends GoRouteData with $CollectionsListRoute {
-  const CollectionsListRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const CollectionsListScreen();
-}
-
-/// Route data for creating a collection. Declared above the `:id` route so the
-/// literal `new` segment matches first.
-@TypedGoRoute<CollectionNewRoute>(
-  path: '/collections/new',
-  name: 'collection_new',
-)
-class CollectionNewRoute extends GoRouteData with $CollectionNewRoute {
-  const CollectionNewRoute();
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      const CollectionFormScreen();
-}
-
-/// Route data for the collection detail, shown full-screen (no shell).
-@TypedGoRoute<CollectionDetailRoute>(
-  path: '/collections/:id',
-  name: 'collection_detail',
-)
-class CollectionDetailRoute extends GoRouteData with $CollectionDetailRoute {
-  const CollectionDetailRoute(this.id);
-
-  final String id;
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      CollectionDetailScreen(id: id);
-}
-
-/// Route data for editing a collection, shown full-screen (no shell).
-@TypedGoRoute<CollectionEditRoute>(
-  path: '/collections/:id/edit',
-  name: 'collection_edit',
-)
-class CollectionEditRoute extends GoRouteData with $CollectionEditRoute {
-  const CollectionEditRoute(this.id);
-
-  final String id;
-
-  @override
-  Widget build(BuildContext context, GoRouterState state) =>
-      CollectionFormScreen(id: id);
 }
 
 /// Tracks deep-link targets and splash-screen completion so the redirect can
@@ -279,21 +159,27 @@ class DeepLinkScope extends InheritedWidget {
 }
 
 /// Builds the app router and wires auth redirects to [bloc] state changes.
+///
+/// [featureRoutes] are the non-shell routes contributed by the feature
+/// packages (and auth's login/register). They are mounted alongside the
+/// generated shell routes ([$appRoutes]) so adding a feature's screens never
+/// edits this file — the feature ships its own route table.
 ({GoRouter router, DeepLinkState deepLink}) buildRouterWithDeepLink(
   AuthBloc bloc, {
+  required List<RouteBase> featureRoutes,
   List<NavigatorObserver>? observers,
 }) {
   final deepLink = DeepLinkState();
   final homeLocation = const HomeRoute().location;
   final splashLocation = const SplashRoute().location;
-  final loginLocation = const LoginRoute().location;
-  final registerLocation = const RegisterRoute().location;
+  const loginLocation = AuthRoutes.login;
+  const registerLocation = AuthRoutes.register;
 
   final router = GoRouter(
     // No initialLocation — GoRouter resolves the platform deep-link URI on
     // cold start and the redirect below captures it before sending the user
     // through splash / auth.
-    routes: $appRoutes,
+    routes: [...$appRoutes, ...featureRoutes],
     observers: observers,
     refreshListenable: _BlocListenable(bloc.stream),
     redirect: (context, state) {

--- a/packages/features/auth/lib/src/presentation/auth_routes.dart
+++ b/packages/features/auth/lib/src/presentation/auth_routes.dart
@@ -1,8 +1,12 @@
+import 'package:go_router/go_router.dart';
+
+import 'screens/login_screen.dart';
+import 'screens/register_screen.dart';
+
 /// Canonical navigation paths owned by the auth feature.
 ///
-/// The app router wires these same paths to the feature's screens; the feature
-/// navigates by pushing them via `go_router`'s `context.go`, so it doesn't
-/// depend on the app shell's typed-route classes.
+/// The feature navigates by pushing these via `go_router`'s `context.go`, so it
+/// doesn't depend on the app shell.
 abstract final class AuthRoutes {
   /// The login screen.
   static const login = '/login';
@@ -10,6 +14,22 @@ abstract final class AuthRoutes {
   /// The registration screen.
   static const register = '/register';
 
-  /// The change-password screen (nested under the profile tab).
+  /// The change-password screen (nested under the profile tab, mounted by the
+  /// app shell because it lives inside the profile branch).
   static const changePassword = '/profile/change-password';
 }
+
+/// The auth feature's unauthenticated routes, mounted by the host app.
+///
+/// `changePassword` is not listed here: it is nested under the app shell's
+/// profile tab, so the shell mounts it directly.
+List<RouteBase> get authRoutes => [
+  GoRoute(
+    path: AuthRoutes.login,
+    builder: (context, state) => const LoginScreen(),
+  ),
+  GoRoute(
+    path: AuthRoutes.register,
+    builder: (context, state) => const RegisterScreen(),
+  ),
+];

--- a/packages/features/auth/test/presentation/auth_routes_test.dart
+++ b/packages/features/auth/test/presentation/auth_routes_test.dart
@@ -1,0 +1,22 @@
+import 'package:feature_auth/feature_auth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  group('authRoutes', () {
+    final paths = authRoutes
+        .whereType<GoRoute>()
+        .map((route) => route.path)
+        .toList();
+
+    test('contributes the unauthenticated entry paths', () {
+      expect(paths, [AuthRoutes.login, AuthRoutes.register]);
+    });
+
+    test('does not include change-password (mounted under the profile tab)', () {
+      // change-password is nested inside the app shell's profile branch, so the
+      // shell mounts it — auth must not also contribute it as a top-level route.
+      expect(paths, isNot(contains(AuthRoutes.changePassword)));
+    });
+  });
+}

--- a/packages/features/bookmarks/lib/src/presentation/bookmarks_routes.dart
+++ b/packages/features/bookmarks/lib/src/presentation/bookmarks_routes.dart
@@ -1,8 +1,14 @@
+import 'package:go_router/go_router.dart';
+
+import 'screens/bookmark_detail_screen.dart';
+import 'screens/bookmark_form_screen.dart';
+
 /// Canonical navigation paths owned by the bookmarks feature.
 ///
-/// The app router wires these same paths to the feature's screens; the feature
-/// navigates by pushing them via `go_router`'s `context.push`, so it doesn't
-/// depend on the app shell's typed-route classes.
+/// The feature navigates by pushing these via `go_router`'s `context.push`, so
+/// it doesn't depend on the app shell. The `*Pattern` entries are the matching
+/// templates the route table below mounts; the helper methods build concrete
+/// locations to navigate to.
 abstract final class BookmarksRoutes {
   /// The bookmarks list (a shell tab).
   static const list = '/bookmarks';
@@ -10,9 +16,37 @@ abstract final class BookmarksRoutes {
   /// The create-bookmark form, shown outside the app shell.
   static const create = '/bookmarks/new';
 
+  /// Path template for the bookmark detail screen.
+  static const detailPattern = '/bookmarks/:id';
+
+  /// Path template for the edit-bookmark form.
+  static const editPattern = '/bookmarks/:id/edit';
+
   /// The detail screen for the bookmark with [id].
   static String detail(String id) => '/bookmarks/$id';
 
   /// The edit form for the bookmark with [id].
   static String edit(String id) => '/bookmarks/$id/edit';
 }
+
+/// The bookmarks feature's non-shell routes, mounted by the host app.
+///
+/// The list tab itself lives in the app shell; these are the full-screen
+/// routes the feature owns. `create` precedes the `:id` template so the literal
+/// `/bookmarks/new` segment matches before the parameterized one.
+List<RouteBase> get bookmarksRoutes => [
+  GoRoute(
+    path: BookmarksRoutes.create,
+    builder: (context, state) => const BookmarkFormScreen(),
+  ),
+  GoRoute(
+    path: BookmarksRoutes.detailPattern,
+    builder: (context, state) =>
+        BookmarkDetailScreen(id: state.pathParameters['id']!),
+  ),
+  GoRoute(
+    path: BookmarksRoutes.editPattern,
+    builder: (context, state) =>
+        BookmarkFormScreen(id: state.pathParameters['id']),
+  ),
+];

--- a/packages/features/bookmarks/test/presentation/bookmarks_routes_test.dart
+++ b/packages/features/bookmarks/test/presentation/bookmarks_routes_test.dart
@@ -1,0 +1,29 @@
+import 'package:feature_bookmarks/feature_bookmarks.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  group('bookmarksRoutes', () {
+    final paths = bookmarksRoutes
+        .whereType<GoRoute>()
+        .map((route) => route.path)
+        .toList();
+
+    test("contributes the feature's non-shell paths", () {
+      expect(paths, [
+        BookmarksRoutes.create,
+        BookmarksRoutes.detailPattern,
+        BookmarksRoutes.editPattern,
+      ]);
+    });
+
+    test('orders the literal create path before the :id template', () {
+      // go_router matches in order, so `/bookmarks/new` must precede
+      // `/bookmarks/:id` or the literal segment would be swallowed.
+      expect(
+        paths.indexOf(BookmarksRoutes.create),
+        lessThan(paths.indexOf(BookmarksRoutes.detailPattern)),
+      );
+    });
+  });
+}

--- a/packages/features/collections/lib/src/presentation/collections_routes.dart
+++ b/packages/features/collections/lib/src/presentation/collections_routes.dart
@@ -1,14 +1,27 @@
+import 'package:go_router/go_router.dart';
+
+import 'screens/collection_detail_screen.dart';
+import 'screens/collection_form_screen.dart';
+import 'screens/collections_list_screen.dart';
+
 /// Canonical navigation paths owned by the collections feature.
 ///
-/// The app router wires these same paths to the feature's screens; the feature
-/// navigates by pushing them via `go_router`'s `context.push`, so it doesn't
-/// depend on the app shell's typed-route classes.
+/// The feature navigates by pushing these via `go_router`'s `context.push`, so
+/// it doesn't depend on the app shell. The `*Pattern` entries are the matching
+/// templates the route table below mounts; the helper methods build concrete
+/// locations to navigate to.
 abstract final class CollectionsRoutes {
-  /// The collections list (a shell tab).
+  /// The standalone collections browser.
   static const list = '/collections';
 
   /// The create-collection form, shown outside the app shell.
   static const create = '/collections/new';
+
+  /// Path template for the collection detail screen.
+  static const detailPattern = '/collections/:id';
+
+  /// Path template for the edit-collection form.
+  static const editPattern = '/collections/:id/edit';
 
   /// The detail screen for the collection with [id].
   static String detail(String id) => '/collections/$id';
@@ -16,3 +29,29 @@ abstract final class CollectionsRoutes {
   /// The edit form for the collection with [id].
   static String edit(String id) => '/collections/$id/edit';
 }
+
+/// The collections feature's routes, mounted by the host app.
+///
+/// Collections is not a shell tab, so the feature owns all of its routes.
+/// `create` precedes the `:id` template so the literal `/collections/new`
+/// segment matches before the parameterized one.
+List<RouteBase> get collectionsRoutes => [
+  GoRoute(
+    path: CollectionsRoutes.list,
+    builder: (context, state) => const CollectionsListScreen(),
+  ),
+  GoRoute(
+    path: CollectionsRoutes.create,
+    builder: (context, state) => const CollectionFormScreen(),
+  ),
+  GoRoute(
+    path: CollectionsRoutes.detailPattern,
+    builder: (context, state) =>
+        CollectionDetailScreen(id: state.pathParameters['id']!),
+  ),
+  GoRoute(
+    path: CollectionsRoutes.editPattern,
+    builder: (context, state) =>
+        CollectionFormScreen(id: state.pathParameters['id']),
+  ),
+];

--- a/packages/features/collections/test/presentation/collections_routes_test.dart
+++ b/packages/features/collections/test/presentation/collections_routes_test.dart
@@ -1,0 +1,30 @@
+import 'package:feature_collections/feature_collections.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+void main() {
+  group('collectionsRoutes', () {
+    final paths = collectionsRoutes
+        .whereType<GoRoute>()
+        .map((route) => route.path)
+        .toList();
+
+    test("contributes all of the feature's routes", () {
+      expect(paths, [
+        CollectionsRoutes.list,
+        CollectionsRoutes.create,
+        CollectionsRoutes.detailPattern,
+        CollectionsRoutes.editPattern,
+      ]);
+    });
+
+    test('orders the literal create path before the :id template', () {
+      // go_router matches in order, so `/collections/new` must precede
+      // `/collections/:id` or the literal segment would be swallowed.
+      expect(
+        paths.indexOf(CollectionsRoutes.create),
+        lessThan(paths.indexOf(CollectionsRoutes.detailPattern)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## What

Group 2 of the structure review: make routing pluggable through `FeatureModule`, so adding a feature's screens no longer means hand-editing the app router. This is the **pragmatic seam** — the bottom-nav shell stays app-level (it legitimately decides which features are tabs); the per-feature *screen* routes move to the features.

## Why

`router.dart` hand-declared all 11 routes as `go_router_builder` typed classes — the bulk being per-feature screens (bookmark detail/form, all of collections, login, register). Adding a feature meant editing the app shell, even though features already navigate by **string path** (`BookmarksRoutes.detail(id)`) and never use those typed classes. Sync already plugs in via `FeatureModule`; routing now joins it.

## Change

- **`FeatureModule` gains `Iterable<RouteBase> get routes`** (defaults to `const []`), next to `syncController`. `bookmarks`/`collections` return their route table; `notifications` stays empty (tab only).
- **Features export a plain `List<RouteBase>`** (`bookmarksRoutes`, `collectionsRoutes`, `authRoutes`) built from existing path constants + screens — **no go_router_builder, no codegen added to features**. New `*Pattern` constants sit beside the navigation helpers so template and builder can't drift.
- **`router.dart` slims by ~130 lines**: the 10 non-shell typed route classes and the `feature_collections` import are gone. It keeps only app-level wiring — the typed `StatefulShellRoute` (tabs + nested change-password) and the boot splash route. `$appRoutes` regenerates to just shell + splash.
- **`buildRouterWithDeepLink` composes `[...$appRoutes, ...featureRoutes]`**; the app gathers `featureRoutes` from `auth` + `(features ?? enabledFeatures)`, so the existing `App.features` test seam now covers routes too. The redirect keys off the exported `AuthRoutes.login`/`.register` constants.
- **Integration tests** repointed from the deleted typed routes to `context.go` / `context.push` with the feature path constants.

## Verification

- `fvm flutter analyze` → **No issues found** (incl. both integration_test targets, which compile-check here).
- Root suite (incl. `widget_test` sign-in→home, which drives the full composed router) → **pass**.
- `bookmarks` / `collections` / `auth` / `notifications` package suites → **pass**.
- Architecture guardrails (`package_layering`, `feature_boundaries`, `di_module_ordering`) → **pass**.
- New **route-table test per moved feature** asserts the contributed paths and literal-before-`:id` match ordering.

`router.g.dart` is gitignored (regenerated by CI/`setup.sh`), so this PR ships the source change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Navigation system restructured to support modular, feature-contributed routing architecture.

* **Tests**
  * Added test coverage validating authentication, bookmarks, and collections navigation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->