### PR TITLE
feat: wire up `fst add-feature` (markers + CLI submodule bump)

### DIFF
--- a/lib/app/di/injection.dart
+++ b/lib/app/di/injection.dart
@@ -43,6 +43,7 @@ final GetIt getIt = GetIt.instance;
     ExternalModule(FeatureBookmarksPackageModule),
     ExternalModule(FeatureHomePackageModule),
     ExternalModule(FeatureProfilePackageModule),
+    // fst:feature-modules — `fst add-feature` inserts new feature modules above
   ],
 )
 Future<void> configureDependencies() async {

--- a/lib/app/features.dart
+++ b/lib/app/features.dart
@@ -13,6 +13,7 @@ const List<FeatureModule> enabledFeatures = [
   _BookmarksModule(),
   _CollectionsModule(),
   _NotificationsModule(),
+  // fst:enabled-features — `fst add-feature` inserts new modules above this line
 ];
 
 final class _BookmarksModule extends FeatureModule {
@@ -50,6 +51,8 @@ final class _NotificationsModule extends FeatureModule {
     return _FeatureSync(onStart: ctrl.start, onStop: ctrl.stop);
   }
 }
+
+// fst:feature-module-classes — `fst add-feature` inserts new module classes above
 
 /// Adapts any feature's sync controller to [FeatureSyncController] without a
 /// bespoke wrapper class per feature. The controllers don't implement the

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ workspace:
   - packages/features/splash
   - packages/features/home
   - packages/features/profile
+  # fst:features — `fst add-feature` inserts new feature packages above this line
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -73,6 +74,7 @@ dependencies:
   feature_splash: ^0.1.0
   feature_home: ^0.1.0
   feature_profile: ^0.1.0
+  # fst:feature-deps — `fst add-feature` inserts new feature deps above this line
 
   flutter:
     sdk: flutter


### PR DESCRIPTION
## What

Completes the `fst add-feature` generator in this repo: adds the `// fst:` sentinel markers the command inserts against, and bumps the `tool/cli` submodule to the CLI release that ships the command ([flutter-starter-template-cli#6](https://github.com/kido-luci/flutter-starter-template-cli/pull/6)).

With both in place, `fst add-feature <name>` scaffolds a new presentation-only feature package and wires it into the app end to end.

## Changes

- **Sentinel markers** (comment-only) at the four insertion points the command targets:
  - `pubspec.yaml` — the `workspace:` list and the feature-dependency block
  - `lib/app/di/injection.dart` — the injectable `externalPackageModulesBefore` list
  - `lib/app/features.dart` — the `enabledFeatures` list and the module-class section
- **Submodule bump** `tool/cli`: `cabae95 → 424001b` (the merged CLI `main` with the `add-feature` command).

## Why markers

Insertion lands *before* each `// fst:` marker, so reformatting or reordering the lists never breaks placement, and a missing marker makes the command abort with a clear message instead of half-wiring. They're inert comments — no behavior change on their own.

## How it was verified

The command was validated end-to-end against this repo before shipping: it scaffolded + wired a throwaway feature, `fvm flutter analyze` came back clean, and both the generated feature's route test and the app's widget test (DI resolves) passed. The throwaway was fully reverted; this PR is markers + pointer only.

The bare markers are trivially safe (comments added to lists); `fvm flutter analyze` is clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI tooling to the latest version
  * Added infrastructure markers to support automated configuration processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->