### PR TITLE
chore(release): 1.4.0 — fst add-feature generator + routing/encapsulation seams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this template are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-06-18
+
+Adds the `fst add-feature` generator and the seams it builds on, making a new
+feature a one-command operation. No behavior change to the running app.
+
+### Added
+
+- **`fst add-feature` generator** — a new CLI command (in
+  `flutter-starter-template-cli`, adopted here via the `tool/cli` submodule and
+  the `# fst:` / `// fst:` wiring markers) that scaffolds a presentation-only
+  feature package and wires it into the workspace, the dependency list, the
+  injectable DI graph, and `enabledFeatures` in one step.
+- **Pluggable feature routing** — `FeatureModule` gains a `routes` getter, so a
+  feature contributes its own non-shell routes (plain `GoRoute` lists built from
+  its path constants) instead of the app router declaring them.
+- **DI module-ordering guard** — a pure file-scan architecture test that locks
+  the load-bearing order of `externalPackageModulesBefore` (`shared_contracts`
+  before `notifications`, `auth` before the other features), so a reorder that
+  would only fail at runtime fails fast in CI.
+
+### Changed
+
+- **Non-shell routes relocated to their features** — the bookmark, collection,
+  and auth (login/register) route classes moved out of `lib/app/router.dart`
+  into their owning packages. The app shell keeps only the typed bottom-nav
+  `StatefulShellRoute` (tabs plus the nested change-password route) and the boot
+  splash route, so adding a feature's screens no longer edits the router.
+- **Feature barrels narrowed to the consumed surface** — `bookmarks`,
+  `collections`, and `notifications` stop exporting their domain repositories
+  and use cases (resolved only through DI). Each package's public API is now the
+  entity, sync controller, screens, and routes the app actually uses; in-package
+  tests reach the now-internal types through `src/` imports, matching the
+  existing `collections` convention.
+
 ## [1.3.0] - 2026-06-18
 
 Structure cleanup that sharpens the package boundaries and co-locates tests with
@@ -128,6 +162,7 @@ First stable release of the Flutter starter template.
   backend deps, and the pre-push hook).
 - **Tooling** — Dart & CodeGraph MCP servers and vendored agent skills.
 
+[1.4.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.4.0
 [1.3.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.3.0
 [1.2.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.2.0
 [1.1.0]: https://github.com/kido-luci/flutter-starter-template/releases/tag/v1.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.3.0+1
+version: 1.4.0+1
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Release 1.4.0

Bumps the template `1.3.0+1 → 1.4.0+1` and adds the CHANGELOG entry for everything merged since 1.3.0. **Docs + version only — no code changes.**

### What's in this release (merged to `main` since 1.3.0)

| PR | Summary |
|---|---|
| [#133](https://github.com/kido-luci/flutter-starter-template/pull/133) | `fst add-feature` generator — markers + `tool/cli` submodule bump |
| [#132](https://github.com/kido-luci/flutter-starter-template/pull/132) | Pluggable feature routing (`FeatureModule.routes`); non-shell routes relocated to their features |
| [#131](https://github.com/kido-luci/flutter-starter-template/pull/131) | DI module-ordering guard (file-scan architecture test) |
| [#130](https://github.com/kido-luci/flutter-starter-template/pull/130) | Feature barrels narrowed to the consumed surface |

### Why 1.4.0 (minor)

The headline is a genuinely new capability — the `fst add-feature` generator — plus the additive `FeatureModule.routes` seam. The rest are behavior-preserving refactors and a new guard. Nothing breaks the template's public surface, so it's a minor bump, not a major.

### Changes

- `pubspec.yaml`: `version: 1.4.0+1`
- `CHANGELOG.md`: new `## [1.4.0]` entry (Added / Changed) in the established style + the release-tag link reference.

Note: the `fst add-feature` *command* itself lives in `flutter-starter-template-cli` (its own versioning); this is the **template** release that adopts it via the submodule bump that landed in #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `fst add-feature` generator for simplified feature scaffolding.
  * Introduced pluggable feature routing capabilities.

* **Changed**
  * Reorganized package exports for improved clarity.
  * Enhanced CI architecture validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->