### PR TITLE
fix(auth): handle malformed token-refresh body without throwing

### DIFF
--- a/packages/features/auth/lib/src/data/network/token_refresher.dart
+++ b/packages/features/auth/lib/src/data/network/token_refresher.dart
@@ -51,11 +51,17 @@ class TokenRefresher {
         data: {'refresh_token': token},
       );
       final body = response.data;
-      if (body == null) {
+      final RefreshTokenResponse parsed;
+      try {
+        // A null or malformed body means the server gave us no usable tokens,
+        // even though the HTTP status looked fine. Treat it the same as a dead
+        // session rather than letting the parse error escape the refresher.
+        if (body == null) throw const FormatException('empty refresh body');
+        parsed = RefreshTokenResponse.fromJson(body);
+      } on Object {
         await _local.clearSession();
         return RefreshOutcome.invalidSession;
       }
-      final parsed = RefreshTokenResponse.fromJson(body);
       await _local.updateTokens(
         accessToken: parsed.accessToken,
         refreshToken: parsed.refreshToken,

--- a/packages/features/auth/test/data/network/token_refresher_test.dart
+++ b/packages/features/auth/test/data/network/token_refresher_test.dart
@@ -121,6 +121,26 @@ void main() {
     verify(() => local.clearSession()).called(1);
   });
 
+  test(
+    'clears session (invalidSession) on a malformed body, without throwing',
+    () async {
+      when(() => local.refreshToken).thenReturn('old');
+      // A 200 with a non-null body missing the required token fields: parsing
+      // throws a (non-Dio) error that must be treated as an unusable body, not
+      // allowed to escape the refresher.
+      stubPost(() => okResponse({'unexpected': 'shape'}));
+
+      expect(await refresher.refresh(), RefreshOutcome.invalidSession);
+      verify(() => local.clearSession()).called(1);
+      verifyNever(
+        () => local.updateTokens(
+          accessToken: any(named: 'accessToken'),
+          refreshToken: any(named: 'refreshToken'),
+        ),
+      );
+    },
+  );
+
   test('single-flight: concurrent callers share one POST', () async {
     when(() => local.refreshToken).thenReturn('old');
     final completer = Completer<Response<Map<String, dynamic>>>();


### PR DESCRIPTION
## Problem

`TokenRefresher._run()` handled a `null` refresh-response body but not a **non-null malformed** one. A `200` response whose body is missing the required token fields makes `RefreshTokenResponse.fromJson` throw a `CastError` — which is **not** a `DioException`, so it escaped the `on DioException` catch and rejected the in-flight future.

Because neither caller wraps `refresh()`:
- `AuthInterceptor.onError` `await`s it *outside* its own try (the try only covers `_dio.fetch`), so the original request fails with a `CastError` instead of the clean 401 passthrough.
- `restoreSession` (the splash cold-start path) has no try around it, so the error propagates into the bloc's restore handler at launch.

This contradicts the `RefreshOutcome` enum's own doc, which claims `invalidSession` covers a body that is *"unusable"*.

## Fix

Funnel the null-body and parse-failure cases through one catch and return `RefreshOutcome.invalidSession` (clearing the dead session), so no parse error escapes the refresher. A malformed body is treated the same as a null body, matching the documented contract.

## Test plan

- Added regression test *"clears session (invalidSession) on a malformed body, without throwing"* (200 + body missing token fields → `invalidSession`, `clearSession()` called, `updateTokens()` not called).
- Confirmed red→green: pre-fix the new test failed with `type 'Null' is not a subtype of type 'Map<String, dynamic>'` from `fromJson`; post-fix it passes.
- `cd packages/features/auth && fvm flutter test` → **67 passed**.
- `fvm flutter analyze` (auth) → **No issues found**.

Scope is isolated to the `auth` package's `TokenRefresher`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced token refresh error handling to properly manage malformed server responses; invalid responses now trigger session clearing.

* **Tests**
  * Added test coverage for malformed server response scenarios during token refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->