### PR TITLE
fix(auth): map malformed sign-in/register responses to a failure

### DIFF
--- a/packages/features/auth/lib/src/data/repositories/auth_repository_impl.dart
+++ b/packages/features/auth/lib/src/data/repositories/auth_repository_impl.dart
@@ -41,6 +41,10 @@ class AuthRepositoryImpl implements AuthRepository {
       return Ok(user);
     } on DioException catch (e) {
       return Err(_mapDioError(e));
+    } on Object {
+      // A malformed response body makes the parse throw a non-Dio error; map
+      // it to a failure instead of letting it escape into the bloc.
+      return const Err(UnknownFailure('Unexpected server response'));
     }
   }
 
@@ -62,6 +66,10 @@ class AuthRepositoryImpl implements AuthRepository {
       return Ok(user);
     } on DioException catch (e) {
       return Err(_mapDioError(e));
+    } on Object {
+      // A malformed response body makes the parse throw a non-Dio error; map
+      // it to a failure instead of letting it escape into the bloc.
+      return const Err(UnknownFailure('Unexpected server response'));
     }
   }
 

--- a/packages/features/auth/test/data/repositories/auth_repository_impl_test.dart
+++ b/packages/features/auth/test/data/repositories/auth_repository_impl_test.dart
@@ -3,6 +3,7 @@ import 'package:feature_auth/src/data/datasources/auth_local_data_source.dart';
 import 'package:feature_auth/src/data/datasources/auth_remote_data_source.dart';
 import 'package:feature_auth/src/data/models/auth_user_dto.dart';
 import 'package:feature_auth/src/data/models/refresh_token_request.dart';
+import 'package:feature_auth/src/data/models/register_request.dart';
 import 'package:feature_auth/src/data/models/sign_in_request.dart';
 import 'package:feature_auth/src/data/models/sign_in_response.dart';
 import 'package:feature_auth/src/data/network/token_refresher.dart';
@@ -19,6 +20,8 @@ class MockAuthLocalDataSource extends Mock implements AuthLocalDataSource {}
 class MockTokenRefresher extends Mock implements TokenRefresher {}
 
 class FakeSignInRequest extends Fake implements SignInRequest {}
+
+class FakeRegisterRequest extends Fake implements RegisterRequest {}
 
 class FakeRefreshTokenRequest extends Fake implements RefreshTokenRequest {}
 
@@ -40,6 +43,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakeSignInRequest());
+    registerFallbackValue(FakeRegisterRequest());
     registerFallbackValue(FakeRefreshTokenRequest());
     registerFallbackValue(FakeAuthUser());
   });
@@ -139,6 +143,50 @@ void main() {
       final err = result as Err<AuthUser>;
       expect(err.failure, isA<UnknownFailure>());
       expect(err.failure.message, 'Network error');
+    });
+
+    test('returns UnknownFailure and does not persist on a malformed '
+        'response body', () async {
+      // A malformed 200 body makes retrofit throw a (non-Dio) parse error; it
+      // must be mapped to a Result, not allowed to escape into AuthBloc.
+      when(() => mockRemote.signIn(any())).thenThrow(TypeError());
+
+      final result = await repository.signIn(
+        username: 'alice',
+        password: 'pass',
+      );
+
+      expect(result, isA<Err<AuthUser>>());
+      expect((result as Err<AuthUser>).failure, isA<UnknownFailure>());
+      verifyNever(
+        () => mockLocal.setSession(
+          user: any(named: 'user'),
+          accessToken: any(named: 'accessToken'),
+          refreshToken: any(named: 'refreshToken'),
+        ),
+      );
+    });
+  });
+
+  group('register', () {
+    test('returns UnknownFailure and does not persist on a malformed '
+        'response body', () async {
+      when(() => mockRemote.register(any())).thenThrow(TypeError());
+
+      final result = await repository.register(
+        username: 'alice',
+        password: 'pass',
+      );
+
+      expect(result, isA<Err<AuthUser>>());
+      expect((result as Err<AuthUser>).failure, isA<UnknownFailure>());
+      verifyNever(
+        () => mockLocal.setSession(
+          user: any(named: 'user'),
+          accessToken: any(named: 'accessToken'),
+          refreshToken: any(named: 'refreshToken'),
+        ),
+      );
     });
   });
 


### PR DESCRIPTION
## Problem

A `200` response with a malformed body makes retrofit throw a **non-`DioException`** parse error (`CastError`) inside `AuthRepositoryImpl.signIn` / `register`. The `try { … } on DioException` catch didn't cover it, so the error escaped into `AuthBloc` as an unhandled exception instead of a clean `Result` failure.

This is the same class of bug as the `TokenRefresher` fix in #135, on the user-facing login/register actions.

## Scope (informed by investigation)

The background sync paths are **already hardened** and were left untouched:
- `OfflineCrudSync.run()` wraps `_pull()` (incl. `listSince`) in `try { } on Object`, and its push loop has a per-row `on Object` guard.
- `NotificationsSyncService._run()` has its own top-level `on Object catch`.

The only unguarded retrofit-parse path was `AuthRepositoryImpl.signIn`/`register` (the only methods that parse a body into a domain object). `changePassword`/`signOut`/`deleteAccount` don't parse a response body, so they're unaffected.

## Fix

Add an `on Object` fallback to `signIn` and `register` that returns `Err(UnknownFailure('Unexpected server response'))` **without** persisting a session — matching the defensive pattern already used by `TokenRefresher`, the sync engine, and notifications sync. Reuses the existing `UnknownFailure` (the login/register screens just render `failure.message`).

## Test plan

- Added regression tests to `auth_repository_impl_test` for both `signIn` and `register`: stub the remote source to throw a non-Dio error, assert `Err(UnknownFailure)` and that `setSession` is **not** called.
- Confirmed red→green: pre-fix both failed with the `TypeError` escaping uncaught; post-fix both pass.
- `cd packages/features/auth && fvm flutter test` → **69 passed**.
- `fvm flutter analyze` (auth) → **No issues found**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication error handling to properly manage unexpected server responses during sign-in and registration, preventing app crashes from malformed responses.

* **Tests**
  * Added test coverage for authentication error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->