### PR TITLE
test: cover splash redirect, home, and profile screens

### DIFF
--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -182,58 +182,87 @@ class DeepLinkScope extends InheritedWidget {
     routes: [...$appRoutes, ...featureRoutes],
     observers: observers,
     refreshListenable: _BlocListenable(bloc.stream),
-    redirect: (context, state) {
-      final location = state.matchedLocation;
-      final auth = bloc.state;
-
-      // ── Phase 1: Before splash completes ──
-      // Intercept every navigation until restoreSession and the splash
-      // minimum display time complete. The splash screen flips
-      // splashCompleted after both gates finish.
-      if (!deepLink.splashCompleted) {
-        // Already on splash — let it run.
-        if (location == splashLocation) return null;
-        // Any other location (deep link or default '/') — capture and
-        // send through splash first.
-        deepLink.pendingRedirect ??= state.uri.toString();
-        return splashLocation;
-      }
-
-      // ── Phase 2: Unauthenticated ──
-      // Splash completed with no session, or user signed out.
-      if (auth is AuthInitial || auth is AuthFailure) {
-        if (location == loginLocation || location == registerLocation) {
-          return null;
-        }
-        deepLink.pendingRedirect ??= state.uri.toString();
-        return loginLocation;
-      }
-
-      // ── Phase 3: Authenticated (incl. mid-sign-out) ──
-      // AuthSigningOut still holds a user; let the screen stay put until the
-      // op completes and AuthBloc emits AuthInitial.
-      if (auth is AuthAuthenticated || auth is AuthSigningOut) {
-        final target = deepLink.pendingRedirect;
-        if (target != null) {
-          deepLink.pendingRedirect = null;
-          if (target != state.uri.toString()) return target;
-        }
-        // Leaving splash or login/register — restore the captured deep link.
-        if (location == splashLocation ||
-            location == loginLocation ||
-            location == registerLocation) {
-          return homeLocation;
-        }
-        // Already on a valid, protected route — allow it.
-        return null;
-      }
-
-      // AuthSubmitting — don't interfere.
-      return null;
-    },
+    redirect: (context, state) => resolveSplashRedirect(
+      auth: bloc.state,
+      location: state.matchedLocation,
+      requestedUri: state.uri.toString(),
+      deepLink: deepLink,
+      splashLocation: splashLocation,
+      loginLocation: loginLocation,
+      registerLocation: registerLocation,
+      homeLocation: homeLocation,
+    ),
   );
 
   return (router: router, deepLink: deepLink);
+}
+
+/// Resolves the auth/splash redirect for a single navigation.
+///
+/// Pure decision function behind [buildRouterWithDeepLink]'s `redirect`: given
+/// the current [auth] state, the [location] GoRouter matched, the
+/// [requestedUri] the user is trying to reach, and the mutable [deepLink] gate,
+/// it returns the location to redirect to, or `null` to allow the navigation.
+/// Extracted so the three-phase state machine can be unit-tested without
+/// assembling a full [GoRouter] and widget tree.
+///
+/// Mutates [DeepLinkState.pendingRedirect] to capture a cold-start/deep-link
+/// target before splash/auth, then replays it once the user is authenticated.
+@visibleForTesting
+String? resolveSplashRedirect({
+  required AuthState auth,
+  required String location,
+  required String requestedUri,
+  required DeepLinkState deepLink,
+  required String splashLocation,
+  required String loginLocation,
+  required String registerLocation,
+  required String homeLocation,
+}) {
+  // ── Phase 1: Before splash completes ──
+  // Intercept every navigation until restoreSession and the splash minimum
+  // display time complete. The splash screen flips splashCompleted after both
+  // gates finish.
+  if (!deepLink.splashCompleted) {
+    // Already on splash — let it run.
+    if (location == splashLocation) return null;
+    // Any other location (deep link or default '/') — capture and send
+    // through splash first.
+    deepLink.pendingRedirect ??= requestedUri;
+    return splashLocation;
+  }
+
+  // ── Phase 2: Unauthenticated ──
+  // Splash completed with no session, or user signed out.
+  if (auth is AuthInitial || auth is AuthFailure) {
+    if (location == loginLocation || location == registerLocation) {
+      return null;
+    }
+    deepLink.pendingRedirect ??= requestedUri;
+    return loginLocation;
+  }
+
+  // ── Phase 3: Authenticated (incl. mid-sign-out) ──
+  // AuthSigningOut still holds a user; let the screen stay put until the op
+  // completes and AuthBloc emits AuthInitial.
+  if (auth is AuthAuthenticated || auth is AuthSigningOut) {
+    final target = deepLink.pendingRedirect;
+    if (target != null) {
+      deepLink.pendingRedirect = null;
+      if (target != requestedUri) return target;
+    }
+    // Leaving splash or login/register — restore the captured deep link.
+    if (location == splashLocation ||
+        location == loginLocation ||
+        location == registerLocation) {
+      return homeLocation;
+    }
+    // Already on a valid, protected route — allow it.
+    return null;
+  }
+
+  // AuthSubmitting / AuthRestoring — don't interfere.
+  return null;
 }
 
 /// Adapts a [Stream] to the [Listenable] contract GoRouter needs for

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -251,7 +251,7 @@ String? resolveSplashRedirect({
       deepLink.pendingRedirect = null;
       if (target != requestedUri) return target;
     }
-    // Leaving splash or login/register — restore the captured deep link.
+    // No pending deep link; bounce off splash/login/register to home.
     if (location == splashLocation ||
         location == loginLocation ||
         location == registerLocation) {

--- a/packages/features/home/test/presentation/widgets/home_body_test.dart
+++ b/packages/features/home/test/presentation/widgets/home_body_test.dart
@@ -1,0 +1,97 @@
+// Widget tests for the home dashboard body. home_bloc_test covers the
+// stats-to-state mapping; these assert that HomeBody renders that state for the
+// branches that don't pull network thumbnails — the empty dashboard and the
+// featured-collections row.
+//
+// Populated bookmark cards are intentionally not exercised here: each renders
+// an AppLinkPreviewThumbnail whose link-preview fetch schedules a real 5s
+// timeout timer, which would leak past the test and fail it. The bloc test
+// already verifies the bookmark-stats mapping.
+
+import 'package:app_ui/app_ui.dart';
+import 'package:architecture/architecture.dart';
+import 'package:feature_home/feature_home.dart';
+import 'package:feature_home/src/presentation/widgets/home_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localization/localization.dart';
+import 'package:shared_contracts/shared_contracts.dart';
+
+import '../../support.dart';
+
+void main() {
+  Future<HomeBloc> loadedBloc({
+    BookmarkStats stats = const BookmarkStats(),
+    List<CollectionSummary> collections = const [],
+  }) async {
+    final statsReader = MockBookmarkStatsReader();
+    when(statsReader.call).thenAnswer((_) async => Ok(stats));
+    final collectionsReader = MockCollectionsReader();
+    when(collectionsReader.call).thenAnswer((_) async => Ok(collections));
+
+    final bloc = HomeBloc(statsReader, collectionsReader)
+      ..add(const HomeLoadRequested());
+    // Wait for the load to settle. When collections are expected, also wait for
+    // the (separate) collections emit that follows the stats emit.
+    await bloc.stream.firstWhere(
+      (s) => !s.isLoading && (collections.isEmpty || s.collections.isNotEmpty),
+    );
+    return bloc;
+  }
+
+  Future<void> pumpHome(WidgetTester tester, HomeBloc bloc) async {
+    // A tall, wide surface so the whole scrolling dashboard lays out and is
+    // hit-testable without scrolling.
+    tester.view.physicalSize = const Size(1200, 2400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: BlocProvider<HomeBloc>.value(
+          value: bloc,
+          child: const HomeBody(),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('renders the empty dashboard with no bookmark thumbnails', (
+    tester,
+  ) async {
+    final bloc = await loadedBloc();
+    await pumpHome(tester, bloc);
+
+    expect(find.text('Home'), findsWidgets); // app bar title
+    expect(find.byType(FloatingActionButton), findsOneWidget);
+    expect(find.text('No bookmarks yet. Tap + to add one.'), findsOneWidget);
+    expect(find.byType(AppLinkPreviewThumbnail), findsNothing);
+
+    await bloc.close();
+  });
+
+  testWidgets('renders featured collections from state', (tester) async {
+    final bloc = await loadedBloc(
+      collections: const [
+        CollectionSummary(
+          id: 'c1',
+          name: 'Reading list',
+          icon: 'book',
+          color: 0xFF2196F3,
+          itemCount: 4,
+        ),
+      ],
+    );
+    await pumpHome(tester, bloc);
+
+    expect(find.text('Reading list'), findsOneWidget);
+    // Collection cards are gradient tiles, not link-preview thumbnails.
+    expect(find.byType(AppLinkPreviewThumbnail), findsNothing);
+
+    await bloc.close();
+  });
+}

--- a/packages/features/profile/test/presentation/widgets/profile_screen_test.dart
+++ b/packages/features/profile/test/presentation/widgets/profile_screen_test.dart
@@ -1,0 +1,156 @@
+// Widget tests for the profile screen body. delete_account_flow_test covers the
+// destructive delete flow; these cover the rest of the screen: the session
+// identity header, the appearance theme-mode control wiring, and the sign-out
+// confirmation. The harness mirrors delete_account_flow_test (mocked blocs +
+// FakeSession) with a tall surface so every settings card is hit-testable.
+
+import 'package:app_ui/app_ui.dart';
+// Deliberate cross-feature capability import: profile surfaces auth's
+// delete-account flow (see the capability exception in CLAUDE.md).
+import 'package:feature_auth/feature_auth.dart';
+import 'package:feature_profile/src/presentation/bloc/profile_bloc.dart';
+import 'package:feature_profile/src/presentation/bloc/profile_state.dart';
+import 'package:feature_profile/src/presentation/widgets/profile_widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localization/localization.dart';
+import 'package:shared_ui/shared_ui.dart';
+import 'package:theme/theme.dart';
+
+import '../../support.dart';
+
+class MockThemeBloc extends Mock implements ThemeBloc {}
+
+class MockProfileBloc extends Mock implements ProfileBloc {}
+
+class MockDeleteAccountCubit extends Mock implements DeleteAccountCubit {}
+
+void main() {
+  late FakeSession session;
+  late MockThemeBloc themeBloc;
+  late MockProfileBloc profileBloc;
+  late MockDeleteAccountCubit deleteAccountCubit;
+
+  setUpAll(() {
+    registerFallbackValue(const ThemeModeChanged(ThemeMode.system));
+  });
+
+  setUp(() {
+    session = FakeSession(currentUser: testUser);
+    themeBloc = MockThemeBloc();
+    profileBloc = MockProfileBloc();
+    deleteAccountCubit = MockDeleteAccountCubit();
+
+    const themeState = ThemeState(
+      mode: ThemeMode.system,
+      scheme: ThemeState.defaultScheme,
+    );
+    when(() => themeBloc.state).thenReturn(themeState);
+    when(() => themeBloc.stream).thenAnswer((_) => const Stream.empty());
+
+    const profileState = ProfileState();
+    when(() => profileBloc.state).thenReturn(profileState);
+    when(() => profileBloc.stream).thenAnswer((_) => const Stream.empty());
+
+    when(
+      () => deleteAccountCubit.state,
+    ).thenReturn(const DeleteAccountState.initial());
+    when(
+      () => deleteAccountCubit.stream,
+    ).thenAnswer((_) => const Stream.empty());
+  });
+
+  Future<void> pumpProfile(WidgetTester tester) async {
+    tester.view.physicalSize = const Size(1200, 3200);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.reset);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: SessionScope(
+          session: session,
+          child: MultiBlocProvider(
+            providers: [
+              BlocProvider<ThemeBloc>.value(value: themeBloc),
+              BlocProvider<ProfileBloc>.value(value: profileBloc),
+              BlocProvider<DeleteAccountCubit>.value(value: deleteAccountCubit),
+            ],
+            child: const ProfileBody(),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('header shows the signed-in user identity', (tester) async {
+    await pumpProfile(tester);
+
+    expect(find.text(testUser.username), findsOneWidget); // 'alice'
+    expect(find.text(testUser.id), findsOneWidget); // 'user-1'
+  });
+
+  testWidgets('selecting a theme mode dispatches ThemeModeChanged', (
+    tester,
+  ) async {
+    await pumpProfile(tester);
+
+    final darkTile = find.byWidgetPredicate(
+      (w) => w is RadioListTile<ThemeMode> && w.value == ThemeMode.dark,
+    );
+    expect(darkTile, findsOneWidget);
+    await tester.ensureVisible(darkTile);
+    await tester.tap(darkTile);
+    await tester.pumpAndSettle();
+
+    verify(
+      () => themeBloc.add(
+        any(
+          that: isA<ThemeModeChanged>().having(
+            (e) => e.mode,
+            'mode',
+            ThemeMode.dark,
+          ),
+        ),
+      ),
+    ).called(1);
+  });
+
+  testWidgets('confirming sign-out clears the session', (tester) async {
+    await pumpProfile(tester);
+    expect(session.currentUser, isNotNull);
+
+    await tester.tap(find.byType(AppButton)); // the Sign Out button
+    await tester.pumpAndSettle();
+
+    // The confirmation dialog's confirm button is its only FilledButton.
+    await tester.tap(
+      find.descendant(
+        of: find.byType(Dialog),
+        matching: find.byType(FilledButton),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(session.currentUser, isNull);
+  });
+
+  testWidgets('cancelling sign-out keeps the session', (tester) async {
+    await pumpProfile(tester);
+
+    await tester.tap(find.byType(AppButton));
+    await tester.pumpAndSettle();
+    await tester.tap(
+      find.descendant(
+        of: find.byType(Dialog),
+        matching: find.widgetWithText(TextButton, 'Cancel'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(session.currentUser, isNotNull);
+  });
+}

--- a/packages/features/splash/pubspec.yaml
+++ b/packages/features/splash/pubspec.yaml
@@ -23,6 +23,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+  # Shared test doubles (FakeSession) and fixtures.
+  test_utils: ^0.1.0
+
 flutter:
   assets:
     - assets/icons/

--- a/packages/features/splash/test/presentation/screens/splash_screen_test.dart
+++ b/packages/features/splash/test/presentation/screens/splash_screen_test.dart
@@ -1,0 +1,76 @@
+// Widget tests for the splash gate. `SplashScreen` restores the session and
+// enforces a minimum display time, then hands control back to the host via
+// `onRestored` exactly once. The host owns the routing decision, so these
+// tests assert the gate's timing contract rather than any navigation.
+
+import 'package:feature_splash/feature_splash.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:localization/localization.dart';
+import 'package:shared_ui/shared_ui.dart';
+import 'package:test_utils/test_utils.dart';
+
+/// A [FakeSession] that records how many times [restore] was called.
+class _RecordingSession extends FakeSession {
+  int restoreCalls = 0;
+
+  @override
+  Future<void> restore() async {
+    restoreCalls++;
+  }
+}
+
+void main() {
+  Widget host(
+    _RecordingSession session,
+    void Function(BuildContext context) onRestored,
+  ) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: SessionScope(
+        session: session,
+        child: SplashScreen(onRestored: onRestored),
+      ),
+    );
+  }
+
+  testWidgets('restores the session on the first frame', (tester) async {
+    final session = _RecordingSession();
+    await tester.pumpWidget(host(session, (_) {}));
+
+    await tester.pump(); // fire the post-frame callback → bootstrap
+    expect(session.restoreCalls, 1);
+
+    // Drain the minimum-display timer so no timer is left pending.
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+  });
+
+  testWidgets('calls onRestored only after the minimum display time', (
+    tester,
+  ) async {
+    final session = _RecordingSession();
+    var restoredCalls = 0;
+    await tester.pumpWidget(host(session, (_) => restoredCalls++));
+
+    await tester.pump(); // start bootstrap
+    await tester.pump(const Duration(milliseconds: 1900)); // just before 2s
+    expect(restoredCalls, 0);
+
+    await tester.pump(const Duration(milliseconds: 200)); // cross the 2s gate
+    await tester.pump(); // flush the Future.wait continuation
+    expect(restoredCalls, 1);
+  });
+
+  testWidgets('shows the splash content while bootstrapping', (tester) async {
+    final session = _RecordingSession();
+    await tester.pumpWidget(host(session, (_) {}));
+    await tester.pump();
+
+    expect(find.byType(SplashContent), findsOneWidget);
+
+    await tester.pump(const Duration(seconds: 2));
+    await tester.pump();
+  });
+}

--- a/test/app/router_redirect_test.dart
+++ b/test/app/router_redirect_test.dart
@@ -1,0 +1,298 @@
+// Unit tests for the splash/auth redirect state machine that drives the app's
+// cold-start flow. The logic lives in `resolveSplashRedirect`
+// (lib/app/router.dart), extracted from GoRouter's `redirect` callback so the
+// three phases can be exercised without assembling a router + widget tree.
+//
+// The phases:
+//   1. Before splash completes — capture the requested URI, force /splash.
+//   2. Splash done, unauthenticated — force /login (allowing login/register).
+//   3. Splash done, authenticated — replay a captured deep link, otherwise
+//      bounce off splash/login/register to home and allow protected routes.
+
+import 'package:feature_auth/feature_auth.dart';
+import 'package:flutter_starter_template/app/router.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../test_utils.dart';
+
+const splash = '/splash';
+const home = '/';
+const String login = AuthRoutes.login;
+const String register = AuthRoutes.register;
+
+/// Builds a fresh deep-link gate for one navigation.
+DeepLinkState gate({bool splashCompleted = false, String? pending}) {
+  return DeepLinkState()
+    ..splashCompleted = splashCompleted
+    ..pendingRedirect = pending;
+}
+
+/// Resolves a redirect with the app's real locations wired in. [requestedUri]
+/// defaults to [location] (the common case where they match).
+String? resolve({
+  required AuthState auth,
+  required String location,
+  required DeepLinkState deepLink,
+  String? requestedUri,
+}) {
+  return resolveSplashRedirect(
+    auth: auth,
+    location: location,
+    requestedUri: requestedUri ?? location,
+    deepLink: deepLink,
+    splashLocation: splash,
+    loginLocation: login,
+    registerLocation: register,
+    homeLocation: home,
+  );
+}
+
+void main() {
+  group('Phase 1 — before splash completes', () {
+    test('stays on splash when already there, capturing nothing', () {
+      final deepLink = gate();
+      expect(
+        resolve(
+          auth: const AuthState.initial(),
+          location: splash,
+          deepLink: deepLink,
+        ),
+        isNull,
+      );
+      expect(deepLink.pendingRedirect, isNull);
+    });
+
+    test('captures the default location and routes through splash', () {
+      final deepLink = gate();
+      expect(
+        resolve(
+          auth: const AuthState.initial(),
+          location: home,
+          deepLink: deepLink,
+        ),
+        splash,
+      );
+      expect(deepLink.pendingRedirect, home);
+    });
+
+    test('captures a cold-start deep link before sending through splash', () {
+      final deepLink = gate();
+      expect(
+        resolve(
+          auth: const AuthState.authenticated(testUser),
+          location: '/bookmarks',
+          deepLink: deepLink,
+        ),
+        splash,
+      );
+      expect(deepLink.pendingRedirect, '/bookmarks');
+    });
+
+    test('does not overwrite an already-captured target', () {
+      final deepLink = gate(pending: '/bookmarks');
+      expect(
+        resolve(
+          auth: const AuthState.initial(),
+          location: '/notifications',
+          deepLink: deepLink,
+        ),
+        splash,
+      );
+      expect(deepLink.pendingRedirect, '/bookmarks');
+    });
+  });
+
+  group('Phase 2 — splash done, unauthenticated', () {
+    test('AuthInitial on a protected route captures it and goes to login', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.initial(),
+          location: '/profile',
+          deepLink: deepLink,
+        ),
+        login,
+      );
+      expect(deepLink.pendingRedirect, '/profile');
+    });
+
+    test('AuthFailure behaves like AuthInitial', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.failure(testFailure),
+          location: '/profile',
+          deepLink: deepLink,
+        ),
+        login,
+      );
+    });
+
+    test('allows the login route', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.initial(),
+          location: login,
+          deepLink: deepLink,
+        ),
+        isNull,
+      );
+      expect(deepLink.pendingRedirect, isNull);
+    });
+
+    test('allows the register route', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.initial(),
+          location: register,
+          deepLink: deepLink,
+        ),
+        isNull,
+      );
+    });
+
+    test('does not overwrite an already-captured target', () {
+      final deepLink = gate(splashCompleted: true, pending: '/bookmarks');
+      expect(
+        resolve(
+          auth: const AuthState.initial(),
+          location: '/profile',
+          deepLink: deepLink,
+        ),
+        login,
+      );
+      expect(deepLink.pendingRedirect, '/bookmarks');
+    });
+  });
+
+  group('Phase 3 — splash done, authenticated', () {
+    test('replays a captured deep link, beating the splash→home bounce', () {
+      final deepLink = gate(splashCompleted: true, pending: '/bookmarks');
+      expect(
+        resolve(
+          auth: const AuthState.authenticated(testUser),
+          location: splash,
+          deepLink: deepLink,
+        ),
+        '/bookmarks',
+      );
+      expect(deepLink.pendingRedirect, isNull);
+    });
+
+    test(
+      'clears the captured target without redirecting when already there',
+      () {
+        final deepLink = gate(splashCompleted: true, pending: '/bookmarks');
+        expect(
+          resolve(
+            auth: const AuthState.authenticated(testUser),
+            location: '/bookmarks',
+            deepLink: deepLink,
+          ),
+          isNull,
+        );
+        expect(deepLink.pendingRedirect, isNull);
+      },
+    );
+
+    test('bounces off splash to home', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.authenticated(testUser),
+          location: splash,
+          deepLink: deepLink,
+        ),
+        home,
+      );
+    });
+
+    test('bounces off login to home', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.authenticated(testUser),
+          location: login,
+          deepLink: deepLink,
+        ),
+        home,
+      );
+    });
+
+    test('bounces off register to home', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.authenticated(testUser),
+          location: register,
+          deepLink: deepLink,
+        ),
+        home,
+      );
+    });
+
+    test('allows a protected route', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.authenticated(testUser),
+          location: '/profile',
+          deepLink: deepLink,
+        ),
+        isNull,
+      );
+    });
+
+    test('AuthSigningOut keeps the user on the current protected route', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.signingOut(testUser),
+          location: '/profile',
+          deepLink: deepLink,
+        ),
+        isNull,
+      );
+    });
+
+    test('AuthSigningOut still bounces off splash to home', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.signingOut(testUser),
+          location: splash,
+          deepLink: deepLink,
+        ),
+        home,
+      );
+    });
+  });
+
+  group('transient states do not interfere once splash has completed', () {
+    test('AuthSubmitting allows the navigation', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.submitting(),
+          location: '/profile',
+          deepLink: deepLink,
+        ),
+        isNull,
+      );
+    });
+
+    test('AuthRestoring allows the navigation', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(
+        resolve(
+          auth: const AuthState.restoring(),
+          location: '/profile',
+          deepLink: deepLink,
+        ),
+        isNull,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Closes the structural-confidence gap surfaced in a code-structure review: the highest-logic areas of the app had the thinnest test coverage. No architecture changes.

- **Splash redirect** — extracted the three-phase splash/auth redirect from `buildRouterWithDeepLink` into a `@visibleForTesting resolveSplashRedirect()` (behavior-preserving) so the cold-start state machine is unit-testable without a `GoRouter` + widget tree. Added **19 unit tests** covering phases 1–3, deep-link capture/replay, and transient auth states.
- **feature_splash** (previously **zero tests**) — **3 `SplashScreen` widget tests**: `session.restore()` on first frame, the 2s minimum-display gate, and `onRestored` firing exactly once.
- **feature_home** — **2 `HomeBody` widget tests** (empty dashboard + featured collections). Scoped to the thumbnail-free branches on purpose: populated bookmark cards mount an `AppLinkPreviewThumbnail` whose link-preview fetch schedules a real 5s timeout timer that would leak past the test; the bloc test already covers the stats→state mapping.
- **feature_profile** — **4 `ProfileBody` widget tests**: session identity header, theme-mode control wiring, and sign-out confirm/cancel.
- Added `test_utils` as a dev dependency of `feature_splash` for `FakeSession`.

## Test Plan
- [x] `fvm flutter test` (root app) — 30/30, includes the refactored redirect via `widget_test` + architecture guardrails + the 19 new redirect tests
- [x] `feature_splash` — 3/3
- [x] `feature_home` — 6/6 (4 bloc + 2 new)
- [x] `feature_profile` — 9/9 (bloc + delete flow + 4 new)
- [x] `fvm flutter analyze` clean on root, feature_splash, feature_home, feature_profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved routing/authentication redirect handling by centralizing splash and deep-link redirect decisions into a dedicated resolver.

* **Tests**
  * Added unit tests covering splash/auth redirect resolution across multiple auth phases and deep-link replay behavior.
  * Added widget tests for the Home dashboard empty state and featured collection rendering.
  * Added widget tests for the profile screen header, theme selection, and sign-out confirmation/cancel.

* **Chores**
  * Updated splash feature test tooling by adding a shared `test_utils` dev dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->