### PR TITLE
docs(readme): document the fst add-feature generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ To enable seamless local development and testing, this template is paired with a
 - [✨ What's Inside](#-whats-inside)
 - [🧬 Architecture](#-architecture)
   - [📁 Feature Slice (Clean Architecture)](#-feature-slice-clean-architecture)
+  - [🪄 Scaffolding a New Feature](#-scaffolding-a-new-feature)
 - [🚀 Quick Start](#-quick-start)
 - [🧪 Testing & Code Quality](#-testing--code-quality)
 - [🔄 Git Workflow & PRs](#-git-workflow--prs)
@@ -85,6 +86,7 @@ To enable seamless local development and testing, this template is paired with a
 | 📡 **REST**               | `Retrofit` + `Dio` typed clients with auth interceptor |
 | ⚙️ **Go Backend**         | Companion server — `chi/v5`, JWT issuer, bookmark & collection CRUD, uploads |
 | 🤖 **AI-Native**          | Rules, MCP servers, and agent skills for Claude, Cursor, Codex, Command Code, and Antigravity |
+| 🪄 **Feature Generator**  | `fst add-feature <name>` scaffolds a presentation feature package and wires the workspace, DI graph, and routing in one command |
 | 🚀 **Release CI**         | Fastlane lanes — iOS → TestFlight, Android → Play — flavor‑aware, wired to GitHub Actions |
 
 <br>
@@ -334,6 +336,36 @@ packages/features/<name>/
 │       └── locator.dart         Shared GetIt instance
 └── pubspec.yaml                 name: feature_<name>, resolution: workspace
 ```
+
+<br>
+
+### 🪄 Scaffolding a New Feature
+
+Rather than hand-create the package above, the project's `fst` CLI scaffolds and
+wires a presentation-only feature in one command. Run it from the **repo root**:
+
+```bash
+dart pub global activate flutter_starter_template_cli   # one-time — provides `fst`
+fst add-feature settings                                # or run bare to be prompted
+```
+
+This generates `packages/features/settings/` — a presentation-only slice with a
+screen routed at `/settings` — and wires it into every place the app needs to
+know about it:
+
+| Wired into | File |
+|---|---|
+| Workspace member + dependency | `pubspec.yaml` |
+| Injectable DI graph | `lib/app/di/injection.dart` |
+| `enabledFeatures` registry | `lib/app/features.dart` |
+
+It then runs `pub get` + code generation so the tree compiles immediately. Pass
+`--no-codegen` to skip that step and regenerate yourself later.
+
+The wiring edits land at the `# fst:` / `// fst:` markers in those files (so the
+generator never has to parse Dart) — leave the markers in place. The `fst` CLI
+source lives in [`tool/cli/`](tool/cli); it's the same tool as the `fst create`
+project scaffolder.
 
 <br>
 


### PR DESCRIPTION
## Summary

The v1.4.0 release added the `fst add-feature` generator, but the README never mentioned it — a reader had no way to discover that scaffolding a new feature is a one-command operation. This adds documentation for it.

Changes (README-only, +32 lines):

- **New subsection** under Architecture → "🪄 Scaffolding a New Feature": the command (`fst add-feature <name>`), what it generates (a presentation-only `packages/features/<name>/` slice routed at `/<name>`), the three files it wires (`pubspec.yaml`, `lib/app/di/injection.dart`, `lib/app/features.dart`), the `--no-codegen` flag, and the `# fst:` / `// fst:` wiring markers.
- **TOC entry** for the new subsection.
- **"What's Inside" row** for the feature generator.

## Verification

Every claim was checked against the actual source:
- Command signature/flags from [tool/cli/lib/src/commands/add_feature_command.dart](tool/cli/lib/src/commands/add_feature_command.dart) (`fst add-feature <name> [--no-codegen]`, runs `pub get` + `tool/codegen.sh`).
- The `# fst:` / `// fst:` markers confirmed present in `pubspec.yaml`, `lib/app/features.dart`, and `lib/app/di/injection.dart`.

No code touched — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide on scaffolding new features, including step-by-step instructions, what gets generated, and how the application integrates the new feature into the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->