### PR TITLE
fix(ios): align flavor display names with Android for clean CLI rename

### DIFF
--- a/ios/Flutter/Debug-dev.xcconfig
+++ b/ios/Flutter/Debug-dev.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-dev.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Dev
+APP_DISPLAY_NAME = Flutter Starter (Dev)
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate.dev

--- a/ios/Flutter/Debug-prod.xcconfig
+++ b/ios/Flutter/Debug-prod.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-prod.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Template
+APP_DISPLAY_NAME = Flutter Starter
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate

--- a/ios/Flutter/Debug-staging.xcconfig
+++ b/ios/Flutter/Debug-staging.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug-staging.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Staging
+APP_DISPLAY_NAME = Flutter Starter (Staging)
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate.staging

--- a/ios/Flutter/Profile-dev.xcconfig
+++ b/ios/Flutter/Profile-dev.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-dev.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Dev
+APP_DISPLAY_NAME = Flutter Starter (Dev)
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate.dev

--- a/ios/Flutter/Profile-prod.xcconfig
+++ b/ios/Flutter/Profile-prod.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-prod.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Template
+APP_DISPLAY_NAME = Flutter Starter
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate

--- a/ios/Flutter/Profile-staging.xcconfig
+++ b/ios/Flutter/Profile-staging.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile-staging.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Staging
+APP_DISPLAY_NAME = Flutter Starter (Staging)
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate.staging

--- a/ios/Flutter/Release-dev.xcconfig
+++ b/ios/Flutter/Release-dev.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release-dev.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Dev
+APP_DISPLAY_NAME = Flutter Starter (Dev)
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate.dev

--- a/ios/Flutter/Release-prod.xcconfig
+++ b/ios/Flutter/Release-prod.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release-prod.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Template
+APP_DISPLAY_NAME = Flutter Starter
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate

--- a/ios/Flutter/Release-staging.xcconfig
+++ b/ios/Flutter/Release-staging.xcconfig
@@ -1,5 +1,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release-staging.xcconfig"
 #include "Generated.xcconfig"
 
-APP_DISPLAY_NAME = Flutter Starter Staging
+APP_DISPLAY_NAME = Flutter Starter (Staging)
 PRODUCT_BUNDLE_IDENTIFIER = com.luci-studio.flutterStarterTemplate.staging


### PR DESCRIPTION
## Why

`fst create` renames the template by substituting known display-name tokens — `Flutter Starter`, `Flutter Starter (Dev)`, `Flutter Starter (Staging)`. The iOS xcconfig values had drifted from Android's `app_name`:

- iOS **prod** was `Flutter Starter Template` → after rename, the prod iOS app showed a stray "Template" word (e.g. **"Acme App Template"**).
- iOS **dev/staging** were `Flutter Starter Dev` / `Flutter Starter Staging` (no parens), so they renamed inconsistently vs Android's parenthesized labels.

## What

Normalize all nine iOS flavor xcconfigs so every `APP_DISPLAY_NAME` is exactly one rewriter token, matching Android:

| Flavor | Both platforms now |
|---|---|
| dev | `Flutter Starter (Dev)` |
| staging | `Flutter Starter (Staging)` |
| prod | `Flutter Starter` |

A `fst create` for "Acme App" now yields `Acme App` / `Acme App (Dev)` / `Acme App (Staging)` identically on iOS and Android — no leftover "Template".

## Scope

iOS xcconfig only. Android already used these values; no app/Dart/rewriter code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app display names across all build configurations for consistent naming. Development builds now display "Flutter Starter (Dev)", staging builds display "Flutter Starter (Staging)", and production builds display "Flutter Starter" on the home screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->