### PR TITLE
ci: fix dead path filter + cache Gradle/CocoaPods to cut CI time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,13 @@ jobs:
         uses: dorny/paths-filter@v3
         id: filter
         with:
+          # Use the `every` quantifier so a path matches `code` only when it
+          # satisfies ALL patterns — i.e. it matches `**` AND is not excluded by
+          # any `!` negation below. The action's default (`some`) matches when
+          # ANY pattern hits, and since `**` always hits, the negations are dead
+          # and `code` is permanently true — so docs/tooling/submodule-only PRs
+          # never actually skip the heavy jobs. `every` makes the exclusions real.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'
@@ -250,6 +257,21 @@ jobs:
           channel: stable
           cache: true
 
+      # Cache Gradle's downloaded dependencies and wrapper so the Android build
+      # doesn't refetch the toolchain + dependencies every run. Keyed on the
+      # Gradle build files; restore-keys give a partial-cache fallback. Only
+      # external deps are cached here, not generated Dart — the build_runner
+      # caching caveat documented above does not apply to Gradle's cache.
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('android/**/*.gradle*', 'android/gradle/wrapper/gradle-wrapper.properties', 'android/gradle.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       # The com.google.gms.google-services Gradle plugin parses
       # google-services.json at build time (it never contacts Firebase), and
       # the file is git-ignored — so a fresh checkout has none and Gradle fails
@@ -339,6 +361,20 @@ jobs:
           flutter-version: 3.44.0
           channel: stable
           cache: true
+
+      # Cache the installed Pods and the CocoaPods download cache so the
+      # `pod install` that `flutter build ios` runs doesn't refetch every pod
+      # each run. Keyed on the committed ios/Podfile.lock; restore-keys give a
+      # partial-cache fallback when the lockfile changes.
+      - name: Cache CocoaPods
+        uses: actions/cache@v4
+        with:
+          path: |
+            ios/Pods
+            ~/Library/Caches/CocoaPods
+          key: ${{ runner.os }}-pods-${{ hashFiles('ios/Podfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pods-
 
       # This project requires CocoaPods, not SPM (see CLAUDE.md). The setting is
       # machine-global, so each runner must disable SPM before the first build.


### PR DESCRIPTION
## Problem

Two sources of wasted CI time:

**1. The path filter never actually skips anything.** `dorny/paths-filter` defaults to `predicate-quantifier: some` — a path matches the `code` filter if **any** pattern matches. Since `'**'` matches everything, all the `'!...'` negations (`.md`, `doc/`, `.agents/`, `tool/cli`, `simple_backend_server`, …) are dead and `code` is **always `true`**. So every docs-/tooling-/submodule-only PR still runs the full ~13-min Android + iOS + golden + test pipeline.

Verified on the `tool/cli`-only bump in [#142](https://github.com/kido-luci/flutter-starter-template/pull/142) — its `Detect changes` job:
```
[modified] tool/cli
Matching files: tool/cli [modified]
Changes output set to ["code"]   ← code=true despite '!tool/cli'
predicate-quantifier: some
```

**2. Native builds refetch everything every run.** `build-android` had no Gradle cache and `build-ios` had no CocoaPods cache, so each run re-downloaded the Gradle toolchain/deps and re-fetched all pods.

## Fix

1. **`predicate-quantifier: 'every'`** on the filter step — a path matches `code` only when it satisfies *all* patterns (matches `**` **and** isn't excluded). This makes the existing exclusion list real: docs/tooling/submodule-only PRs now skip the heavy jobs (skipped required checks still satisfy branch protection, so no deadlock — the same property the current job-level gating relies on).
2. **Cache `~/.gradle`** in `build-android` (keyed on the Gradle build files) and **cache `ios/Pods` + `~/Library/Caches/CocoaPods`** in `build-ios` (keyed on `ios/Podfile.lock`). Only external dependencies are cached — not generated Dart — so the documented `build_runner` caching caveat does not apply.

## Expected impact

- Docs/tooling/submodule PRs: full pipeline → **skipped** (seconds).
- Code PRs: Android/iOS jobs skip dependency re-download on cache hits (first run after merge primes the cache).

## Notes / not included
- **Merge queue** (eliminates the forced re-run from "require branches up to date", which cost #142 a second full cycle) is a branch-protection **setting** — can't be changed from a workflow file. Recommended as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI build gate logic for better code change detection.
  * Optimized Android build pipeline with dependency and toolchain caching to reduce build times.
  * Optimized iOS build pipeline with CocoaPods caching to reduce build times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->