### PR TITLE
fix: fst create — codegen uses FVM SDK; features.dart survives excluding all routed demos

### DIFF
--- a/lib/app/features.dart
+++ b/lib/app/features.dart
@@ -71,6 +71,13 @@ final class _NotificationsModule extends FeatureModule {
     final ctrl = getIt<NotificationsSyncController>();
     return _FeatureSync(onStart: ctrl.start, onStop: ctrl.stop);
   }
+
+  // Notifications' screen is mounted as a shell branch in router.dart, not via
+  // enabledFeatures — so it contributes no app-level routes. The explicit empty
+  // override also keeps go_router referenced when notifications is the only demo
+  // feature left after `fst create --exclude-feature bookmarks,collections`.
+  @override
+  Iterable<RouteBase> get routes => const <RouteBase>[];
 }
 // fst:feature:notifications:end
 

--- a/tool/codegen.sh
+++ b/tool/codegen.sh
@@ -13,11 +13,20 @@
 # a tracked exception (committed, holds stable schema UIDs) and is regenerated +
 # verified separately in CI, so it is not built here.
 #
-# Uses the `dart` on PATH (the FVM-pinned SDK on dev machines, the action-managed
-# SDK in CI). Safe to call from any directory — it resolves the repo root itself.
+# Prefers the FVM-pinned SDK when `fvm` is installed (this template pins Flutter
+# via .fvmrc); otherwise falls back to the `dart` on PATH (the action-managed SDK
+# in CI). Safe to call from any directory — it resolves the repo root itself.
+#
+# The fvm shim lives here, not only in setup.sh: setup.sh's dart()/flutter()
+# functions don't propagate to this child process, and this script is also run
+# standalone (e.g. by `fst add-feature`).
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if command -v fvm >/dev/null 2>&1; then
+  dart() { fvm dart "$@"; }
+fi
 
 run_pkg() {
   local dir="$1"


### PR DESCRIPTION
Two bugs found by running a real end-to-end `fst create` (clone → rename → `--no-firebase` → `--exclude-feature collections` → `setup.sh`):

## 1. Codegen ran under the wrong Dart SDK
`tool/codegen.sh` used the `dart` on PATH. On a dev machine that's the system SDK (here 3.11.5), not the FVM-pinned one — so `build_runner` failed version solving against the workspace's `^3.12.0` constraint:
```
The current Dart SDK version is 3.11.5. Because acme_test requires SDK ^3.12.0, version solving failed.
```
`setup.sh` defines `dart()`/`flutter()` fvm shims but they don't propagate to the `codegen.sh` child process. **Fix:** add the same fvm shim to `codegen.sh` (CI without fvm still falls back to PATH dart). Also fixes a developer running `./tool/setup.sh` with an older system Dart.

## 2. `go_router` import unused when only routeless demos remain
Excluding `bookmarks`+`collections` but keeping `notifications` left `go_router` unused in `features.dart` — notifications' module contributes no routes (its screen is a shell branch). It can't simply be stripped (`fst add-feature` inserts route-bearing modules needing it). **Fix:** explicit empty `routes` override on `_NotificationsModule` keeps the import referenced; the `fst:feature:_infra` strip still removes it when *all* demo features are gone.

## Verification
Ran `fst create --yes --no-firebase --exclude-feature collections …` end-to-end (real clone + setup): codegen succeeds, and the generated project (firebase off, bookmarks+collections excluded) `analyze`s clean and passes all 30 tests. Template default also clean + green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved notifications feature routing by restructuring how the notifications screen is mounted.

* **Chores**
  * Enhanced code generation tooling to automatically use Flutter Version Manager (FVM) SDK when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->