### PR TITLE
chore(hooks): exclude submodules from pre-push format + analyze

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -16,9 +16,9 @@ set -euo pipefail
 if command -v fvm >/dev/null 2>&1; then
   dart() { fvm dart "$@"; }
   flutter() { fvm flutter "$@"; }
-  format_fix_cmd="fvm dart format ."
+  format_fix_cmd="fvm dart format \$(git ls-files '*.dart')"
 else
-  format_fix_cmd="dart format ."
+  format_fix_cmd="dart format \$(git ls-files '*.dart')"
 fi
 
 if ! command -v dart >/dev/null 2>&1 || ! command -v flutter >/dev/null 2>&1; then
@@ -37,9 +37,23 @@ if ! dart run build_runner build --delete-conflicting-outputs; then
 fi
 
 echo "▶ pre-push: verifying formatting (dart format)…"
-if ! dart format --output=none --set-exit-if-changed .; then
-  echo "✖ Formatting issues found. Fix with: ${format_fix_cmd}" >&2
-  exit 1
+# Check only files tracked by THIS repo. Submodule contents (published/cli,
+# published/rev_sync, simple_backend_server) are gitlinks, so `git ls-files`
+# excludes them — their own repos/CI own their formatting, and e.g. the CLI's
+# source is maintained on a different SDK. Passing `.` instead would reformat
+# the submodules and false-fail the push (CI is unaffected: it never checks out
+# published/cli).
+tracked_dart="$(git ls-files '*.dart')"
+# Pass the file list directly (not via xargs): `dart` here is a shell function
+# wrapping `fvm dart`, and xargs would invoke the PATH `dart` binary instead —
+# a different SDK whose formatter rules differ. Word-splitting is intentional
+# (paths have no spaces); the guard skips the no-files case.
+if [ -n "$tracked_dart" ]; then
+  # shellcheck disable=SC2086
+  if ! dart format --output=none --set-exit-if-changed $tracked_dart; then
+    echo "✖ Formatting issues found. Fix with: ${format_fix_cmd}" >&2
+    exit 1
+  fi
 fi
 
 echo "▶ pre-push: analyzing (flutter analyze)…"

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -35,6 +35,13 @@ analyzer:
     - "**/*.g.dart"
     - "**/*.config.dart"
     - lib/firebase_options.dart
+    # Submodules are independently-maintained repos (own pubspec / pub get / CI /
+    # formatter version). Analyzing their source from the root context yields
+    # spurious "undefined" errors (they aren't resolved here) — leave them to
+    # their own tooling. CI never checks out published/cli; this keeps local
+    # `flutter analyze` and the pre-push hook consistent with CI.
+    - published/**
+    - simple_backend_server/**
 
 
 # Additional information about this file can be found at


### PR DESCRIPTION
## Summary

After the reorg (#156) the `fst` CLI lives at `published/cli`. Once that submodule is checked out locally (e.g. after `git submodule update --init`), the pre-push hook started false-failing on the submodule's own source — even for unrelated changes (it forced `--no-verify` on the #158 docs PR). CI is unaffected: it only checks out `published/rev_sync`, never `published/cli`.

Two scans reached into submodules:

- **format** — `dart format --output=none --set-exit-if-changed .` reformatted the CLI's source, which is maintained on a different Dart SDK (the CLI repo's vs this repo's FVM-pinned 3.12.0). Now formats only files tracked by *this* repo via `git ls-files '*.dart'` (submodule contents are gitlinks → excluded), passing them to the `dart` shell function (`fvm dart`) directly — **not** through `xargs dart`, which would invoke the PATH `dart` binary (a different SDK, the actual cause of the spurious diff).
- **analyze** — `flutter analyze` descended into `published/cli`, which isn't `pub get`-resolved in this context, producing spurious "undefined function" errors. Excluded `published/**` and `simple_backend_server/**` in `analysis_options.yaml` (this also stops the IDE from showing the same false errors).

## Test Plan

- [x] `git ls-files '*.dart'` returns 0 files under `published/` (submodules excluded)
- [x] format check passes on the clean tree and still catches a mis-formatted *tracked* file (negative test)
- [x] confirmed root cause: PATH `dart` 3.11.5 vs `fvm dart` 3.12.0 formats differently
- [x] `fvm flutter analyze` → No issues (was 72 false errors from `published/cli`)
- [x] full hook run locally → `✓ pre-push checks passed`; this branch pushed **without** `--no-verify`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-push formatting checks to focus on tracked Dart files while excluding generated code and submodules, with clearer fix guidance.
  * Updated code analysis configuration to exclude independently maintained submodules from analysis to reduce spurious errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->