### PR TITLE
chore(deps): bump firebase plugins + very_good_analysis

### DIFF
--- a/lib/core/platform/firebase/firebase_service.dart
+++ b/lib/core/platform/firebase/firebase_service.dart
@@ -1,6 +1,3 @@
-// FirebaseService is accessed via GetIt in main.dart, but the analyzer flags it as unreachable because of the entry point below.
-// ignore_for_file: unreachable_from_main
-
 import 'package:app_platform/app_platform.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:injectable/injectable.dart';

--- a/packages/analytics/pubspec.yaml
+++ b/packages/analytics/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   architecture: ^0.1.0
-  firebase_analytics: ^12.4.2
+  firebase_analytics: ^12.4.3
   injectable: ^3.0.0
 
 dev_dependencies:

--- a/packages/app_platform/pubspec.yaml
+++ b/packages/app_platform/pubspec.yaml
@@ -17,8 +17,8 @@ dependencies:
   injectable: ^3.0.0
 
   camera: ^0.12.0+1
-  firebase_crashlytics: ^5.2.3
-  firebase_messaging: ^16.3.0
+  firebase_crashlytics: ^5.2.4
+  firebase_messaging: ^16.4.0
   flutter_local_notifications: ^22.0.1
   image_picker: ^1.2.2
   permission_handler: ^12.0.3

--- a/packages/config/pubspec.yaml
+++ b/packages/config/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  firebase_remote_config: ^6.5.2
+  firebase_remote_config: ^6.5.3
   injectable: ^3.0.0
 
 dev_dependencies:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "0d1f0adfabbab9f46a1a80ce84a4d8b852b6e4dbf53ce413b30e0cf7d3631b71"
+      sha256: "78f98c1f9c4dbbd22c2bb7b7f17c4a5c06150e8b2cb791a0947979ad0d3dabd5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.72"
+    version: "1.3.73"
   analyzer:
     dependency: transitive
     description:
@@ -485,90 +485,90 @@ packages:
     dependency: transitive
     description:
       name: firebase_analytics
-      sha256: "1f68d8a30265149035e9bb0b73962e43f3bf2debef4a7ae2d1d588361d5858a9"
+      sha256: "1c46136d9226e7e070013582097d997248a34cf94856c7e95f4fdf346bf4a397"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.2"
+    version: "12.4.3"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: "65f97fb923f036d487aa95be99eab90e0f8f636e4783c94deeb52c0e6f5dbae7"
+      sha256: "0b4ae09407352ec462a2403b8addf18bdf94a35e0e0c9dda198274516c32456a"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: ec49a95c6abaadbd6a4327cc2680d911f86e62fdf6f2c96a3a326603410e2abf
+      sha256: e66c02ab6491393767b197dfb37908178295cfdb1c5d30e33cad9d7276d1c5fa
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+8"
+    version: "0.6.1+9"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: ec46a100a560d3bd5f97f2d89ba7492cb09b6dd0a4a28753d1258f360d6bd9f9
+      sha256: d2625088d8f8836a7a74a7eb94a5372d70ad88382602ba2dcc02805c294d0d16
       url: "https://pub.dev"
     source: hosted
-    version: "4.10.0"
+    version: "4.11.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "4a120366dbf7d5a8ee9438978530b664b855728fb8dcc3a201017660817e555b"
+      sha256: "913e7c96ef83a80ad7e1c3f8a059167b3de23b5d5e07fa3ed8f11abe24de98b6"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.1"
+    version: "7.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "5ad1be848692ec148f2d6a8ad2a3838cb852ea5f3c9e6479a7afce479e1854f8"
+      sha256: "30ba3ae56f5beb2cea836033201570612c911661889f815eca73b6056c7b55bf"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.0"
+    version: "3.9.0"
   firebase_crashlytics:
     dependency: transitive
     description:
       name: firebase_crashlytics
-      sha256: "5d111db2b40426e76e2da95d133c19a9dbcf6500c4e9b3785c68da51fb3f6602"
+      sha256: "2d9c791abef1cfd66c2572f5a4e172aa9f43476961af49742b1511dd327611df"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.3"
+    version: "5.2.4"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: "5bf4a83a1b9e0a5218f6d6491227440dd659242a55b16c279de0b8839791539a"
+      sha256: cbedfe34081c4ad5c4e0558165383d4fa6b8fd70ae6e696190aad345adbb346c
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.23"
+    version: "3.8.24"
   firebase_messaging:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: "9651e833454156b9f0927eaedccffba0f7f6a6e20ceddef82517211e7017e9c4"
+      sha256: f2d1734d167e07746949ada91a288a9b14a03be470eec89ee249ed90c8d4db44
       url: "https://pub.dev"
     source: hosted
-    version: "16.3.0"
+    version: "16.4.0"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "292bb5dc9c4a429078895406c347d7c7690deb858c1adeed8f4b4346f769dfa3"
+      sha256: e10f6d521e7ed663d0ea2f4ec7de4c6729f8c2ce25d32faf6d6b4219da8515c2
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "4.9.0"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "08c565bc83729439f5de2dfea77b4832002b705eb2f840366cefa80e4e5c3c66"
+      sha256: "7ab45dfaf8efcd1a769baa9b8debbd0da281f5d3fc07274296b564396a980292"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "4.2.1"
   firebase_performance:
     dependency: transitive
     description:
@@ -597,26 +597,26 @@ packages:
     dependency: transitive
     description:
       name: firebase_remote_config
-      sha256: "359c9682bbfb0d2c5f2e056a7f1022c532766d0b9c10f637c4ce1a2d83e3e11a"
+      sha256: "6f310b2dfbb84d781992ac5e4be741be5606c3e971741517869b21099a1a82b0"
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.2"
+    version: "6.5.3"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
-      sha256: "889c038cfdc3016135583ccc3d8f5389ce536dcd105cad9b2a64eb2d469076e5"
+      sha256: "59a20db282c7f6166b02d5158e6bcd998937b1c1711307af8f55cb5da110bb2a"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
-      sha256: "32972f95cd38739c99faf74f1abed829a8fb1f8777fabdf5e6c2f6167b2eaed1"
+      sha256: a97dced4db76235b1680cf647e8a23528dff1b94fab6e7ed1cfc3e2f9d9f4b72
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.9"
+    version: "1.10.10"
   fixnum:
     dependency: transitive
     description:
@@ -1988,10 +1988,10 @@ packages:
     dependency: "direct dev"
     description:
       name: very_good_analysis
-      sha256: d1cb1d66a5aae2c702d68caca6c8347306d35e728fd94555fa21fa0448a972e0
+      sha256: "481af67ab5877af20325251dc215a4ebac7666a1c8cf09198ffd457bc612b33d"
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.0"
+    version: "10.3.0"
   video_player:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -173,7 +173,7 @@ dev_dependencies:
   # (output: lib/gen/assets.gen.dart). Use e.g. Assets.images.logo instead
   # of raw 'assets/images/logo.png' strings.
   flutter_gen_runner: ^5.14.1
-  very_good_analysis: ^10.2.0
+  very_good_analysis: ^10.3.0
 
   # Generates native launcher icons for all platforms from a single source
   # image. Run: dart run flutter_launcher_icons (config below).


### PR DESCRIPTION
## Summary

Manually re-creates the stale Dependabot PR #146 against current `main` (#146 was 16 commits behind — predating the `published/` reorg — so its CI ran on an outdated base and Dependabot didn't respond to `rebase`/`recreate`).

Bumps:
- `firebase_analytics` ^12.4.2 → ^12.4.3
- `firebase_crashlytics` ^5.2.3 → ^5.2.4
- `firebase_messaging` ^16.3.0 → ^16.4.0
- `firebase_remote_config` ^6.5.2 → ^6.5.3
- `very_good_analysis` ^10.2.0 → ^10.3.0

`very_good_analysis` 10.3.0 adds the `unnecessary_ignore` lint, which flagged an obsolete `// ignore_for_file: unreachable_from_main` in `lib/core/platform/firebase/firebase_service.dart` — removed.

Supersedes #146.

## Test Plan
- [x] `fvm flutter pub get` resolves
- [x] `fvm flutter analyze` — no issues (after removing the obsolete ignore)
- [x] `test/widget_test.dart` + app_platform / analytics / config suites green
- [x] pre-push hook passed (build_runner + format + analyze)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Firebase dependencies (Analytics, Cloud Messaging, Remote Config, and Crashlytics) to latest patch versions
  * Updated development analysis tool to latest version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->