### PR TITLE
docs(agents): refresh AGENTS.md for multi-agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,66 +1,208 @@
 # AGENTS.md
 
-This file provides guidance to Codex when working with code in this
-repository.
+Guidance for AI coding agents (OpenCode, Codex, Claude, Cursor) working in
+this repository. High-signal, repo-specific facts only — see the `README.md`
+for the full narrative.
 
-## Flutter version is pinned via FVM
+## Toolchain — Flutter is pinned via FVM
 
-This project pins Flutter to the version in `.fvmrc` using FVM. Always invoke
-Flutter and Dart through FVM so the pinned SDK is used.
+Flutter is pinned to **3.44.0** in `.fvmrc`. Always invoke Flutter and Dart
+through FVM so the pinned SDK is used (CI and the pre-push hook do the same).
 
 ```bash
 fvm flutter <command>
 fvm dart <command>
 ```
 
-If `.fvm/flutter_sdk` is missing, run `fvm install` once.
+If `.fvm/flutter_sdk` is missing, run `fvm install` once (or just run
+`tool/setup.sh`, which does this plus pub get, codegen, backend deps, and the
+pre-push hook in one idempotent pass).
 
 ## Common commands
 
 ```bash
 fvm flutter pub get
-fvm flutter run
+fvm flutter run --flavor dev --dart-define-from-file=env/dev.json   # staging|prod likewise
+fvm dart run build_runner build --delete-conflicting-outputs         # REQUIRED after clone / pub get
+fvm dart run build_runner watch --delete-conflicting-outputs         # incremental
 fvm flutter analyze
-fvm flutter test
-fvm flutter test test/widget_test.dart
-fvm flutter test --name "<substring>"
-fvm dart run build_runner build --delete-conflicting-outputs
+fvm dart format .
+fvm dart fix --apply
 ```
 
-VS Code launch configs in `.vscode/launch.json` cover Debug / Profile /
-Release modes against `lib/main.dart`.
+### Tests — mind the golden tag
 
-## Project conventions
+```bash
+fvm flutter test --exclude-tags golden                    # root tests (CI does this)
+fvm flutter test test/widget_test.dart                    # one file
+fvm flutter test --name "signs in"                        # by name match
+fvm flutter test --update-goldens --tags golden           # regenerate golden baselines (macOS only)
+(cd packages/network && fvm flutter test --exclude-tags golden)   # one package's tests
+```
 
-- Use the feature-first Clean Architecture layout already present under
-  `lib/features/<feature>/{data,domain,presentation}`.
-- Keep reusable cross-feature code under `lib/core`.
-- Prefer BLoC state patterns already used in the project.
-- Use immutable models and Freezed unions where the surrounding code does.
-- Do not hand-edit generated files such as `*.freezed.dart`, `*.g.dart`,
-  `router.g.dart`, `injection.config.dart`, or `objectbox.g.dart`; update the
-  source file and regenerate.
-- Keep localization changes in ARB files and generated localization outputs.
+Golden tests are tagged `golden` and **excluded in CI** (baselines are
+generated on macOS, CI runs on Ubuntu). Running plain `fvm flutter test`
+locally will execute goldens and may fail on non-macOS — prefer
+`--exclude-tags golden` unless you're intentionally working on goldens.
+
+### Local verification gate (CI parity) — run before pushing
+
+```bash
+fvm dart format .
+fvm flutter analyze
+fvm flutter test --exclude-tags golden
+for package in packages/*; do
+  if [ -d "$package/test" ]; then (cd "$package" && fvm flutter test --exclude-tags golden); fi
+done
+```
+
+The pre-push hook (`.githooks/pre-push`) runs build_runner → `dart format` →
+`flutter analyze` automatically once enabled: `git config core.hooksPath .githooks`.
+Bypass in an emergency with `git push --no-verify`.
+
+### E2E (integration tests)
+
+```bash
+tool/run_e2e.sh                # resets + starts backend, runs, tears down
+tool/run_e2e.sh <device-id>    # target a specific device
+```
+
+Needs a booted **iOS Simulator** (only `ios/` ships `GoogleService-Info.plist`)
+and the live Go backend. Not run in CI. Run before cutting a release.
+
+## Architecture — Dart Pub Workspace
+
+The root `lib/` is a thin **composition root** (routing, DI, Firebase
+bootstrap, optional-feature wiring) and owns **no feature code**. There is no
+`lib/features/` directory.
+
+- Features are self-contained `feature_<name>` packages under
+  `packages/features/<name>/` with their own `lib/src/{data,domain,presentation}`
+  and a micro-package DI module (`Feature<Name>PackageModule`).
+- Reusable infrastructure lives in `packages/` (`network`, `database`,
+  `storage`, `config`, `analytics`, `app_platform`, `theme`, `app_ui`,
+  `shared_ui`, `shared_contracts`, `localization`, `architecture`, …),
+  consumed via package barrels like `package:network/network.dart`.
+- App-level cross-feature glue lives in `lib/core/` (ObjectBox bootstrap,
+  sync cursor store, app-wide DI module, Firebase platform bootstrap).
+- Dependencies point **downward only**: `app → features → shared/infra → architecture`.
+  A feature may **not** import another feature except through a documented
+  single-consumer capability (e.g. `bookmarks` embeds `collections` widgets,
+  `profile` surfaces `auth`'s delete-account). Enforced by guardrail tests
+  under `test/architecture/`.
+- The app depends on workspace packages, never raw third-party libs — e.g.
+  depend on `network`, not `dio`/`retrofit` directly.
+
+## Scaffolding features — use the `fst` CLI
+
+Don't hand-create a feature package. From the **repo root**:
+
+```bash
+fst add-feature <name>          # scaffolds packages/features/<name>/ + wires workspace, DI, routing
+```
+
+The wiring edits land at `# fst:` / `// fst:` markers in `pubspec.yaml`,
+`lib/app/di/injection.dart`, and `lib/app/features.dart` — **leave the
+markers in place** (the generator never parses Dart; it relies on them).
+
+## Code generation — required, git-ignored, with one exception
+
+Most generated output (`*.g.dart`, `*.freezed.dart`, `*.config.dart`,
+`*.gen.dart`) is **git-ignored** and regenerated on demand. After cloning or
+any `pub get`, run `build_runner` once before the project compiles — until
+then the analyzer will show errors for missing generated sources.
+
+**ObjectBox is the deliberate exception:** `lib/objectbox.g.dart` **and**
+`lib/objectbox-model.json` are **version-controlled**. They hold the stable
+entity/property UIDs that keep on-device data intact across schema migrations
+— regenerating them from scratch risks a destructive schema change. Treat
+both as source-of-truth; CI fails if the tracked binding drifts from the
+`@Entity` definitions.
+
+Generators in play: freezed, retrofit, json_serializable, injectable,
+objectbox, go_router_builder, flutter_gen.
+
+Do **not** hand-edit any generated file — update the source and regenerate.
+
+## Conventions
+
+- Lint set: `very_good_analysis` ^10.2.0 with strict-casts, strict-inference,
+  strict-raw-types (see `analysis_options.yaml`).
+- **Prefer relative imports** (`prefer_relative_imports: true`) — not
+  package: imports within a package.
+- State management: BLoC (`flutter_bloc` + `bloc_concurrency`); sealed state
+  unions via Freezed. Tests use `bloc_test`.
+- DI: `get_it` + `injectable` codegen — never hand-wire registrations; add
+  `@injectable` / `@singleton` and regenerate.
+- Immutable models + Freezed unions where the surrounding code does.
+- Routing: `go_router` with typed `TypedGoRoute` routes (go_router_builder).
+- Localization: ARB sources + `gen-l10n` live in the `localization` package
+  (`packages/localization/lib/l10n/`). Edit ARB there, then
+  `(cd packages/localization && fvm flutter gen-l10n)`. Consume via
+  `package:localization/localization.dart` / `context.l10n`.
+- Submodules (`published/rev_sync`, `published/cli`, `simple_backend_server`)
+  are independently maintained — their own pubspec, SDK, and CI. Don't
+  reformat or analyze them from the root (they're excluded in
+  `analysis_options.yaml`).
+
+## Flavors & environment
+
+Three flavors driven by `--dart-define-from-file` with typed `EnvConfig`
+(`packages/config`):
+
+```bash
+fvm flutter run --flavor dev     --dart-define-from-file=env/dev.json
+fvm flutter run --flavor staging --dart-define-from-file=env/staging.json
+fvm flutter run --flavor prod    --dart-define-from-file=env/prod.json
+```
+
+## iOS — CocoaPods, not Swift Package Manager
+
+iOS builds must use CocoaPods. Flutter 3.44.0 hardcodes the SPM-generated
+package to deployment target 13.0, but Firebase needs 15.0, and
+`permission_handler_apple` + `objectbox_flutter_libs` don't support SPM yet.
+This is a **machine-global** Flutter config — every new machine and CI runner
+must run it once before the first iOS build (`tool/setup.sh` does this on
+macOS):
+
+```bash
+fvm flutter config --no-enable-swift-package-manager
+```
+
+## Backend (companion Go server)
+
+`simple_backend_server/` is a git submodule (SQLite-backed, `chi/v5` + JWT).
+If empty: `git submodule update --init --recursive`.
+
+```bash
+cd simple_backend_server && go run .     # → http://localhost:8080
+```
+
+Any username/password works in dev. Bookmarks & collections carry a per-owner
+`rev` + `deleted_at` tombstones; clients pull deltas with `?since=<rev>` and
+send `X-Expected-Rev` on writes (`409` on conflict).
 
 ## MCP servers
 
-The project-scoped MCP config lives in `.mcp.json`.
+Project-scoped config in `.mcp.json`.
 
-- `dart` runs via `fvm dart mcp-server` and should be preferred for static
-  analysis, formatting, package management, tests, runtime diagnostics, hot
-  reload/restart, and Flutter inspector workflows when available.
-- `codegraph` runs via `codegraph serve --mcp --path <project>` and should be
-  preferred for structural code questions.
-- `firebase` runs via `npx -y firebase-tools@latest mcp` and should be
-  preferred for working with Firebase projects, resources, and data.
+- `dart` (`fvm dart mcp-server`) — prefer for static analysis, formatting,
+  package management, tests, runtime diagnostics, hot reload, Flutter
+  inspector.
+- `codegraph` (`codegraph serve --mcp --path .`) — prefer for structural
+  code questions (symbol search, callers/callees, impact, focused context).
+- `firebase` (`npx -y firebase-tools@latest mcp`) — prefer for Firebase
+  projects, resources, and data.
+
+If `.codegraph/` is missing, ask before building the index:
+`codegraph init -i`.
 
 ## Agent skills
 
-Official task-playbook skills from `flutter/skills`, `dart-lang/skills`, and `firebase/agent-skills` are
-vendored under `.agents/skills/` and hash-pinned in `skills-lock.json`.
-
-When a task matches a skill, open that skill's `SKILL.md` and follow it rather
-than improvising. Common mappings:
+Official task playbooks from `flutter/skills`, `dart-lang/skills`, and
+`firebase/agent-skills` are vendored under `.agents/skills/` and hash-pinned
+in `skills-lock.json`. When a task matches a skill, open its `SKILL.md` and
+follow it rather than improvising. Common mappings:
 
 - Routing: `flutter-setup-declarative-routing`
 - JSON serialization: `flutter-implement-json-serialization`


### PR DESCRIPTION
## What

Substantial rewrite of `AGENTS.md` — turns the thin Codex-only stub into
high-signal, repo-specific guidance for any AI coding agent (OpenCode, Codex,
Claude, Cursor). Docs-only; no code touched.

## Highlights

- **Toolchain**: pin called out as Flutter 3.44.0; points to `tool/setup.sh`.
- **Commands**: flavored `run`, build_runner, format/fix; a dedicated
  **golden-tag** note (goldens excluded in CI, macOS-only baselines) and a
  local **CI-parity verification gate** + pre-push hook usage.
- **Architecture**: documents the Dart pub workspace — thin `lib/`
  composition root, `feature_<name>` packages, downward-only dependency
  direction, the single-consumer capability exception, and `test/architecture/`
  guardrails.
- **Scaffolding**: use the `fst add-feature` CLI; leave the `# fst:` / `// fst:`
  wiring markers in place.
- **Codegen**: most generated output is git-ignored + regenerated, with the
  deliberate **ObjectBox exception** (`objectbox.g.dart` + `objectbox-model.json`
  are version-controlled for stable UIDs).
- **Conventions**: lint set, relative imports, BLoC/Freezed, get_it/injectable,
  go_router, localization package, submodule handling.
- **Flavors & env**, **iOS CocoaPods-not-SPM** rationale, **Go backend**
  submodule, **MCP servers**, and **agent skills** mappings.

## Notes

- Documentation only — no behavior change. CI should be green on analyze/test
  (no Dart touched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contributor guidance with clearer setup, build, testing, and release workflows.
  * Added more detailed instructions for running checks locally, including formatting, analysis, unit tests, and golden test handling.
  * Documented repository structure, feature scaffolding, code generation, environment flavors, and platform-specific build requirements.
  * Clarified integration/E2E test expectations and local verification steps for parity with CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->