### PR TITLE
feat: optional auth/backend pillars (--no-auth, --no-backend, --minimal)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,7 +371,7 @@ jobs:
               [ ! -d "$auth" ] || { echo "::error::auth package not removed (no-auth)"; fail=1; }
               [ ! -f "$profile_header" ] || { echo "::error::profile_header not removed (no-auth)"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks wrongly removed (no-auth)"; fail=1; }
-              if grep -rIq 'fst:auth' "$out/lib" "$out/test" 2>/dev/null; then
+              if grep -rIq 'fst:auth:' "$out/lib" "$out/test" "$out/packages" 2>/dev/null; then
                 echo "::error::fst:auth markers survived the strip (no-auth)"; fail=1
               fi
               ;;
@@ -380,8 +380,10 @@ jobs:
               [ ! -d "$network" ] || { echo "::error::network not removed ($CONFIG)"; fail=1; }
               [ ! -d "$syncconn" ] || { echo "::error::sync_connectivity_plus not removed ($CONFIG)"; fail=1; }
               [ ! -d "$bookmarks" ] || { echo "::error::bookmarks not removed ($CONFIG)"; fail=1; }
+              [ ! -d "$out/packages/features/collections" ] || { echo "::error::collections not removed ($CONFIG)"; fail=1; }
+              [ ! -d "$notifications" ] || { echo "::error::notifications not removed ($CONFIG)"; fail=1; }
               [ -d "$out/published/rev_sync" ] || { echo "::error::rev_sync wrongly removed ($CONFIG)"; fail=1; }
-              if grep -rIq 'fst:backend\|fst:auth' "$out/lib" "$out/test" 2>/dev/null; then
+              if grep -rIq 'fst:backend:\|fst:auth:' "$out/lib" "$out/test" "$out/packages" 2>/dev/null; then
                 echo "::error::fst markers survived the strip ($CONFIG)"; fail=1
               fi
               ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,11 @@ jobs:
             cli:
               - 'published/cli'
               - 'pubspec.yaml'
+              - 'analysis_options.yaml'
               - 'lib/app/**'
+              - 'lib/core/**'
+              - 'packages/features/profile/**'
+              - 'packages/features/splash/**'
               - 'test/widget_test.dart'
               - 'test/test_utils/**'
               - 'test/architecture/**'
@@ -260,19 +264,30 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
-  # Scaffold-drift smoke-test: runs the `fst` CLI's `create` against THIS
-  # checkout (via --template-path) and asserts the generated project is coherent.
-  # It catches the failure mode flutter analyze can't — the CLI and the template
-  # drifting apart (renamed/removed `fst:` markers, changed identifiers,
-  # restructured wiring). Pure Dart: no Flutter, no codegen, no network beyond
-  # the CLI's own pub get, so it's fast. Gated on the `cli` filter. Compile-level
-  # verification of the scaffold is intentionally out of scope — analyze-and-test
-  # already builds the template itself.
+  # Scaffold-drift smoke-test (matrix over optional-pillar configs): runs the
+  # `fst` CLI's `create` against THIS checkout (via --template-path) for each
+  # pillar combination and asserts the generated project is coherent. Catches
+  # the failure mode flutter analyze can't — the CLI and the template drifting
+  # apart (renamed/removed `fst:` markers, mis-scoped strips, changed wiring) —
+  # independently per config. Pure Dart: no Flutter, no codegen, so it's fast and
+  # the configs run in parallel. Gated on the `cli` filter. Compile-level
+  # verification of each strip is done locally / at release (the default template
+  # is compiled by analyze-and-test + the build jobs).
   cli-smoke:
-    name: CLI create smoke-test
+    name: CLI scaffold (${{ matrix.name }})
     needs: changes
     if: needs.changes.outputs.cli == 'true'
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: default, flags: '' }
+          - { name: exclude-notifications, flags: '--exclude-feature notifications' }
+          - { name: no-firebase, flags: '--no-firebase' }
+          - { name: no-auth, flags: '--no-auth' }
+          - { name: no-backend, flags: '--no-backend' }
+          - { name: minimal, flags: '--minimal' }
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -306,19 +321,18 @@ jobs:
             --template-path "$GITHUB_WORKSPACE" \
             --output-dir "$RUNNER_TEMP/smoke" \
             --no-setup \
-            --no-firebase \
-            --exclude-feature notifications
+            ${{ matrix.flags }}
 
       - name: Assert the scaffold is coherent
+        env:
+          CONFIG: ${{ matrix.name }}
         run: |
           out="$RUNNER_TEMP/smoke"
           fail=0
+
+          # ── Shared coherence checks (every config) ──
           grep -q '^name: smoke_app' "$out/pubspec.yaml" \
             || { echo "::error::pubspec not renamed to smoke_app"; fail=1; }
-          [ ! -d "$out/packages/features/notifications" ] \
-            || { echo "::error::excluded feature notifications not removed"; fail=1; }
-          [ -d "$out/packages/features/bookmarks" ] \
-            || { echo "::error::kept feature bookmarks missing"; fail=1; }
           [ ! -d "$out/published/cli" ] \
             || { echo "::error::dev submodule published/cli leaked"; fail=1; }
           [ ! -d "$out/simple_backend_server" ] \
@@ -329,9 +343,49 @@ jobs:
             || { echo "::error::no fresh git repo was initialised"; fail=1; }
           if grep -rIl 'flutter_starter_template\|lucistudio\|Luci Studio' \
               "$out/lib" "$out/pubspec.yaml" "$out/android" 2>/dev/null; then
-            echo "::error::template identifiers leaked into the scaffold"
-            fail=1
+            echo "::error::template identifiers leaked into the scaffold"; fail=1
           fi
+
+          auth="$out/packages/features/auth"
+          network="$out/packages/network"
+          syncconn="$out/packages/sync_connectivity_plus"
+          bookmarks="$out/packages/features/bookmarks"
+          notifications="$out/packages/features/notifications"
+          profile_header="$out/packages/features/profile/lib/src/presentation/widgets/profile_header.dart"
+
+          # ── Per-config structural assertions ──
+          case "$CONFIG" in
+            default)
+              [ -d "$auth" ] || { echo "::error::auth removed in default"; fail=1; }
+              [ -d "$bookmarks" ] || { echo "::error::bookmarks missing in default"; fail=1; }
+              ;;
+            exclude-notifications)
+              [ ! -d "$notifications" ] || { echo "::error::notifications not removed"; fail=1; }
+              [ -d "$bookmarks" ] || { echo "::error::bookmarks wrongly removed"; fail=1; }
+              ;;
+            no-firebase)
+              [ -d "$auth" ] || { echo "::error::auth removed in no-firebase"; fail=1; }
+              [ ! -f "$out/android/app/google-services.json" ] || { echo "::error::firebase config left in no-firebase"; fail=1; }
+              ;;
+            no-auth)
+              [ ! -d "$auth" ] || { echo "::error::auth package not removed (no-auth)"; fail=1; }
+              [ ! -f "$profile_header" ] || { echo "::error::profile_header not removed (no-auth)"; fail=1; }
+              [ -d "$bookmarks" ] || { echo "::error::bookmarks wrongly removed (no-auth)"; fail=1; }
+              if grep -rIq 'fst:auth' "$out/lib" "$out/test" 2>/dev/null; then
+                echo "::error::fst:auth markers survived the strip (no-auth)"; fail=1
+              fi
+              ;;
+            no-backend|minimal)
+              [ ! -d "$auth" ] || { echo "::error::auth not removed ($CONFIG)"; fail=1; }
+              [ ! -d "$network" ] || { echo "::error::network not removed ($CONFIG)"; fail=1; }
+              [ ! -d "$syncconn" ] || { echo "::error::sync_connectivity_plus not removed ($CONFIG)"; fail=1; }
+              [ ! -d "$bookmarks" ] || { echo "::error::bookmarks not removed ($CONFIG)"; fail=1; }
+              [ -d "$out/published/rev_sync" ] || { echo "::error::rev_sync wrongly removed ($CONFIG)"; fail=1; }
+              if grep -rIq 'fst:backend\|fst:auth' "$out/lib" "$out/test" 2>/dev/null; then
+                echo "::error::fst markers survived the strip ($CONFIG)"; fail=1
+              fi
+              ;;
+          esac
           exit $fail
 
   # Compile smoke-test: `flutter analyze` type-checks Dart but never assembles

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ To enable seamless local development and testing, this template is paired with a
   - [📁 Feature Slice (Clean Architecture)](#-feature-slice-clean-architecture)
   - [🪄 Scaffolding a New Feature](#-scaffolding-a-new-feature)
 - [🚀 Quick Start](#-quick-start)
+- [🧩 Optional Pillars / Choose Your Stack](#-optional-pillars--choose-your-stack)
 - [🧪 Testing & Code Quality](#-testing--code-quality)
 - [🔄 Git Workflow & PRs](#-git-workflow--prs)
 - [🔥 Firebase](#-firebase)
@@ -480,6 +481,62 @@ go run .                    # → http://localhost:8080
 ```bash
 fvm flutter run
 ```
+
+<br>
+
+## 🧩 Optional Pillars / Choose Your Stack
+
+The `fst create` command scaffolds the full template by default — offline-first
+sync, JWT auth, Firebase, and all three server-backed demo features. Pass flags
+at create time to strip any pillar you don't need; the result compiles cleanly
+with no leftover stubs.
+
+| Project shape | Command |
+|---|---|
+| Full offline-first app (default) | `fst create` |
+| Without Firebase | `fst create --no-firebase` |
+| Without auth (user-less app) | `fst create --no-auth` |
+| Fully local-only (no backend, no auth) | `fst create --no-backend` |
+| Minimal (local-only + no Firebase) | `fst create --minimal` |
+
+### Flags
+
+**`--no-firebase`** — Scaffolds without Firebase. `kFirebaseEnabled` is set to
+`false`, analytics and crash-reporting bindings become no-ops, the Firebase
+Android Gradle plugins are removed, and the native credential files are deleted.
+The app builds and runs with no Firebase project.
+
+**`--no-auth`** — Removes the auth pillar. Deletes
+`packages/features/auth`, strips auth-specific UI from `profile` (leaving a
+Settings screen with theme toggle and about only — the user header,
+change-password, delete-account, and sign-out actions are gone), and removes
+auth wiring from the router and DI graph. The splash screen waits its minimum
+display time then proceeds directly.
+
+**`--no-backend`** — Scaffolds a fully local-only app. This flag is a
+composite: it implies `--no-auth` (no server means no JWT), removes the three
+server-backed demo features (`bookmarks`, `collections`, `notifications`), and
+strips the `network` and `sync_connectivity_plus` packages along with the sync
+cursor store. The `rev_sync` engine itself **stays** — `database` entities use
+its types — but no sync runs. What remains: `home`, `profile` (Settings),
+`splash`, and on-device ObjectBox storage.
+
+**`--minimal`** — `--no-backend` + `--no-firebase`. The leanest possible
+scaffold: local-only, no Firebase, no accounts.
+
+**`--exclude-feature <name>`** — Drop individual server-backed demo features
+(`bookmarks`, `collections`, `notifications`) without removing the whole backend
+pillar. Repeatable. Excluding `collections` also excludes `bookmarks` (which
+depends on it).
+
+### Composition rules
+
+- `--no-backend` implies `--no-auth`.
+- `--minimal` = `--no-backend --no-firebase`.
+
+<br>
+
+---
 
 <br>
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,6 +20,13 @@ linter:
     lines_longer_than_80_chars: false
     cascade_invocations: false
     sort_pub_dependencies: false
+    # Optional-pillar strips (fst:auth, fst:sync, …) wrap widgets with a
+    # `Widget x = base; x = wrap(x); return …;` idiom. The marked reassignment is
+    # deleted in the stripped tree, leaving a single-assignment local — which
+    # these two stylistic rules would each flag (in one tree or the other). Off
+    # so the template and every stripped variant both lint clean.
+    prefer_final_locals: false
+    join_return_with_assignment: false
 
 analyzer:
   language:

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -54,7 +54,6 @@ class _AppState extends State<App> {
   late final DeepLinkState _deepLink;
   late final List<FeatureSyncController> _syncControllers;
   late final VideoPlayerService _videoPlayerService;
-  StreamSubscription<AuthState>? _authSub;
 
   @override
   void initState() {
@@ -64,7 +63,7 @@ class _AppState extends State<App> {
     _session = widget.session ?? AuthSession(_authBloc);
     final features = widget.features ?? enabledFeatures;
     final result = buildRouterWithDeepLink(
-      _authBloc,
+      _session,
       featureRoutes: [
         ...authRoutes,
         for (final f in features) ...f.routes,
@@ -79,13 +78,16 @@ class _AppState extends State<App> {
         .toList(growable: false);
     _videoPlayerService =
         widget.videoPlayerService ?? getIt<VideoPlayerService>();
-    _authSub = _authBloc.stream.listen(_onAuthChanged);
+    _session.addListener(_onSessionChanged);
   }
 
-  void _onAuthChanged(AuthState state) {
+  void _onSessionChanged() {
+    // Sync runs only for a settled, signed-in user — not while signing out or
+    // still restoring (both leave no active user).
+    final active = _session.currentUser != null && !_session.isSigningOut;
     for (final c in _syncControllers) {
       unawaited(
-        (state is AuthAuthenticated ? c.start() : c.stop()).catchError(
+        (active ? c.start() : c.stop()).catchError(
           (Object error, StackTrace stackTrace) {
             developer.log(
               'Feature sync lifecycle failed',
@@ -101,7 +103,7 @@ class _AppState extends State<App> {
 
   @override
   void dispose() {
-    _authSub?.cancel();
+    _session.removeListener(_onSessionChanged);
     for (final c in _syncControllers) {
       unawaited(
         c.stop().catchError((Object error, StackTrace stackTrace) {

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -4,7 +4,9 @@ import 'dart:developer' as developer;
 import 'package:analytics/analytics.dart';
 import 'package:app_platform/app_platform.dart';
 import 'package:app_ui/app_ui.dart';
+// fst:auth:start
 import 'package:feature_auth/feature_auth.dart';
+// fst:auth:end
 // fst:feature:notifications:start
 import 'package:feature_notifications/feature_notifications.dart';
 // fst:feature:notifications:end
@@ -12,7 +14,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:shared_contracts/shared_contracts.dart';
+// fst:auth:start
 import 'package:shared_ui/shared_ui.dart';
+// fst:auth:end
 import 'package:theme/theme.dart';
 
 import '../core/extensions/build_context_extensions.dart';
@@ -24,22 +28,26 @@ import 'router.dart';
 class App extends StatefulWidget {
   const App({
     super.key,
+    // fst:auth:start
     this.authBloc,
+    this.session,
+    // fst:auth:end
     this.themeBloc,
     this.features,
     this.navigatorObservers,
-    this.session,
     this.videoPlayerService,
   });
 
+  // fst:auth:start
   final AuthBloc? authBloc;
+  final Session? session;
+  // fst:auth:end
   final ThemeBloc? themeBloc;
 
   /// Optional feature overrides — primarily for testing. Defaults to
   /// [enabledFeatures] from `features.dart`.
   final List<FeatureModule>? features;
   final List<NavigatorObserver>? navigatorObservers;
-  final Session? session;
   final VideoPlayerService? videoPlayerService;
 
   @override
@@ -47,9 +55,11 @@ class App extends StatefulWidget {
 }
 
 class _AppState extends State<App> {
+  // fst:auth:start
   late final AuthBloc _authBloc;
+  // fst:auth:end
   late final ThemeBloc _themeBloc;
-  late final Session _session;
+  Session? _session;
   late final GoRouter _router;
   late final DeepLinkState _deepLink;
   late final List<FeatureSyncController> _syncControllers;
@@ -58,16 +68,26 @@ class _AppState extends State<App> {
   @override
   void initState() {
     super.initState();
+    // fst:auth:start
     _authBloc = widget.authBloc ?? getIt<AuthBloc>();
+    // fst:auth:end
     _themeBloc = widget.themeBloc ?? getIt<ThemeBloc>();
+    // fst:auth:start
     _session = widget.session ?? AuthSession(_authBloc);
+    // fst:auth:end
     final features = widget.features ?? enabledFeatures;
     final result = buildRouterWithDeepLink(
       _session,
       featureRoutes: [
+        // fst:auth:start
         ...authRoutes,
+        // fst:auth:end
         for (final f in features) ...f.routes,
       ],
+      // fst:auth:start
+      loginLocation: AuthRoutes.login,
+      registerLocation: AuthRoutes.register,
+      // fst:auth:end
       observers: widget.navigatorObservers ?? [getIt<AnalyticsRouteObserver>()],
     );
     _router = result.router;
@@ -78,13 +98,25 @@ class _AppState extends State<App> {
         .toList(growable: false);
     _videoPlayerService =
         widget.videoPlayerService ?? getIt<VideoPlayerService>();
-    _session.addListener(_onSessionChanged);
+    final session = _session;
+    if (session != null) {
+      session.addListener(_onSessionChanged);
+    } else {
+      // No auth pillar: nothing gates sync, so run it for the whole app.
+      _setSyncActive(active: true);
+    }
   }
 
   void _onSessionChanged() {
     // Sync runs only for a settled, signed-in user — not while signing out or
     // still restoring (both leave no active user).
-    final active = _session.currentUser != null && !_session.isSigningOut;
+    final session = _session!;
+    _setSyncActive(
+      active: session.currentUser != null && !session.isSigningOut,
+    );
+  }
+
+  void _setSyncActive({required bool active}) {
     for (final c in _syncControllers) {
       unawaited(
         (active ? c.start() : c.stop()).catchError(
@@ -103,7 +135,7 @@ class _AppState extends State<App> {
 
   @override
   void dispose() {
-    _session.removeListener(_onSessionChanged);
+    _session?.removeListener(_onSessionChanged);
     for (final c in _syncControllers) {
       unawaited(
         c.stop().catchError((Object error, StackTrace stackTrace) {
@@ -116,42 +148,42 @@ class _AppState extends State<App> {
         }),
       );
     }
-    _session.dispose();
+    _session?.dispose();
     _router.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
-    return DeepLinkScope(
-      deepLink: _deepLink,
-      child: SessionScope(
-        session: _session,
-        child: RepositoryProvider<VideoPlayerService>.value(
-          value: _videoPlayerService,
-          child: MultiBlocProvider(
-            providers: [
-              BlocProvider.value(value: _authBloc),
-              BlocProvider.value(value: _themeBloc),
-              // fst:feature:notifications:start
-              BlocProvider.value(value: getIt<NotificationsBloc>()),
-              // fst:feature:notifications:end
-            ],
-            child: BlocBuilder<ThemeBloc, ThemeState>(
-              builder: (context, themeState) => MaterialApp.router(
-                debugShowCheckedModeBanner: false,
-                onGenerateTitle: (context) => context.l10n.appTitle,
-                theme: AppTheme.light(scheme: themeState.scheme),
-                darkTheme: AppTheme.dark(scheme: themeState.scheme),
-                themeMode: themeState.mode,
-                localizationsDelegates: AppLocalizations.localizationsDelegates,
-                supportedLocales: AppLocalizations.supportedLocales,
-                routerConfig: _router,
-              ),
-            ),
+    Widget app = RepositoryProvider<VideoPlayerService>.value(
+      value: _videoPlayerService,
+      child: MultiBlocProvider(
+        providers: [
+          // fst:auth:start
+          BlocProvider.value(value: _authBloc),
+          // fst:auth:end
+          BlocProvider.value(value: _themeBloc),
+          // fst:feature:notifications:start
+          BlocProvider.value(value: getIt<NotificationsBloc>()),
+          // fst:feature:notifications:end
+        ],
+        child: BlocBuilder<ThemeBloc, ThemeState>(
+          builder: (context, themeState) => MaterialApp.router(
+            debugShowCheckedModeBanner: false,
+            onGenerateTitle: (context) => context.l10n.appTitle,
+            theme: AppTheme.light(scheme: themeState.scheme),
+            darkTheme: AppTheme.dark(scheme: themeState.scheme),
+            themeMode: themeState.mode,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            routerConfig: _router,
           ),
         ),
       ),
     );
+    // fst:auth:start
+    app = SessionScope(session: _session!, child: app);
+    // fst:auth:end
+    return DeepLinkScope(deepLink: _deepLink, child: app);
   }
 }

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -60,6 +60,9 @@ class _AppState extends State<App> {
   // fst:auth:end
   late final ThemeBloc _themeBloc;
   Session? _session;
+  // Whether this State created _session (and so must dispose it). An injected
+  // widget.session is owned by the caller and must outlive this widget.
+  bool _ownsSession = false;
   late final GoRouter _router;
   late final DeepLinkState _deepLink;
   late final List<FeatureSyncController> _syncControllers;
@@ -74,6 +77,7 @@ class _AppState extends State<App> {
     _themeBloc = widget.themeBloc ?? getIt<ThemeBloc>();
     // fst:auth:start
     _session = widget.session ?? AuthSession(_authBloc);
+    _ownsSession = widget.session == null;
     // fst:auth:end
     final features = widget.features ?? enabledFeatures;
     final result = buildRouterWithDeepLink(
@@ -148,7 +152,9 @@ class _AppState extends State<App> {
         }),
       );
     }
-    _session?.dispose();
+    if (_ownsSession) {
+      _session?.dispose();
+    }
     _router.dispose();
     super.dispose();
   }

--- a/lib/app/di/injection.dart
+++ b/lib/app/di/injection.dart
@@ -17,10 +17,14 @@ import 'package:feature_notifications/feature_notifications.dart';
 import 'package:feature_profile/feature_profile.dart';
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart';
+// fst:backend:start
 import 'package:network/network.dart';
+// fst:backend:end
 import 'package:shared_contracts/shared_contracts.dart';
 import 'package:storage/storage.dart';
+// fst:backend:start
 import 'package:sync_connectivity_plus/sync_connectivity_plus.dart';
+// fst:backend:end
 import 'package:theme/theme.dart';
 
 import 'injection.config.dart';
@@ -42,10 +46,14 @@ final GetIt getIt = GetIt.instance;
     ExternalModule(AnalyticsPackageModule),
     ExternalModule(ConfigPackageModule),
     ExternalModule(StoragePackageModule),
+    // fst:backend:start
     ExternalModule(NetworkPackageModule),
+    // fst:backend:end
     ExternalModule(AppPlatformPackageModule),
     ExternalModule(ThemePackageModule),
+    // fst:backend:start
     ExternalModule(SyncConnectivityPlusPackageModule),
+    // fst:backend:end
     ExternalModule(SharedContractsPackageModule),
     // fst:auth:start
     ExternalModule(FeatureAuthPackageModule),

--- a/lib/app/di/injection.dart
+++ b/lib/app/di/injection.dart
@@ -1,7 +1,9 @@
 import 'package:analytics/analytics.dart';
 import 'package:app_platform/app_platform.dart';
 import 'package:config/config.dart';
+// fst:auth:start
 import 'package:feature_auth/feature_auth.dart';
+// fst:auth:end
 // fst:feature:bookmarks:start
 import 'package:feature_bookmarks/feature_bookmarks.dart';
 // fst:feature:bookmarks:end
@@ -45,7 +47,9 @@ final GetIt getIt = GetIt.instance;
     ExternalModule(ThemePackageModule),
     ExternalModule(SyncConnectivityPlusPackageModule),
     ExternalModule(SharedContractsPackageModule),
+    // fst:auth:start
     ExternalModule(FeatureAuthPackageModule),
+    // fst:auth:end
     // fst:feature:notifications:start
     ExternalModule(FeatureNotificationsPackageModule),
     // fst:feature:notifications:end

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:feature_auth/feature_auth.dart';
 // fst:feature:bookmarks:start
 import 'package:feature_bookmarks/feature_bookmarks.dart';
@@ -12,6 +10,7 @@ import 'package:feature_profile/feature_profile.dart';
 import 'package:feature_splash/feature_splash.dart';
 import 'package:flutter/widgets.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_contracts/shared_contracts.dart';
 
 import 'widgets/app_shell.dart';
 
@@ -174,14 +173,14 @@ class DeepLinkScope extends InheritedWidget {
       deepLink != oldWidget.deepLink;
 }
 
-/// Builds the app router and wires auth redirects to [bloc] state changes.
+/// Builds the app router and wires auth redirects to [session] status changes.
 ///
 /// [featureRoutes] are the non-shell routes contributed by the feature
 /// packages (and auth's login/register). They are mounted alongside the
 /// generated shell routes ([$appRoutes]) so adding a feature's screens never
 /// edits this file — the feature ships its own route table.
 ({GoRouter router, DeepLinkState deepLink}) buildRouterWithDeepLink(
-  AuthBloc bloc, {
+  Session session, {
   required List<RouteBase> featureRoutes,
   List<NavigatorObserver>? observers,
 }) {
@@ -197,9 +196,9 @@ class DeepLinkScope extends InheritedWidget {
     // through splash / auth.
     routes: [...$appRoutes, ...featureRoutes],
     observers: observers,
-    refreshListenable: _BlocListenable(bloc.stream),
+    refreshListenable: session,
     redirect: (context, state) => resolveSplashRedirect(
-      auth: bloc.state,
+      status: session.status,
       location: state.matchedLocation,
       requestedUri: state.uri.toString(),
       deepLink: deepLink,
@@ -216,7 +215,7 @@ class DeepLinkScope extends InheritedWidget {
 /// Resolves the auth/splash redirect for a single navigation.
 ///
 /// Pure decision function behind [buildRouterWithDeepLink]'s `redirect`: given
-/// the current [auth] state, the [location] GoRouter matched, the
+/// the current session [status], the [location] GoRouter matched, the
 /// [requestedUri] the user is trying to reach, and the mutable [deepLink] gate,
 /// it returns the location to redirect to, or `null` to allow the navigation.
 /// Extracted so the three-phase state machine can be unit-tested without
@@ -226,7 +225,7 @@ class DeepLinkScope extends InheritedWidget {
 /// target before splash/auth, then replays it once the user is authenticated.
 @visibleForTesting
 String? resolveSplashRedirect({
-  required AuthState auth,
+  required SessionStatus status,
   required String location,
   required String requestedUri,
   required DeepLinkState deepLink,
@@ -250,7 +249,7 @@ String? resolveSplashRedirect({
 
   // ── Phase 2: Unauthenticated ──
   // Splash completed with no session, or user signed out.
-  if (auth is AuthInitial || auth is AuthFailure) {
+  if (status == SessionStatus.unauthenticated) {
     if (location == loginLocation || location == registerLocation) {
       return null;
     }
@@ -259,9 +258,9 @@ String? resolveSplashRedirect({
   }
 
   // ── Phase 3: Authenticated (incl. mid-sign-out) ──
-  // AuthSigningOut still holds a user; let the screen stay put until the op
-  // completes and AuthBloc emits AuthInitial.
-  if (auth is AuthAuthenticated || auth is AuthSigningOut) {
+  // A signing-out session still holds a user; let the screen stay put until the
+  // op completes and the session settles to unauthenticated.
+  if (status == SessionStatus.authenticated) {
     final target = deepLink.pendingRedirect;
     if (target != null) {
       deepLink.pendingRedirect = null;
@@ -277,22 +276,6 @@ String? resolveSplashRedirect({
     return null;
   }
 
-  // AuthSubmitting / AuthRestoring — don't interfere.
+  // SessionStatus.unknown — still restoring/submitting; don't interfere.
   return null;
-}
-
-/// Adapts a [Stream] to the [Listenable] contract GoRouter needs for
-/// `refreshListenable`.
-class _BlocListenable extends ChangeNotifier {
-  _BlocListenable(Stream<dynamic> stream) {
-    _subscription = stream.listen((_) => notifyListeners());
-  }
-
-  late final StreamSubscription<dynamic> _subscription;
-
-  @override
-  void dispose() {
-    _subscription.cancel();
-    super.dispose();
-  }
 }

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,4 +1,6 @@
+// fst:auth:start
 import 'package:feature_auth/feature_auth.dart';
+// fst:auth:end
 // fst:feature:bookmarks:start
 import 'package:feature_bookmarks/feature_bookmarks.dart';
 // fst:feature:bookmarks:end
@@ -49,10 +51,12 @@ part 'router.g.dart';
           path: '/profile',
           name: 'profile',
           routes: <TypedRoute<RouteData>>[
+            // fst:auth:start
             TypedGoRoute<ChangePasswordRoute>(
               path: 'change-password',
               name: 'change-password',
             ),
+            // fst:auth:end
           ],
         ),
       ],
@@ -128,6 +132,7 @@ class ProfileRoute extends GoRouteData with $ProfileRoute {
       const ProfileScreen();
 }
 
+// fst:auth:start
 class ChangePasswordRoute extends GoRouteData with $ChangePasswordRoute {
   const ChangePasswordRoute();
 
@@ -135,6 +140,7 @@ class ChangePasswordRoute extends GoRouteData with $ChangePasswordRoute {
   Widget build(BuildContext context, GoRouterState state) =>
       const ChangePasswordScreen();
 }
+// fst:auth:end
 
 // fst:feature:bookmarks:start
 class BookmarksListRoute extends GoRouteData with $BookmarksListRoute {
@@ -180,15 +186,15 @@ class DeepLinkScope extends InheritedWidget {
 /// generated shell routes ([$appRoutes]) so adding a feature's screens never
 /// edits this file — the feature ships its own route table.
 ({GoRouter router, DeepLinkState deepLink}) buildRouterWithDeepLink(
-  Session session, {
+  Session? session, {
   required List<RouteBase> featureRoutes,
+  String? loginLocation,
+  String? registerLocation,
   List<NavigatorObserver>? observers,
 }) {
   final deepLink = DeepLinkState();
   final homeLocation = const HomeRoute().location;
   final splashLocation = const SplashRoute().location;
-  const loginLocation = AuthRoutes.login;
-  const registerLocation = AuthRoutes.register;
 
   final router = GoRouter(
     // No initialLocation — GoRouter resolves the platform deep-link URI on
@@ -198,7 +204,7 @@ class DeepLinkScope extends InheritedWidget {
     observers: observers,
     refreshListenable: session,
     redirect: (context, state) => resolveSplashRedirect(
-      status: session.status,
+      status: session?.status,
       location: state.matchedLocation,
       requestedUri: state.uri.toString(),
       deepLink: deepLink,
@@ -225,14 +231,14 @@ class DeepLinkScope extends InheritedWidget {
 /// target before splash/auth, then replays it once the user is authenticated.
 @visibleForTesting
 String? resolveSplashRedirect({
-  required SessionStatus status,
+  required SessionStatus? status,
   required String location,
   required String requestedUri,
   required DeepLinkState deepLink,
   required String splashLocation,
-  required String loginLocation,
-  required String registerLocation,
   required String homeLocation,
+  String? loginLocation,
+  String? registerLocation,
 }) {
   // ── Phase 1: Before splash completes ──
   // Intercept every navigation until restoreSession and the splash minimum
@@ -245,6 +251,19 @@ String? resolveSplashRedirect({
     // through splash first.
     deepLink.pendingRedirect ??= requestedUri;
     return splashLocation;
+  }
+
+  // ── No auth pillar (status == null) ──
+  // Splash is the only gate: replay any captured deep link, bounce off splash
+  // to home, and otherwise allow the navigation.
+  if (status == null) {
+    final target = deepLink.pendingRedirect;
+    if (target != null) {
+      deepLink.pendingRedirect = null;
+      if (target != requestedUri) return target;
+    }
+    if (location == splashLocation) return homeLocation;
+    return null;
   }
 
   // ── Phase 2: Unauthenticated ──

--- a/packages/features/auth/lib/src/presentation/auth_session.dart
+++ b/packages/features/auth/lib/src/presentation/auth_session.dart
@@ -6,6 +6,18 @@ import 'package:shared_contracts/shared_contracts.dart';
 import 'bloc/auth_bloc.dart';
 import 'bloc/auth_state.dart';
 
+/// Maps an [AuthState] to the coarse [SessionStatus] the router reads.
+///
+/// A user is present (so [SessionStatus.authenticated]) while authenticated or
+/// signing out; the session is settled with no user (so
+/// [SessionStatus.unauthenticated]) on the initial/failed states; otherwise it
+/// is still settling ([SessionStatus.unknown]).
+SessionStatus sessionStatusFor(AuthState state) => switch (state) {
+  AuthAuthenticated() || AuthSigningOut() => SessionStatus.authenticated,
+  AuthInitial() || AuthFailure() => SessionStatus.unauthenticated,
+  AuthRestoring() || AuthSubmitting() => SessionStatus.unknown,
+};
+
 /// Adapts [AuthBloc] to the app-wide [Session] contract.
 ///
 /// Keeps [AuthBloc] as the single source of truth while exposing only the
@@ -27,6 +39,9 @@ class AuthSession extends ChangeNotifier implements Session {
 
   @override
   bool get isSigningOut => _bloc.state is AuthSigningOut;
+
+  @override
+  SessionStatus get status => sessionStatusFor(_bloc.state);
 
   @override
   Future<void> restore() async {

--- a/packages/features/profile/lib/src/presentation/screens/profile_screen.dart
+++ b/packages/features/profile/lib/src/presentation/screens/profile_screen.dart
@@ -1,7 +1,9 @@
+// fst:auth:start
 // Deliberate cross-feature capability import: profile surfaces auth's
 // delete-account flow. Single consumer, so it stays in auth rather than being
 // promoted to `shared` (see the capability exception in CLAUDE.md).
 import 'package:feature_auth/feature_auth.dart';
+// fst:auth:end
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -19,9 +21,11 @@ class ProfileScreen extends StatelessWidget {
         BlocProvider<ProfileBloc>(
           create: (_) => getIt<ProfileBloc>()..add(const ProfileLoaded()),
         ),
+        // fst:auth:start
         BlocProvider<DeleteAccountCubit>(
           create: (_) => getIt<DeleteAccountCubit>(),
         ),
+        // fst:auth:end
       ],
       child: const ProfileBody(),
     );

--- a/packages/features/profile/lib/src/presentation/widgets/profile_about.dart
+++ b/packages/features/profile/lib/src/presentation/widgets/profile_about.dart
@@ -79,4 +79,5 @@ class _SignOutButton extends StatelessWidget {
     }
   }
 }
+
 // fst:auth:end

--- a/packages/features/profile/lib/src/presentation/widgets/profile_about.dart
+++ b/packages/features/profile/lib/src/presentation/widgets/profile_about.dart
@@ -37,6 +37,7 @@ class _AppInfoTile extends StatelessWidget {
   }
 }
 
+// fst:auth:start
 class _SignOutButton extends StatelessWidget {
   const _SignOutButton();
 
@@ -78,3 +79,4 @@ class _SignOutButton extends StatelessWidget {
     }
   }
 }
+// fst:auth:end

--- a/packages/features/profile/lib/src/presentation/widgets/profile_widgets.dart
+++ b/packages/features/profile/lib/src/presentation/widgets/profile_widgets.dart
@@ -1,20 +1,26 @@
 import 'package:app_ui/app_ui.dart';
+// fst:auth:start
 // Deliberate cross-feature capability import: profile surfaces auth's
 // delete-account flow (see the capability exception in CLAUDE.md).
 import 'package:feature_auth/feature_auth.dart';
+// fst:auth:end
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:go_router/go_router.dart';
 import 'package:localization/localization.dart';
+// fst:auth:start
 import 'package:shared_ui/shared_ui.dart';
+// fst:auth:end
 import 'package:theme/theme.dart';
 
 import '../bloc/profile_bloc.dart';
 import '../bloc/profile_state.dart';
+// fst:auth:start
 part 'profile_header.dart';
 part 'profile_account.dart';
+// fst:auth:end
 part 'profile_appearance.dart';
 part 'profile_about.dart';
 
@@ -24,6 +30,7 @@ class ProfileBody extends StatelessWidget {
   /// Extra bottom padding so content clears the floating bottom bar.
   static const double _bottomInset = 96;
 
+  // fst:auth:start
   void _onDeleteAccountState(BuildContext context, DeleteAccountState state) {
     switch (state) {
       case DeleteAccountSuccess():
@@ -41,35 +48,44 @@ class ProfileBody extends StatelessWidget {
         break;
     }
   }
+  // fst:auth:end
 
   @override
   Widget build(BuildContext context) {
-    return BlocListener<DeleteAccountCubit, DeleteAccountState>(
-      listener: _onDeleteAccountState,
-      child: AppScaffold(
-        title: context.l10n.profileAppBarTitle,
-        padding: EdgeInsets.zero,
-        body: ListView(
-          padding: const EdgeInsets.fromLTRB(
-            AppSpacing.xl,
-            AppSpacing.lg,
-            AppSpacing.xl,
-            _bottomInset,
-          ),
-          children: [
-            const _ProfileHeader().animateSlideDown(),
-            const SizedBox(height: AppSpacing.lg),
-            const _AccountCard().animateSlideUp(delay: 120.ms),
-            const SizedBox(height: AppSpacing.lg),
-            const _AppearanceCard().animateSlideUp(delay: 200.ms),
-            const SizedBox(height: AppSpacing.lg),
-            const _AboutCard().animateSlideUp(delay: 280.ms),
-            const SizedBox(height: AppSpacing.xxl),
-            const _SignOutButton().animateFadeIn(delay: 360.ms),
-          ],
+    Widget body = AppScaffold(
+      title: context.l10n.profileAppBarTitle,
+      padding: EdgeInsets.zero,
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(
+          AppSpacing.xl,
+          AppSpacing.lg,
+          AppSpacing.xl,
+          _bottomInset,
         ),
+        children: [
+          // fst:auth:start
+          const _ProfileHeader().animateSlideDown(),
+          const SizedBox(height: AppSpacing.lg),
+          const _AccountCard().animateSlideUp(delay: 120.ms),
+          const SizedBox(height: AppSpacing.lg),
+          // fst:auth:end
+          const _AppearanceCard().animateSlideUp(delay: 200.ms),
+          const SizedBox(height: AppSpacing.lg),
+          const _AboutCard().animateSlideUp(delay: 280.ms),
+          // fst:auth:start
+          const SizedBox(height: AppSpacing.xxl),
+          const _SignOutButton().animateFadeIn(delay: 360.ms),
+          // fst:auth:end
+        ],
       ),
     );
+    // fst:auth:start
+    body = BlocListener<DeleteAccountCubit, DeleteAccountState>(
+      listener: _onDeleteAccountState,
+      child: body,
+    );
+    // fst:auth:end
+    return body;
   }
 }
 

--- a/packages/features/profile/pubspec.yaml
+++ b/packages/features/profile/pubspec.yaml
@@ -18,11 +18,15 @@ dependencies:
   architecture: ^0.1.0
   analytics: ^0.1.0
   app_ui: ^0.1.0
+  # fst:auth:start
   shared_ui: ^0.1.0
+  # fst:auth:end
   theme: ^0.1.0
   localization: ^0.1.0
+  # fst:auth:start
   # Capability: profile surfaces auth's delete-account flow (single consumer).
   feature_auth: ^0.1.0
+  # fst:auth:end
 
   # Third-party.
   flutter_bloc: ^9.1.1

--- a/packages/features/splash/lib/src/presentation/screens/splash_screen.dart
+++ b/packages/features/splash/lib/src/presentation/screens/splash_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+// fst:auth:start
 import 'package:shared_ui/shared_ui.dart';
+// fst:auth:end
 
 import '../widgets/splash_widgets.dart';
 
@@ -31,9 +33,10 @@ class _SplashScreenState extends State<SplashScreen> {
   }
 
   Future<void> _bootstrap() async {
-    final session = SessionScope.of(context);
     await Future.wait<void>([
-      session.restore(),
+      // fst:auth:start
+      SessionScope.of(context).restore(),
+      // fst:auth:end
       Future<void>.delayed(SplashScreen._minDisplay),
     ]);
     if (!mounted) return;

--- a/packages/features/splash/pubspec.yaml
+++ b/packages/features/splash/pubspec.yaml
@@ -16,7 +16,9 @@ dependencies:
 
   # Workspace packages.
   app_ui: ^0.1.0
+  # fst:auth:start
   shared_ui: ^0.1.0
+  # fst:auth:end
   localization: ^0.1.0
 
 dev_dependencies:

--- a/packages/shared_contracts/lib/src/session.dart
+++ b/packages/shared_contracts/lib/src/session.dart
@@ -2,6 +2,14 @@ import 'package:flutter/foundation.dart';
 
 import 'auth_user.dart';
 
+/// Coarse authentication status of the app-wide [Session].
+///
+/// Drives routing decisions (the splash/auth redirect) without exposing the
+/// auth feature's state machine. [unknown] means the session is still settling
+/// — restoring a persisted login or a sign-in in flight — and the router
+/// should not redirect yet.
+enum SessionStatus { unknown, authenticated, unauthenticated }
+
 /// Application-wide authenticated session, readable by any feature.
 ///
 /// Decouples feature UI from the auth feature's presentation layer: features
@@ -16,6 +24,13 @@ abstract interface class Session implements Listenable {
 
   /// Whether a sign-out is currently in progress.
   bool get isSigningOut;
+
+  /// Coarse authentication status, for routing decisions.
+  ///
+  /// [SessionStatus.authenticated] while a user is present (including during a
+  /// sign-out); [SessionStatus.unauthenticated] once restore settles with no
+  /// user; [SessionStatus.unknown] while still restoring or submitting.
+  SessionStatus get status;
 
   /// Restores any persisted login.
   ///

--- a/packages/test_utils/lib/src/mocks/shared_contracts_mocks.dart
+++ b/packages/test_utils/lib/src/mocks/shared_contracts_mocks.dart
@@ -19,7 +19,12 @@ class MockBookmarkSummariesReader extends Mock
 
 /// In-memory [Session] double for widget tests.
 class FakeSession extends ChangeNotifier implements Session {
-  FakeSession({this.currentUser, this.isSigningOut = false});
+  FakeSession({this.currentUser, this.isSigningOut = false, SessionStatus? status})
+    : status =
+          status ??
+          (currentUser != null
+              ? SessionStatus.authenticated
+              : SessionStatus.unauthenticated);
 
   @override
   AuthUser? currentUser;
@@ -28,12 +33,16 @@ class FakeSession extends ChangeNotifier implements Session {
   bool isSigningOut;
 
   @override
+  SessionStatus status;
+
+  @override
   Future<void> restore() async {}
 
   @override
   void signOut() {
     currentUser = null;
     isSigningOut = false;
+    status = SessionStatus.unauthenticated;
     notifyListeners();
   }
 
@@ -41,6 +50,7 @@ class FakeSession extends ChangeNotifier implements Session {
   void clearSession() {
     currentUser = null;
     isSigningOut = false;
+    status = SessionStatus.unauthenticated;
     notifyListeners();
   }
 }

--- a/packages/test_utils/lib/src/mocks/shared_contracts_mocks.dart
+++ b/packages/test_utils/lib/src/mocks/shared_contracts_mocks.dart
@@ -19,12 +19,15 @@ class MockBookmarkSummariesReader extends Mock
 
 /// In-memory [Session] double for widget tests.
 class FakeSession extends ChangeNotifier implements Session {
-  FakeSession({this.currentUser, this.isSigningOut = false, SessionStatus? status})
-    : status =
-          status ??
-          (currentUser != null
-              ? SessionStatus.authenticated
-              : SessionStatus.unauthenticated);
+  FakeSession({
+    this.currentUser,
+    this.isSigningOut = false,
+    SessionStatus? status,
+  }) : status =
+           status ??
+           (currentUser != null
+               ? SessionStatus.authenticated
+               : SessionStatus.unauthenticated);
 
   @override
   AuthUser? currentUser;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,10 +26,14 @@ workspace:
   - packages/analytics
   - packages/config
   - packages/architecture
+  # fst:backend:start
   - packages/network
+  # fst:backend:end
   - packages/app_platform
   - packages/storage
+  # fst:backend:start
   - packages/sync_connectivity_plus
+  # fst:backend:end
   - packages/theme
   - packages/test_utils
   - packages/shared_contracts
@@ -64,12 +68,16 @@ dependencies:
   analytics: ^0.1.0
   config: ^0.1.0
   architecture: ^0.1.0
+  # fst:backend:start
   network: ^0.1.0
+  # fst:backend:end
   app_platform: ^0.1.0
   storage: ^0.1.0
   rev_sync:
     path: published/rev_sync
+  # fst:backend:start
   sync_connectivity_plus: ^0.1.0
+  # fst:backend:end
   theme: ^0.1.0
   shared_contracts: ^0.1.0
   shared_ui: ^0.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,9 @@ workspace:
   - packages/shared_ui
   - packages/database
   - packages/localization
+  # fst:auth:start
   - packages/features/auth
+  # fst:auth:end
   # fst:feature:notifications:start
   - packages/features/notifications
   # fst:feature:notifications:end
@@ -73,7 +75,9 @@ dependencies:
   shared_ui: ^0.1.0
   database: ^0.1.0
   localization: ^0.1.0
+  # fst:auth:start
   feature_auth: ^0.1.0
+  # fst:auth:end
   # fst:feature:notifications:start
   feature_notifications: ^0.1.0
   # fst:feature:notifications:end

--- a/test/app/router_redirect_test.dart
+++ b/test/app/router_redirect_test.dart
@@ -295,4 +295,43 @@ void main() {
       );
     });
   });
+
+  group('no auth pillar — status null, splash is the only gate', () {
+    String? resolveNoAuth({
+      required String location,
+      required DeepLinkState deepLink,
+      String? requestedUri,
+    }) {
+      return resolveSplashRedirect(
+        status: null,
+        location: location,
+        requestedUri: requestedUri ?? location,
+        deepLink: deepLink,
+        splashLocation: splash,
+        homeLocation: home,
+      );
+    }
+
+    test('still forces splash before it completes, capturing the target', () {
+      final deepLink = gate();
+      expect(resolveNoAuth(location: home, deepLink: deepLink), splash);
+      expect(deepLink.pendingRedirect, home);
+    });
+
+    test('bounces off splash to home once completed', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(resolveNoAuth(location: splash, deepLink: deepLink), home);
+    });
+
+    test('replays a captured deep link', () {
+      final deepLink = gate(splashCompleted: true, pending: '/bookmarks');
+      expect(resolveNoAuth(location: splash, deepLink: deepLink), '/bookmarks');
+      expect(deepLink.pendingRedirect, isNull);
+    });
+
+    test('allows any route without an auth gate', () {
+      final deepLink = gate(splashCompleted: true);
+      expect(resolveNoAuth(location: '/bookmarks', deepLink: deepLink), isNull);
+    });
+  });
 }

--- a/test/app/router_redirect_test.dart
+++ b/test/app/router_redirect_test.dart
@@ -36,7 +36,7 @@ String? resolve({
   String? requestedUri,
 }) {
   return resolveSplashRedirect(
-    auth: auth,
+    status: sessionStatusFor(auth),
     location: location,
     requestedUri: requestedUri ?? location,
     deepLink: deepLink,

--- a/test/app/router_redirect_test.dart
+++ b/test/app/router_redirect_test.dart
@@ -9,16 +9,22 @@
 //   3. Splash done, authenticated — replay a captured deep link, otherwise
 //      bounce off splash/login/register to home and allow protected routes.
 
+// fst:auth:start
 import 'package:feature_auth/feature_auth.dart';
+// fst:auth:end
 import 'package:flutter_starter_template/app/router.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+// fst:auth:start
 import '../test_utils.dart';
+// fst:auth:end
 
 const splash = '/splash';
 const home = '/';
+// fst:auth:start
 const String login = AuthRoutes.login;
 const String register = AuthRoutes.register;
+// fst:auth:end
 
 /// Builds a fresh deep-link gate for one navigation.
 DeepLinkState gate({bool splashCompleted = false, String? pending}) {
@@ -27,6 +33,7 @@ DeepLinkState gate({bool splashCompleted = false, String? pending}) {
     ..pendingRedirect = pending;
 }
 
+// fst:auth:start
 /// Resolves a redirect with the app's real locations wired in. [requestedUri]
 /// defaults to [location] (the common case where they match).
 String? resolve({
@@ -46,8 +53,10 @@ String? resolve({
     homeLocation: home,
   );
 }
+// fst:auth:end
 
 void main() {
+  // fst:auth:start
   group('Phase 1 — before splash completes', () {
     test('stays on splash when already there, capturing nothing', () {
       final deepLink = gate();
@@ -295,6 +304,7 @@ void main() {
       );
     });
   });
+  // fst:auth:end
 
   group('no auth pillar — status null, splash is the only gate', () {
     String? resolveNoAuth({

--- a/test/architecture/feature_boundaries_test.dart
+++ b/test/architecture/feature_boundaries_test.dart
@@ -40,9 +40,11 @@ const _allowedCrossFeatureImports = <String, Set<String>>{
   // CLAUDE.md; promote to shared_ui if a second consumer appears.
   'feature_bookmarks': {'feature_collections'},
   // fst:feature:bookmarks:end
+  // fst:auth:start
   // profile surfaces auth's account-deletion flow (DeleteAccountCubit, single
   // consumer). See the DeleteAccountCubit worked example in CLAUDE.md.
   'feature_profile': {'feature_auth'},
+  // fst:auth:end
 };
 
 void main() {

--- a/test/architecture/package_layering_test.dart
+++ b/test/architecture/package_layering_test.dart
@@ -39,10 +39,14 @@ const _layers = <String, int>{
   'localization': 1, // gen-l10n AppLocalizations; no workspace package deps
   'shared_contracts': 1, // cross-feature domain contracts -> architecture
   'database': 1, // centralized ObjectBox persistence -> rev_sync
+  // fst:backend:start
   'sync_connectivity_plus': 1, // connectivity_plus adapter -> rev_sync
+  // fst:backend:end
   // 2 — composed infra built on the primitives.
   'shared_ui': 2, // cross-feature presentation contracts -> shared_contracts
+  // fst:backend:start
   'network': 2, // -> config
+  // fst:backend:end
   'app_platform': 2, // -> analytics, architecture
   'theme': 2, // -> analytics, architecture
   // 3 — shared test harness, sits on top of what it provides fakes for.

--- a/test/architecture/package_layering_test.dart
+++ b/test/architecture/package_layering_test.dart
@@ -49,7 +49,9 @@ const _layers = <String, int>{
   'test_utils': 3, // -> analytics, app_platform, storage
   // 4 — base feature packages: the top runtime layer (only the app composes
   //     them), each depending on no sibling feature.
+  // fst:auth:start
   'feature_auth': 4,
+  // fst:auth:end
   // fst:feature:collections:start
   'feature_collections': 4,
   // fst:feature:collections:end

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -1,17 +1,22 @@
 import 'package:bloc_test/bloc_test.dart';
+// fst:auth:start
 import 'package:feature_auth/src/domain/usecases/register.dart';
 import 'package:feature_auth/src/domain/usecases/restore_session.dart';
 import 'package:feature_auth/src/domain/usecases/sign_in.dart';
 import 'package:feature_auth/src/domain/usecases/sign_out.dart';
+// fst:auth:end
 // fst:feature:notifications:start
 import 'package:feature_notifications/feature_notifications.dart';
 // fst:feature:notifications:end
+// fst:auth:start
 import 'package:test_utils/test_utils.dart';
+// fst:auth:end
 
 /// Cross-feature mocks used only by the app-level `widget_test`. Feature-local
 /// mocks live in each feature package's own `test/support.dart`; shared doubles
 /// (`FakeSession`, readers) and fixtures come from `package:test_utils`.
 
+// fst:auth:start
 class MockSignIn extends Mock implements SignInUseCase {}
 
 class MockRegister extends Mock implements RegisterUseCase {}
@@ -19,6 +24,7 @@ class MockRegister extends Mock implements RegisterUseCase {}
 class MockSignOut extends Mock implements SignOutUseCase {}
 
 class MockRestoreSession extends Mock implements RestoreSessionUseCase {}
+// fst:auth:end
 
 // fst:feature:notifications:start
 class MockNotificationsBloc

--- a/test/test_utils/mocks.dart
+++ b/test/test_utils/mocks.dart
@@ -1,4 +1,6 @@
+// fst:feature:notifications:start
 import 'package:bloc_test/bloc_test.dart';
+// fst:feature:notifications:end
 // fst:auth:start
 import 'package:feature_auth/src/domain/usecases/register.dart';
 import 'package:feature_auth/src/domain/usecases/restore_session.dart';
@@ -12,11 +14,11 @@ import 'package:feature_notifications/feature_notifications.dart';
 import 'package:test_utils/test_utils.dart';
 // fst:auth:end
 
+// fst:auth:start
 /// Cross-feature mocks used only by the app-level `widget_test`. Feature-local
 /// mocks live in each feature package's own `test/support.dart`; shared doubles
 /// (`FakeSession`, readers) and fixtures come from `package:test_utils`.
 
-// fst:auth:start
 class MockSignIn extends Mock implements SignInUseCase {}
 
 class MockRegister extends Mock implements RegisterUseCase {}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,15 +1,21 @@
 import 'package:architecture/architecture.dart';
+// fst:auth:start
 import 'package:checks/checks.dart';
 import 'package:feature_auth/src/presentation/bloc/auth_bloc.dart';
 import 'package:feature_auth/src/presentation/bloc/auth_state.dart';
+// fst:auth:end
 import 'package:feature_home/feature_home.dart';
 // fst:feature:notifications:start
 import 'package:feature_notifications/feature_notifications.dart';
 // fst:feature:notifications:end
+// fst:auth:start
 import 'package:flutter/material.dart';
 import 'package:flutter_starter_template/app/app.dart';
+// fst:auth:end
 import 'package:flutter_starter_template/app/di/injection.dart';
+// fst:auth:start
 import 'package:flutter_starter_template/app/feature_module.dart';
+// fst:auth:end
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_contracts/shared_contracts.dart';
 import 'package:storage/storage.dart';
@@ -17,6 +23,7 @@ import 'package:theme/theme.dart';
 
 import 'test_utils.dart';
 
+// fst:auth:start
 final class _NoOpSyncModule extends FeatureModule {
   @override
   FeatureSyncController get syncController => _NoOpSync();
@@ -28,10 +35,13 @@ final class _NoOpSync implements FeatureSyncController {
   @override
   Future<void> stop() async {}
 }
+// fst:auth:end
 
 void main() {
   late MockAnalyticsService analytics;
+  // fst:auth:start
   late AuthBloc authBloc;
+  // fst:auth:end
   late ThemeBloc themeBloc;
   HomeBloc? homeBloc;
 
@@ -41,6 +51,7 @@ void main() {
     analytics = MockAnalyticsService();
     stubAnalyticsService(analytics);
 
+    // fst:auth:start
     final signIn = MockSignIn();
     when(() => signIn((username: 'alice', password: 'hunter2'))).thenAnswer((
       _,
@@ -55,6 +66,7 @@ void main() {
 
     final signOut = MockSignOut();
     when(signOut.call).thenAnswer((_) async => const Ok(null));
+    // fst:auth:end
 
     final bookmarkStats = MockBookmarkStatsReader();
     when(
@@ -66,6 +78,7 @@ void main() {
       collectionsReader.call,
     ).thenAnswer((_) async => const Ok<List<CollectionSummary>>([]));
 
+    // fst:auth:start
     authBloc = AuthBloc(
       signIn: signIn,
       register: MockRegister(),
@@ -73,6 +86,7 @@ void main() {
       restoreSession: restoreSession,
       analytics: analytics,
     );
+    // fst:auth:end
     themeBloc = ThemeBloc(await SharedPreferences.getInstance(), analytics);
 
     getIt.registerFactory<HomeBloc>(() {
@@ -95,9 +109,12 @@ void main() {
       await bloc.close();
     }
     await themeBloc.close();
+    // fst:auth:start
     await authBloc.close();
+    // fst:auth:end
   });
 
+  // fst:auth:start
   testWidgets('signs in and lands on home screen', (tester) async {
     await tester.pumpWidget(
       App(
@@ -148,4 +165,5 @@ void main() {
       'alice',
     );
   });
+  // fst:auth:end
 }


### PR DESCRIPTION
Makes the **auth / backend / sync** pillars independently optional so the
template serves many project shapes — a full offline-first app, a no-account
app, a pure local-only app — selected at `fst create` time. This is the "P0
spine" of the composability work.

## What changed
- **Session seam** — the router and app shell now gate on a new `Session.status`
  (`SessionStatus` enum in `shared_contracts`) instead of `AuthBloc`/`AuthState`,
  so auth can be removed cleanly.
- **`--no-auth`** — `fst:auth` marker regions across the app shell, DI, `profile`,
  `splash`, and tests; the CLI's `disableAuth` strips them. `profile` is trimmed
  to a Settings screen (theme + about); the app becomes user-less.
- **`--no-backend` / `--minimal`** — `fst:backend` regions for `network` +
  `sync_connectivity_plus`. `--no-backend` is a composite: it implies `--no-auth`
  and drops the server-backed demo features (bookmarks/collections/notifications)
  for a local-only ObjectBox app. `rev_sync` **stays** (the `database` entities
  use its types). `--minimal` = `--no-backend --no-firebase`.
- **CI** — the `cli-smoke` job is matrixed over 6 pillar configs (default,
  exclude-notifications, no-firebase, no-auth, no-backend, minimal), scaffolding
  each from this checkout via `--template-path` and asserting it's structurally
  coherent.
- **Docs** — README "Optional Pillars / Choose Your Stack".

## Verification
- Default tree: `flutter analyze` clean, 36 app tests, 99 CLI tests.
- Each strip (`--no-auth` alone, the `--no-backend` composite) was verified on a
  real copy: strip → `build_runner` → `flutter analyze` clean → tests pass — and
  end-to-end via a real `fst create --template-path … --no-backend`.

## Reviewer notes / merge order ⚠️
- Depends on **kido-luci/flutter-starter-template-cli#14**, which is itself
  stacked on cli#13 (`--template-path`). This branch bumps the `published/cli`
  submodule pointer `ff91a2b → 82e4f67` (the 3 new cli commits).
- **After cli#14 squash-merges**, re-point `published/cli` to the new squashed
  SHA (a squash orphans `82e4f67`) before this PR's `cli-smoke` CI will pass
  against cli `main`.
- `prefer_final_locals` + `join_return_with_assignment` are disabled in
  `analysis_options.yaml`: the conditional-wrap strip idiom (`Widget x = base;
  x = wrap(x);`) trips them in one tree or the other.
- `--no-sync` from the original plan was folded into `--no-backend` (the demo
  features are offline-first, so "backend without sync" isn't a clean strip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `fst create` now supports optional scaffold pillars (no Firebase, no auth, no backend, minimal) and `--exclude-feature` for omitting demo/server-backed features.
  * Added a **change-password** route under the profile area.
* **Bug Fixes**
  * Improved splash/auth routing behavior using unified session state, including consistent deep-link capture/replay.
  * Enhanced scaffold validation to catch missing content and leaked template markers.
* **Documentation**
  * Updated the README with a new “Choose Your Stack” section and detailed flag combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->