### PR TITLE
chore(release): 1.8.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.7.0+1
+version: 1.8.0+1
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Release 1.8.0. Bumps the app version and re-points `published/cli` to the released CLI 1.2.0 (#17).

Bundles the composable-pillar work (`--no-auth` / `--no-backend` / `--minimal`) and the P1 project-shape knobs (`add-feature --source`, `create --scheme/--seed-color/--font`, `--auth-provider`). Pointer + version bump only; `cli-smoke` CI exercises the matrix against the released cli main. Tag `v1.8.0` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)