### PR TITLE
feat(ios): add app-level Privacy Manifest (FST-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,21 @@ After that, the normal CocoaPods flow works (`fvm flutter clean`,
 support Swift Package Manager" warning printed during `pub get`/build is then
 harmless.
 
+## iOS: Privacy Manifest
+
+`ios/Runner/PrivacyInfo.xcprivacy` is the **app-level** privacy manifest, wired
+into the Runner target's resources. Apple rejects uploads without it
+(`ITMS-91053: Missing API declarations`). Firebase and other pods ship their own
+manifests, so this file only covers the app target and the statically-linked
+Flutter plugins that don't provide one — currently the required-reason APIs
+`UserDefaults` (CA92.1), `FileTimestamp` (C617.1), `DiskSpace` (E174.1), and
+`SystemBootTime` (35F9.1).
+
+When you add a plugin that uses a required-reason API or collects/links user
+data, update this file: add the `NSPrivacyAccessedAPICategory*` entry (with a
+valid reason code) or extend `NSPrivacyCollectedDataTypes`. If an ad/attribution
+SDK is added, flip `NSPrivacyTracking` to `true` and list the tracking domains.
+
 ## Common commands
 
 ```bash

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
+		AABBCCDD0000000000000F12 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AABBCCDD0000000000000F11 /* PrivacyInfo.xcprivacy */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		CD53E6E87CB61FDE53EFB4CC /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 116EA6F9229D877A97BBA2B8 /* Pods_Runner.framework */; };
 		EFE5836B7CE6A728731EBFC2 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CF106E28D94277580329D16D /* Pods_RunnerTests.framework */; };
@@ -82,6 +83,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AABBCCDD0000000000000F11 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A1B2C3D4E5F60718293A4B5C /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Profile.xcconfig; path = Flutter/Profile.xcconfig; sourceTree = "<group>"; };
 		A2B0D428A3A2482457F510EC /* Pods-RunnerTests.profile-prod.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile-prod.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile-prod.xcconfig"; sourceTree = "<group>"; };
 		B51D9DE5CB7A6E0A92C99350 /* Pods-RunnerTests.release-dev.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release-dev.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release-dev.xcconfig"; sourceTree = "<group>"; };
@@ -222,6 +224,7 @@
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
 				97C147021CF9000F007C117D /* Info.plist */,
+				AABBCCDD0000000000000F11 /* PrivacyInfo.xcprivacy */,
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
@@ -339,6 +342,7 @@
 				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
 				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
 				7873E7F207EE57DB5F60845D /* GoogleService-Info.plist in Resources */,
+				AABBCCDD0000000000000F12 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/Runner/PrivacyInfo.xcprivacy
+++ b/ios/Runner/PrivacyInfo.xcprivacy
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!-- App-level privacy manifest. Third-party SDKs (Firebase, GoogleUtilities,
+	     …) ship their own PrivacyInfo.xcprivacy inside their pods and are not
+	     repeated here. This file covers the app target and the statically-linked
+	     Flutter plugins that do not provide a manifest of their own. -->
+
+	<!-- The app itself performs no tracking. Flip to <true/> and populate
+	     NSPrivacyTrackingDomains when an ad or attribution SDK is added
+	     (roadmap FST-21, ads pillar). -->
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+
+	<!-- Data the app's own code collects is empty: analytics / crash / messaging
+	     data is declared by the Firebase SDK manifests, not here. -->
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+
+	<!-- Required-reason APIs used by statically-linked plugins that ship no
+	     manifest of their own. Add a category here when a new plugin uses one. -->
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<!-- shared_preferences_foundation reads/writes the app's own NSUserDefaults. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+		<!-- sqflite_darwin / objectbox_flutter_libs / path_provider read file
+		     modification timestamps inside the app container. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<!-- ObjectBox / SQLite check available disk space before writing. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>E174.1</string>
+			</array>
+		</dict>
+		<!-- System boot time, used to measure elapsed time on-device. -->
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>35F9.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## What & why

App Store Connect **rejects every upload without an app-level
`PrivacyInfo.xcprivacy`** (`ITMS-91053: Missing API declarations`, enforced since
Spring 2024). The template had none at the Runner-target level — only the
third-party pods shipped their own — so every app scaffolded from it would hit
this rejection on its first iOS upload.

This adds `ios/Runner/PrivacyInfo.xcprivacy` and wires it into the Runner
target's resources (file reference + group + resources build phase) so it lands
at the root of `Runner.app`, where Apple expects the app-level manifest.

## What it declares

Firebase / GoogleUtilities / and most Flutter plugins ship their **own** privacy
bundles (verified in the built `.app`), so they are **not** duplicated here. The
app-level manifest only covers the app target and the statically-linked plugins
that ship no manifest of their own:

| Required-reason API | Reason | Justified by |
|---|---|---|
| `UserDefaults` | `CA92.1` | app's own `NSUserDefaults` / plugins |
| `FileTimestamp` | `C617.1` | **`objectbox_flutter_libs`** (ships no manifest) + SQLite |
| `DiskSpace` | `E174.1` | **`objectbox_flutter_libs`** / SQLite pre-write checks |
| `SystemBootTime` | `35F9.1` | elapsed-time measurement (networking baseline) |

`objectbox_flutter_libs` is the one plugin in the dependency set that does **not**
ship its own manifest, which is what makes the app-level `FileTimestamp` /
`DiskSpace` declarations genuinely required. The app collects no data directly
(analytics / crash / messaging are declared by the Firebase SDK manifests) and
performs no tracking, so `NSPrivacyTracking=false`, `NSPrivacyTrackingDomains`
and `NSPrivacyCollectedDataTypes` are empty. `CLAUDE.md` documents the rule for
updating this file when a new plugin adds a required-reason API or an ad/
attribution SDK is introduced.

## Verification

- `plutil -lint` passes on the manifest and on `project.pbxproj`.
- `xcodebuild -list` parses the project cleanly (no dangling references).
- `fvm flutter build ios --no-codesign` succeeds, and the manifest bundles at the
  correct location: `build/ios/iphoneos/Runner.app/PrivacyInfo.xcprivacy` (app
  root, not inside a sub-framework).

> Note: a full App Store Connect upload validation (the definitive ITMS-91053
> check) requires signing + an account and was not run here; the structural
> requirement — the manifest present and correct in the app bundle — is verified.

## Context

First ticket (**FST-1**) of the agreed optimization roadmap, Sprint 1 — making
the create→ship-to-store pipeline work repeatably for new apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an iOS privacy manifest to the app, declaring its data handling and tracking settings.
  * Documented which privacy-related settings need updating when new plugins or data collection features are added.
  * Included the privacy manifest in the app package so it ships with releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->