### PR TITLE
feat(ios): make permission usage strings generic & app-name-aware (FST-2)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -76,12 +76,12 @@
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>NSCameraUsageDescription</key>
-	<string>This app requires camera access to take photos and videos for your bookmarks.</string>
+	<string>$(APP_DISPLAY_NAME) uses the camera to let you take photos and videos.</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>This app requires microphone access to record audio when capturing video for bookmarks.</string>
+	<string>$(APP_DISPLAY_NAME) uses the microphone to record audio while capturing video.</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>This app requires photo library access to let you select images and videos for bookmarks.</string>
+	<string>$(APP_DISPLAY_NAME) accesses your photo library so you can choose images and videos.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
-	<string>This app requires write access to the photo library to save captured media.</string>
+	<string>$(APP_DISPLAY_NAME) saves images and videos to your photo library.</string>
 </dict>
 </plist>

--- a/test/architecture/ios_permission_strings_test.dart
+++ b/test/architecture/ios_permission_strings_test.dart
@@ -1,0 +1,107 @@
+// Architecture guardrail: keeps the iOS permission usage descriptions generic
+// and app-name-aware, so every project scaffolded from this template ships
+// correct copy instead of the template's own demo-feature wording.
+//
+// The `fst` CLI rewrites the iOS display name (the APP_DISPLAY_NAME build
+// setting in `ios/Flutter/*.xcconfig`) but does NOT touch these strings. So a
+// usage description must not name a template-specific feature (e.g.
+// "bookmarks") and should interpolate the app name via the
+// `$(APP_DISPLAY_NAME)` build setting — which Xcode resolves at build time —
+// rather than hardcoding "This app".
+//
+// Pure file-scan, no third-party dependency, runs in the normal
+// `fvm flutter test` / CI flow.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final infoPlist = File('ios/Runner/Info.plist');
+
+  test('ios/Runner/Info.plist exists (run from the repository root)', () {
+    expect(
+      infoPlist.existsSync(),
+      isTrue,
+      reason:
+          'Expected to find ios/Runner/Info.plist relative to the current '
+          'directory. Run this test from the repository root.',
+    );
+  });
+
+  // The permission usage-description keys whose copy must stay generic.
+  const usageKeys = <String>[
+    'NSCameraUsageDescription',
+    'NSMicrophoneUsageDescription',
+    'NSPhotoLibraryUsageDescription',
+    'NSPhotoLibraryAddUsageDescription',
+  ];
+
+  // Words tied to the template's own demo features — copy that would be wrong
+  // for an app scaffolded from this template.
+  const bannedTerms = <String>['bookmark', 'collection'];
+
+  final descriptions = _usageDescriptions(infoPlist);
+
+  test('every declared usage description is present and non-empty', () {
+    for (final key in usageKeys) {
+      expect(
+        descriptions[key]?.trim().isNotEmpty ?? false,
+        isTrue,
+        reason: '$key is missing or empty in ios/Runner/Info.plist.',
+      );
+    }
+  });
+
+  test('usage descriptions name no template-specific demo feature', () {
+    final offenders = <String>[];
+    descriptions.forEach((key, value) {
+      final lower = value.toLowerCase();
+      for (final term in bannedTerms) {
+        if (lower.contains(term)) {
+          offenders.add('$key mentions "$term": "$value"');
+        }
+      }
+    });
+    expect(
+      offenders,
+      isEmpty,
+      reason:
+          'iOS permission strings must be generic so scaffolded apps inherit '
+          'correct copy. Remove the feature-specific wording:\n\n'
+          '${offenders.join('\n')}',
+    );
+  });
+
+  test(
+    r'usage descriptions interpolate the app name via $(APP_DISPLAY_NAME)',
+    () {
+      final missing = usageKeys.where((key) {
+        final value = descriptions[key] ?? '';
+        return !value.contains(r'$(APP_DISPLAY_NAME)');
+      }).toList();
+      expect(
+        missing,
+        isEmpty,
+        reason:
+            'Interpolate APP_DISPLAY_NAME (the build setting the CLI rewrites, '
+            'not these strings) so the copy resolves to the app name at build '
+            'time. Missing in:\n\n${missing.map((k) => '  $k').join('\n')}',
+      );
+    },
+  );
+}
+
+/// Extracts the `<key>NS…UsageDescription</key><string>…</string>` pairs from
+/// the Info.plist as a map. A deliberately small regex scan — enough to assert
+/// on the usage-description copy without pulling in a full plist parser.
+Map<String, String> _usageDescriptions(File infoPlist) {
+  final xml = infoPlist.readAsStringSync();
+  final pattern = RegExp(
+    r'<key>(NS\w*UsageDescription)</key>\s*<string>(.*?)</string>',
+    dotAll: true,
+  );
+  return {
+    for (final m in pattern.allMatches(xml)) m.group(1)!: m.group(2)!,
+  };
+}

--- a/test/architecture/ios_permission_strings_test.dart
+++ b/test/architecture/ios_permission_strings_test.dart
@@ -18,6 +18,18 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   final infoPlist = File('ios/Runner/Info.plist');
+  late final Map<String, String> descriptions;
+
+  setUpAll(() {
+    expect(
+      infoPlist.existsSync(),
+      isTrue,
+      reason:
+          'Expected to find ios/Runner/Info.plist relative to the current '
+          'directory. Run this test from the repository root.',
+    );
+    descriptions = _usageDescriptions(infoPlist);
+  });
 
   test('ios/Runner/Info.plist exists (run from the repository root)', () {
     expect(
@@ -40,8 +52,6 @@ void main() {
   // Words tied to the template's own demo features — copy that would be wrong
   // for an app scaffolded from this template.
   const bannedTerms = <String>['bookmark', 'collection'];
-
-  final descriptions = _usageDescriptions(infoPlist);
 
   test('every declared usage description is present and non-empty', () {
     for (final key in usageKeys) {


### PR DESCRIPTION
## What & why

The iOS permission usage descriptions hardcoded the template's own **bookmarks**
feature:

> "This app requires camera access to take photos and videos **for your
> bookmarks**."

Every app scaffolded from the template inherited this copy verbatim — so an
e-commerce, fitness, or social app would ship (and submit for review) permission
prompts referencing a feature it doesn't have.

This rewrites the four `NS*UsageDescription` strings to be generic and
**app-name-aware**, interpolating the app name via `$(APP_DISPLAY_NAME)` — the
same build setting the project already uses for `CFBundleDisplayName` and that
the `fst` CLI already rewrites at scaffold time. So a scaffolded
`fst create --name "My App"` produces *"My App uses the camera to let you take
photos and videos."* with **no CLI change required**.

| Key | After |
|---|---|
| `NSCameraUsageDescription` | `$(APP_DISPLAY_NAME) uses the camera to let you take photos and videos.` |
| `NSMicrophoneUsageDescription` | `$(APP_DISPLAY_NAME) uses the microphone to record audio while capturing video.` |
| `NSPhotoLibraryUsageDescription` | `$(APP_DISPLAY_NAME) accesses your photo library so you can choose images and videos.` |
| `NSPhotoLibraryAddUsageDescription` | `$(APP_DISPLAY_NAME) saves images and videos to your photo library.` |

## Guardrail test

`test/architecture/ios_permission_strings_test.dart` (pure file-scan, runs in the
normal `flutter test` / CI flow) asserts the usage descriptions (a) name no
template-specific demo feature (`bookmark` / `collection`) and (b) interpolate
`$(APP_DISPLAY_NAME)`, so the hardcoded copy can't creep back.

## Verification

- `flutter analyze` clean; the 4 guardrail tests pass.
- **prod-flavor build** (`flutter build ios --flavor prod
  --dart-define-from-file=env/prod.json --no-codesign`) resolves the strings
  correctly in the built `Runner.app/Info.plist`:
  *"Flutter Starter uses the camera to let you take photos and videos."* — and no
  `bookmark` literal survives.

> The flavorless `flutter build ios` leaves the name blank because
> `APP_DISPLAY_NAME` is defined per flavor (dev/staging/prod) — the same as
> `CFBundleDisplayName`; a flavorless build has no app identity in this template
> and is not a shipping configuration.

## Scope

Focuses on de-hardcoding the copy. The roadmap AC's *pillar-aware permission-key
stripping* (drop camera/photo keys when the media-using feature is removed)
needs CLI/submodule work and is intentionally deferred to a follow-up.

Sprint 1 ticket **FST-2** of the optimization roadmap (store-readiness for
scaffolded apps). Independent of #174 (FST-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated iOS permission prompts to use the app’s display name and clearer, more general descriptions for camera, microphone, and photo library access.
  * Improved the wording shown to users when the app requests permission to capture, select, or save media.

* **Chores**
  * Added automated checks to keep these iOS permission messages consistent and user-friendly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->