### PR TITLE
test(ci): include ios/ in the cli-smoke template-identifier guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,7 +342,7 @@ jobs:
           [ -d "$out/.git" ] \
             || { echo "::error::no fresh git repo was initialised"; fail=1; }
           if grep -rIl 'flutter_starter_template\|lucistudio\|Luci Studio' \
-              "$out/lib" "$out/pubspec.yaml" "$out/android" 2>/dev/null; then
+              "$out/lib" "$out/pubspec.yaml" "$out/android" "$out/ios" 2>/dev/null; then
             echo "::error::template identifiers leaked into the scaffold"; fail=1
           fi
 


### PR DESCRIPTION
## What & why

The scaffold-drift **cli-smoke** job greps a freshly-scaffolded project for
leaked template identifiers (`flutter_starter_template` / `lucistudio` /
`Luci Studio`), but only across `lib/`, `pubspec.yaml`, and `android/` — **not
`ios/`**. This adds `"$out/ios"` to that grep so a future template change that
reintroduces a hardcoded bundle id / package name / org into the iOS project
(`Info.plist`, `project.pbxproj`, `fastlane/`) is caught by CI.

## Context

Surfaced while investigating roadmap ticket **FST-3** (CLI Fastlane rewrite),
which turned out to be **already solved**: the CLI rewriter walks *every* text
file (no fixed allow-list), so the iOS bundle id is already substituted in the
Fastlane `.env.example`. This guard closes the one coverage gap that
investigation revealed — the smoke-test simply wasn't checking `ios/`.

## Verification

Scaffolded a project from the current checkout
(`--template-path`, `--bundle-id com.example.smoke`) and confirmed `ios/` has
zero matches for the guarded pattern — so the assertion passes today and only
fires on a real future regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
