### PR TITLE
feat(release): add App Store / Play production lanes + metadata (FST-4)

### DIFF
--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -1,16 +1,17 @@
-# Fastfile — Android build + Google Play upload for the flavored Flutter app.
+# Fastfile — Android build + Google Play delivery for the flavored Flutter app.
 #
 # This is a template/scaffold: every account-specific value is read from the
 # environment (see fastlane/.env.example), so the repo carries no secrets and
 # no project-specific identifiers. Fill in fastlane/.env, then run:
 #
-#   bundle exec fastlane beta flavor:prod
+#   bundle exec fastlane beta    flavor:prod   # → internal testing track (draft)
+#   bundle exec fastlane release flavor:prod   # → production, staged rollout
 #
 # Authentication uses a Google Play service-account JSON key. Release signing
 # is configured separately via android/key.properties (see ../app/build.gradle.kts).
 
 # Map a Flutter flavor to the applicationId suffix this template applies and
-# the default Play track to publish to (prod uses the base id, no suffix).
+# the default Play track the `beta` lane publishes to (prod uses the base id).
 FLAVORS = {
   "dev"     => { suffix: ".dev",     track: "internal" },
   "staging" => { suffix: ".staging", track: "internal" },
@@ -50,46 +51,82 @@ def flutter(*args)
   end
 end
 
+# Build a flavor's release app bundle (.aab). Shared by the `beta` and
+# `release` lanes. Returns the resolved package name, the path to the bundle,
+# and the flavor's config.
+def build_appbundle(options)
+  flavor = (options[:flavor] || "prod").to_s
+  config = FLAVORS.fetch(flavor) do
+    UI.user_error!(
+      "Unknown flavor '#{flavor}'. Expected one of: #{FLAVORS.keys.join(', ')}."
+    )
+  end
+
+  package_name = "#{require_env('ANDROID_PACKAGE_NAME_BASE')}#{config[:suffix]}"
+  build_number = resolve_build_number(options)
+
+  # Requires release signing configured via android/key.properties; without it
+  # the bundle is debug-signed and Play will reject it. The dart-define file
+  # carries the flavor's runtime config (API URL, FLAVOR, etc.) read via
+  # String.fromEnvironment — without it the build ships default/empty config.
+  flutter(
+    "build", "appbundle", "--release",
+    "--flavor", flavor, "--build-number", build_number,
+    "--dart-define-from-file", "env/#{flavor}.json"
+  )
+
+  # Output path is relative to android/ (fastlane's working directory).
+  aab = "../build/app/outputs/bundle/" \
+        "#{flavor}Release/app-#{flavor}-release.aab"
+
+  { package_name: package_name, aab: aab, config: config }
+end
+
 default_platform(:android)
 
 platform :android do
-  desc "Build a flavor's app bundle and upload it to Google Play."
+  desc "Build a flavor's app bundle and upload it to an internal testing track."
   desc "Usage: bundle exec fastlane beta flavor:prod (flavor: dev|staging|prod)"
   lane :beta do |options|
-    flavor = (options[:flavor] || "prod").to_s
-    config = FLAVORS.fetch(flavor) do
-      UI.user_error!(
-        "Unknown flavor '#{flavor}'. Expected one of: #{FLAVORS.keys.join(', ')}."
-      )
-    end
-
-    package_name = "#{require_env('ANDROID_PACKAGE_NAME_BASE')}#{config[:suffix]}"
-    build_number = resolve_build_number(options)
-
-    # Requires release signing configured via android/key.properties; without
-    # it the bundle is debug-signed and Play will reject it. The dart-define
-    # file carries the flavor's runtime config (API URL, FLAVOR, etc.) read via
-    # String.fromEnvironment — without it the build ships default/empty config.
-    flutter(
-      "build", "appbundle", "--release",
-      "--flavor", flavor, "--build-number", build_number,
-      "--dart-define-from-file", "env/#{flavor}.json"
-    )
-
-    # Output path is relative to android/ (fastlane's working directory).
-    aab = "../build/app/outputs/bundle/" \
-          "#{flavor}Release/app-#{flavor}-release.aab"
+    build = build_appbundle(options)
 
     upload_to_play_store(
-      package_name: package_name,
-      track: options[:track] || config[:track],
-      aab: aab,
+      package_name: build[:package_name],
+      track: options[:track] || build[:config][:track],
+      aab: build[:aab],
       json_key: require_env("PLAY_STORE_JSON_KEY_PATH"),
       # Publish as a draft so it can be reviewed before going live; switch to
       # "completed" to release straight to the track's testers.
       release_status: "draft",
       skip_upload_apk: true,
       skip_upload_metadata: true,
+      skip_upload_images: true,
+      skip_upload_screenshots: true,
+    )
+  end
+
+  desc "Build a flavor and roll it out to production with its store listing."
+  desc "Staged rollout (default 10%); pass rollout:1.0 for a full release. " \
+       "Uploads fastlane/metadata/android text + changelogs (no screenshots)."
+  desc "Usage: bundle exec fastlane release flavor:prod [rollout:0.2]"
+  lane :release do |options|
+    build = build_appbundle(options)
+
+    rollout = (options[:rollout] || "0.1").to_s
+    # A full rollout must be "completed"; a partial one is "inProgress".
+    release_status = rollout.to_f >= 1.0 ? "completed" : "inProgress"
+
+    upload_to_play_store(
+      package_name: build[:package_name],
+      track: "production",
+      aab: build[:aab],
+      json_key: require_env("PLAY_STORE_JSON_KEY_PATH"),
+      release_status: release_status,
+      rollout: rollout,
+      metadata_path: "fastlane/metadata/android",
+      skip_upload_apk: true,
+      skip_upload_metadata: false,
+      # Feature graphics / screenshots are a separate concern; text only.
       skip_upload_images: true,
       skip_upload_screenshots: true,
     )

--- a/android/fastlane/metadata/android/en-US/changelogs/default.txt
+++ b/android/fastlane/metadata/android/en-US/changelogs/default.txt
@@ -1,0 +1,1 @@
+Initial release.

--- a/android/fastlane/metadata/android/en-US/full_description.txt
+++ b/android/fastlane/metadata/android/en-US/full_description.txt
@@ -1,0 +1,4 @@
+Replace this placeholder with your Google Play description.
+
+Describe your app's features and benefits here. This text appears on your store
+listing on Google Play.

--- a/android/fastlane/metadata/android/en-US/short_description.txt
+++ b/android/fastlane/metadata/android/en-US/short_description.txt
@@ -1,0 +1,1 @@
+Your new Flutter app

--- a/android/fastlane/metadata/android/en-US/title.txt
+++ b/android/fastlane/metadata/android/en-US/title.txt
@@ -1,0 +1,1 @@
+Flutter Starter

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -1,10 +1,11 @@
-# Fastfile — iOS build + TestFlight upload for the flavored Flutter app.
+# Fastfile — iOS build + TestFlight / App Store delivery for the flavored app.
 #
 # This is a template/scaffold: every account-specific value is read from the
 # environment (see fastlane/.env.example), so the repo carries no secrets and
 # no project-specific identifiers. Fill in fastlane/.env, then run:
 #
-#   bundle exec fastlane beta flavor:prod
+#   bundle exec fastlane beta    flavor:prod   # → TestFlight
+#   bundle exec fastlane release flavor:prod   # → App Store (build + metadata)
 #
 # Authentication uses an App Store Connect API key (.p8). Code signing uses
 # `match`: the distribution certificate and provisioning profiles live in a
@@ -33,10 +34,11 @@ def require_env(name)
   value
 end
 
-# Resolve the build number (CFBundleVersion). TestFlight rejects a duplicate or
-# non-increasing value, so prefer an explicit, monotonic source: the lane arg,
-# then BUILD_NUMBER (CI sets this), then the git commit count as a fallback.
-# In CI use BUILD_NUMBER — a shallow checkout makes the commit count unreliable.
+# Resolve the build number (CFBundleVersion). The App Store rejects a duplicate
+# or non-increasing value, so prefer an explicit, monotonic source: the lane
+# arg, then BUILD_NUMBER (CI sets this), then the git commit count as a
+# fallback. In CI use BUILD_NUMBER — a shallow checkout makes the commit count
+# unreliable.
 def resolve_build_number(options)
   explicit = options[:build_number] || ENV["BUILD_NUMBER"]
   return explicit.to_s unless explicit.nil? || explicit.to_s.strip.empty?
@@ -53,89 +55,128 @@ def flutter(*args)
   end
 end
 
+# Build, sign, and archive a flavor into an .ipa with match-provisioned signing,
+# then upload its dSYMs to Crashlytics. Shared by the `beta` (TestFlight) and
+# `release` (App Store) lanes. Returns the App Store Connect API key and the
+# resolved bundle id so the caller can reuse them for the upload step.
+def build_and_sign(options)
+  flavor = (options[:flavor] || "prod").to_s
+  config = FLAVORS.fetch(flavor) do
+    UI.user_error!(
+      "Unknown flavor '#{flavor}'. Expected one of: #{FLAVORS.keys.join(', ')}."
+    )
+  end
+
+  # On CI, create a temporary keychain for match to import the cert into.
+  setup_ci if is_ci?
+
+  bundle_id = "#{require_env('IOS_BUNDLE_ID_BASE')}#{config[:suffix]}"
+  build_number = resolve_build_number(options)
+
+  api_key = app_store_connect_api_key(
+    key_id: require_env("APP_STORE_CONNECT_API_KEY_ID"),
+    issuer_id: require_env("APP_STORE_CONNECT_API_ISSUER_ID"),
+    key_content: require_env("APP_STORE_CONNECT_API_KEY_CONTENT"),
+    is_key_content_base64: true,
+  )
+
+  # Fetch the signing cert + App Store profile for this bundle id. readonly on
+  # CI so a runner never mutates the match repo; locally it can create assets.
+  match(
+    type: "appstore",
+    app_identifier: bundle_id,
+    api_key: api_key,
+    readonly: is_ci?,
+  )
+
+  # Compile Dart + assets without signing; gym handles archive & signing using
+  # the match-provisioned profile selected below. The dart-define file carries
+  # the flavor's runtime config (API URL, FLAVOR, etc.) read via
+  # String.fromEnvironment — without it the build ships default/empty config.
+  flutter(
+    "build", "ios", "--release", "--no-codesign",
+    "--flavor", flavor, "--build-number", build_number,
+    "--dart-define-from-file", "env/#{flavor}.json"
+  )
+
+  build_app(
+    workspace: "Runner.xcworkspace",
+    scheme: config[:scheme],
+    configuration: config[:configuration],
+    export_method: "app-store",
+    output_directory: "build/ipa",
+    output_name: "#{flavor}.ipa",
+    export_options: {
+      signingStyle: "manual",
+      provisioningProfiles: {
+        bundle_id => "match AppStore #{bundle_id}",
+      },
+    },
+  )
+
+  # Upload dSYMs so release crashes symbolicate in Firebase Crashlytics. Skip
+  # gracefully when the Firebase config or symbols are absent (e.g. a local
+  # build without GoogleService-Info.plist in place).
+  dsym_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
+  gsp_path = "Runner/GoogleService-Info.plist"
+  if dsym_path && File.exist?(gsp_path)
+    upload_symbols_to_crashlytics(
+      dsym_path: dsym_path,
+      gsp_path: gsp_path,
+      binary_path: ENV.fetch(
+        "CRASHLYTICS_UPLOAD_SYMBOLS_BIN",
+        "Pods/FirebaseCrashlytics/upload-symbols",
+      ),
+    )
+  end
+
+  { api_key: api_key, bundle_id: bundle_id }
+end
+
 default_platform(:ios)
 
 platform :ios do
   desc "Build a flavor and upload it to TestFlight."
   desc "Usage: bundle exec fastlane beta flavor:prod (flavor: dev|staging|prod)"
   lane :beta do |options|
-    flavor = (options[:flavor] || "prod").to_s
-    config = FLAVORS.fetch(flavor) do
-      UI.user_error!(
-        "Unknown flavor '#{flavor}'. Expected one of: #{FLAVORS.keys.join(', ')}."
-      )
-    end
-
-    # On CI, create a temporary keychain for match to import the cert into.
-    setup_ci if is_ci?
-
-    bundle_id = "#{require_env('IOS_BUNDLE_ID_BASE')}#{config[:suffix]}"
-    build_number = resolve_build_number(options)
-
-    api_key = app_store_connect_api_key(
-      key_id: require_env("APP_STORE_CONNECT_API_KEY_ID"),
-      issuer_id: require_env("APP_STORE_CONNECT_API_ISSUER_ID"),
-      key_content: require_env("APP_STORE_CONNECT_API_KEY_CONTENT"),
-      is_key_content_base64: true,
-    )
-
-    # Fetch the signing cert + App Store profile for this bundle id. readonly on
-    # CI so a runner never mutates the match repo; locally it can create assets.
-    match(
-      type: "appstore",
-      app_identifier: bundle_id,
-      api_key: api_key,
-      readonly: is_ci?,
-    )
-
-    # Compile Dart + assets without signing; gym handles archive & signing using
-    # the match-provisioned profile selected below. The dart-define file carries
-    # the flavor's runtime config (API URL, FLAVOR, etc.) read via
-    # String.fromEnvironment — without it the build ships default/empty config.
-    flutter(
-      "build", "ios", "--release", "--no-codesign",
-      "--flavor", flavor, "--build-number", build_number,
-      "--dart-define-from-file", "env/#{flavor}.json"
-    )
-
-    build_app(
-      workspace: "Runner.xcworkspace",
-      scheme: config[:scheme],
-      configuration: config[:configuration],
-      export_method: "app-store",
-      output_directory: "build/ipa",
-      output_name: "#{flavor}.ipa",
-      export_options: {
-        signingStyle: "manual",
-        provisioningProfiles: {
-          bundle_id => "match AppStore #{bundle_id}",
-        },
-      },
-    )
-
-    # Upload dSYMs so release crashes symbolicate in Firebase Crashlytics. Skip
-    # gracefully when the Firebase config or symbols are absent (e.g. a local
-    # build without GoogleService-Info.plist in place).
-    dsym_path = lane_context[SharedValues::DSYM_OUTPUT_PATH]
-    gsp_path = "Runner/GoogleService-Info.plist"
-    if dsym_path && File.exist?(gsp_path)
-      upload_symbols_to_crashlytics(
-        dsym_path: dsym_path,
-        gsp_path: gsp_path,
-        binary_path: ENV.fetch(
-          "CRASHLYTICS_UPLOAD_SYMBOLS_BIN",
-          "Pods/FirebaseCrashlytics/upload-symbols",
-        ),
-      )
-    end
+    result = build_and_sign(options)
 
     upload_to_testflight(
-      api_key: api_key,
-      app_identifier: bundle_id,
+      api_key: result[:api_key],
+      app_identifier: result[:bundle_id],
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
       # Don't block the lane on Apple's server-side processing; flip to false
       # if a later lane needs the build immediately (e.g. external testers).
       skip_waiting_for_build_processing: true,
+    )
+  end
+
+  desc "Build a flavor and upload it to the App Store with its store listing."
+  desc "Uploads the build + fastlane/metadata and leaves the version in " \
+       "'Prepare for Submission'. Pass submit:true to also submit for review " \
+       "(the irreversible step); the build then phases out to users gradually. " \
+       "The app record must already exist in App Store Connect."
+  desc "Usage: bundle exec fastlane release flavor:prod [submit:true]"
+  lane :release do |options|
+    result = build_and_sign(options)
+
+    upload_to_app_store(
+      api_key: result[:api_key],
+      app_identifier: result[:bundle_id],
+      ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
+      metadata_path: "./fastlane/metadata",
+      # Screenshots are a separate concern (the screenshot-automation roadmap
+      # item); upload the text metadata only.
+      skip_screenshots: true,
+      skip_metadata: false,
+      # Once approved, release the build to users gradually over several days.
+      phased_release: true,
+      # Default to a safe upload that stops short of submitting for review;
+      # pass submit:true to submit. Apple's review is the irreversible step.
+      submit_for_review: options[:submit].to_s == "true",
+      # Non-interactive: skip the HTML metadata-preview confirmation.
+      force: true,
+      run_precheck_before_submit: false,
     )
   end
 end

--- a/ios/fastlane/metadata/copyright.txt
+++ b/ios/fastlane/metadata/copyright.txt
@@ -1,0 +1,1 @@
+2026 Luci Studio

--- a/ios/fastlane/metadata/en-US/description.txt
+++ b/ios/fastlane/metadata/en-US/description.txt
@@ -1,0 +1,4 @@
+Replace this placeholder with your App Store description.
+
+Describe what your app does and why people will want it. This text appears on
+your product page on the App Store.

--- a/ios/fastlane/metadata/en-US/keywords.txt
+++ b/ios/fastlane/metadata/en-US/keywords.txt
@@ -1,0 +1,1 @@
+flutter,starter,app,template

--- a/ios/fastlane/metadata/en-US/marketing_url.txt
+++ b/ios/fastlane/metadata/en-US/marketing_url.txt
@@ -1,0 +1,1 @@
+https://example.com

--- a/ios/fastlane/metadata/en-US/name.txt
+++ b/ios/fastlane/metadata/en-US/name.txt
@@ -1,0 +1,1 @@
+Flutter Starter

--- a/ios/fastlane/metadata/en-US/promotional_text.txt
+++ b/ios/fastlane/metadata/en-US/promotional_text.txt
@@ -1,0 +1,1 @@
+Replace this with a short promotional line for your app.

--- a/ios/fastlane/metadata/en-US/release_notes.txt
+++ b/ios/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,1 @@
+Initial release.

--- a/ios/fastlane/metadata/en-US/subtitle.txt
+++ b/ios/fastlane/metadata/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Your new Flutter app

--- a/ios/fastlane/metadata/en-US/support_url.txt
+++ b/ios/fastlane/metadata/en-US/support_url.txt
@@ -1,0 +1,1 @@
+https://example.com/support


### PR DESCRIPTION
## What & why

Fastlane only shipped a `beta` lane (iOS → TestFlight, Android → internal track
as a draft). There was **no path to a production store release** and **no
store-listing metadata**, so every app built from the template had to be
submitted to the App Store / promoted to production by hand.

This adds a `release` lane to each platform and scaffolds the deliver/supply
metadata trees.

## Changes

**Shared build helper** — factor the build/sign steps out of `beta` so `beta`
and `release` stay in lockstep (`build_and_sign` on iOS, `build_appbundle` on
Android). `beta`'s behaviour is unchanged.

**iOS `release` lane** — builds + signs (match), then `upload_to_app_store`:
- reads `ios/fastlane/metadata/` (text metadata; screenshots skipped),
- `phased_release: true` (gradual rollout once approved),
- `submit_for_review: false` by default — uploads the build + metadata and
  leaves the version in *Prepare for Submission*; pass `submit:true` to submit
  (Apple's review is the irreversible step),
- `force: true` so it runs non-interactively.

`bundle exec fastlane release flavor:prod [submit:true]`

**Android `release` lane** — builds the appbundle, then `upload_to_play_store`
to the **production** track:
- staged rollout, default 10% (`rollout:1.0` for a full release; the lane sets
  `release_status` to `inProgress`/`completed` accordingly),
- store-listing + changelog upload enabled (`skip_upload_metadata: false`),
  images/screenshots skipped.

`bundle exec fastlane release flavor:prod [rollout:0.2]`

**Metadata scaffolds** — `ios/fastlane/metadata/` (deliver) and
`android/fastlane/metadata/android/` (supply), `en-US`, with placeholder copy.
The app name and copyright use the template display name / org, which the `fst`
CLI rewrites per project.

## Verification

- `ruby -c` passes on both Fastfiles.
- Scaffolded a project from this checkout (`--template-path`) and confirmed the
  metadata is rewritten per project — `name.txt` → the new app name,
  `copyright.txt` → the new org — and the iOS tree has zero template-identifier
  survivors.
- **Not run locally:** `fastlane lanes` (the fastlane gem isn't installed here)
  and a real store upload (needs an App Store Connect / Play account). DSL
  parse-validation runs in the release environment; the lanes mirror the
  existing, proven `beta` lane.

## Notes for the reviewer

- The iOS app record must already exist in App Store Connect (deliver updates an
  existing app; it doesn't create one).
- **Out of scope** (separate roadmap items): screenshot automation, and wiring
  `release` into a tag-triggered `release.yml` (that lands with the
  version-bump ticket).

Sprint 1 ticket **FST-4** of the optimization roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
