### PR TITLE
feat(ios,android): strip orphaned media permissions when bookmarks is removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,7 @@ jobs:
         include:
           - { name: default, flags: '' }
           - { name: exclude-notifications, flags: '--exclude-feature notifications' }
+          - { name: exclude-bookmarks, flags: '--exclude-feature bookmarks' }
           - { name: no-firebase, flags: '--no-firebase' }
           - { name: no-auth, flags: '--no-auth' }
           - { name: no-backend, flags: '--no-backend' }
@@ -352,16 +353,58 @@ jobs:
           bookmarks="$out/packages/features/bookmarks"
           notifications="$out/packages/features/notifications"
           profile_header="$out/packages/features/profile/lib/src/presentation/widgets/profile_header.dart"
+          infoplist="$out/ios/Runner/Info.plist"
+          manifest="$out/android/app/src/main/AndroidManifest.xml"
+
+          # The camera / microphone / photo-library permissions exist only for
+          # the bookmarks media-capture flow, so the CLI strips them (and their
+          # fst:feature:bookmarks markers) whenever bookmarks is removed. These
+          # helpers keep the native config from drifting into declaring — or
+          # over-stripping — those permissions.
+          assert_no_media_perms() {
+            local key
+            for key in NSCameraUsageDescription NSMicrophoneUsageDescription \
+                NSPhotoLibraryUsageDescription NSPhotoLibraryAddUsageDescription; do
+              if grep -q "$key" "$infoplist"; then
+                echo "::error::$key not stripped from Info.plist ($CONFIG)"; fail=1
+              fi
+            done
+            for key in android.permission.CAMERA android.permission.RECORD_AUDIO; do
+              if grep -q "$key" "$manifest"; then
+                echo "::error::$key not stripped from AndroidManifest ($CONFIG)"; fail=1
+              fi
+            done
+            if grep -q 'fst:feature:bookmarks' "$infoplist" "$manifest"; then
+              echo "::error::bookmarks permission markers survived ($CONFIG)"; fail=1
+            fi
+          }
+
+          assert_media_perms_present() {
+            grep -q 'NSCameraUsageDescription' "$infoplist" \
+              || { echo "::error::NSCameraUsageDescription wrongly stripped ($CONFIG)"; fail=1; }
+            grep -q 'NSPhotoLibraryUsageDescription' "$infoplist" \
+              || { echo "::error::NSPhotoLibraryUsageDescription wrongly stripped ($CONFIG)"; fail=1; }
+            grep -q 'android.permission.CAMERA' "$manifest" \
+              || { echo "::error::CAMERA permission wrongly stripped ($CONFIG)"; fail=1; }
+          }
 
           # ── Per-config structural assertions ──
           case "$CONFIG" in
             default)
               [ -d "$auth" ] || { echo "::error::auth removed in default"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks missing in default"; fail=1; }
+              assert_media_perms_present
               ;;
             exclude-notifications)
               [ ! -d "$notifications" ] || { echo "::error::notifications not removed"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks wrongly removed"; fail=1; }
+              assert_media_perms_present
+              ;;
+            exclude-bookmarks)
+              [ ! -d "$bookmarks" ] || { echo "::error::bookmarks not removed (exclude-bookmarks)"; fail=1; }
+              [ -d "$out/packages/features/collections" ] || { echo "::error::collections wrongly removed (exclude-bookmarks)"; fail=1; }
+              [ -d "$auth" ] || { echo "::error::auth wrongly removed (exclude-bookmarks)"; fail=1; }
+              assert_no_media_perms
               ;;
             no-firebase)
               [ -d "$auth" ] || { echo "::error::auth removed in no-firebase"; fail=1; }
@@ -386,6 +429,7 @@ jobs:
               if grep -rIq 'fst:backend:\|fst:auth:' "$out/lib" "$out/test" "$out/packages" 2>/dev/null; then
                 echo "::error::fst markers survived the strip ($CONFIG)"; fail=1
               fi
+              assert_no_media_perms
               ;;
           esac
           exit $fail

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <!-- fst:feature:bookmarks:start -->
+    <!-- Media-capture permissions for the bookmarks feature; stripped by the
+         fst CLI when bookmarks is removed. -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- fst:feature:bookmarks:end -->
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -75,6 +75,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<!-- fst:feature:bookmarks:start -->
+	<!-- Media-capture permissions for the bookmarks feature. The fst CLI strips
+	     this block when bookmarks is removed (see test/architecture/
+	     ios_permission_strings_test.dart for the marker contract). -->
 	<key>NSCameraUsageDescription</key>
 	<string>$(APP_DISPLAY_NAME) uses the camera to let you take photos and videos.</string>
 	<key>NSMicrophoneUsageDescription</key>
@@ -83,5 +87,6 @@
 	<string>$(APP_DISPLAY_NAME) accesses your photo library so you can choose images and videos.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>$(APP_DISPLAY_NAME) saves images and videos to your photo library.</string>
+	<!-- fst:feature:bookmarks:end -->
 </dict>
 </plist>

--- a/test/architecture/ios_permission_strings_test.dart
+++ b/test/architecture/ios_permission_strings_test.dart
@@ -95,38 +95,40 @@ void main() {
   // `fst` CLI strips them when bookmarks is removed by stripping the
   // `fst:feature:bookmarks` region — so every usage key must stay inside it,
   // otherwise a trimmed app ships permissions it never requests.
-  test('every usage description sits inside an fst:feature:bookmarks region',
-      () {
-    final xml = infoPlist.readAsStringSync();
-    final start = xml.indexOf('fst:feature:bookmarks:start');
-    final end = xml.indexOf('fst:feature:bookmarks:end');
+  test(
+    'every usage description sits inside an fst:feature:bookmarks region',
+    () {
+      final xml = infoPlist.readAsStringSync();
+      final start = xml.indexOf('fst:feature:bookmarks:start');
+      final end = xml.indexOf('fst:feature:bookmarks:end');
 
-    expect(
-      start,
-      greaterThanOrEqualTo(0),
-      reason: 'Missing the fst:feature:bookmarks:start marker. The CLI needs '
-          'it to strip the media permissions when bookmarks is removed.',
-    );
-    expect(
-      end,
-      greaterThan(start),
-      reason: 'fst:feature:bookmarks:end must follow its :start marker.',
-    );
+      expect(
+        start,
+        greaterThanOrEqualTo(0),
+        reason:
+            'Missing the fst:feature:bookmarks:start marker. The CLI needs '
+            'it to strip the media permissions when bookmarks is removed.',
+      );
+      expect(
+        end,
+        greaterThan(start),
+        reason: 'fst:feature:bookmarks:end must follow its :start marker.',
+      );
 
-    final outside = usageKeys
-        .where((key) {
-          final at = xml.indexOf('<key>$key</key>');
-          return at < start || at > end;
-        })
-        .toList();
-    expect(
-      outside,
-      isEmpty,
-      reason: 'These usage keys are outside the fst:feature:bookmarks region, '
-          'so the CLI would leave them behind when bookmarks is stripped:\n\n'
-          '${outside.map((k) => '  $k').join('\n')}',
-    );
-  });
+      final outside = usageKeys.where((key) {
+        final at = xml.indexOf('<key>$key</key>');
+        return at < start || at > end;
+      }).toList();
+      expect(
+        outside,
+        isEmpty,
+        reason:
+            'These usage keys are outside the fst:feature:bookmarks region, '
+            'so the CLI would leave them behind when bookmarks is stripped:\n\n'
+            '${outside.map((k) => '  $k').join('\n')}',
+      );
+    },
+  );
 }
 
 /// Extracts the `<key>NS…UsageDescription</key><string>…</string>` pairs from

--- a/test/architecture/ios_permission_strings_test.dart
+++ b/test/architecture/ios_permission_strings_test.dart
@@ -90,6 +90,43 @@ void main() {
       );
     },
   );
+
+  // These permissions exist only for the bookmarks media-capture flow. The
+  // `fst` CLI strips them when bookmarks is removed by stripping the
+  // `fst:feature:bookmarks` region — so every usage key must stay inside it,
+  // otherwise a trimmed app ships permissions it never requests.
+  test('every usage description sits inside an fst:feature:bookmarks region',
+      () {
+    final xml = infoPlist.readAsStringSync();
+    final start = xml.indexOf('fst:feature:bookmarks:start');
+    final end = xml.indexOf('fst:feature:bookmarks:end');
+
+    expect(
+      start,
+      greaterThanOrEqualTo(0),
+      reason: 'Missing the fst:feature:bookmarks:start marker. The CLI needs '
+          'it to strip the media permissions when bookmarks is removed.',
+    );
+    expect(
+      end,
+      greaterThan(start),
+      reason: 'fst:feature:bookmarks:end must follow its :start marker.',
+    );
+
+    final outside = usageKeys
+        .where((key) {
+          final at = xml.indexOf('<key>$key</key>');
+          return at < start || at > end;
+        })
+        .toList();
+    expect(
+      outside,
+      isEmpty,
+      reason: 'These usage keys are outside the fst:feature:bookmarks region, '
+          'so the CLI would leave them behind when bookmarks is stripped:\n\n'
+          '${outside.map((k) => '  $k').join('\n')}',
+    );
+  });
 }
 
 /// Extracts the `<key>NS…UsageDescription</key><string>…</string>` pairs from


### PR DESCRIPTION
## What

Make the template's camera / microphone / photo-library permission declarations **strippable** so that projects scaffolded without the `bookmarks` feature don't ship permissions they never request.

These permissions exist only for the bookmarks media-capture flow (via `packages/app_platform`). When a pillar/feature that removes bookmarks is stripped at scaffold time — `fst create --no-backend` / `--minimal` (drops the demo features), or `--exclude-feature bookmarks` / `collections` — the keys become orphaned, and both Apple and Google discourage declaring unused permissions.

## How

Wrap the permission blocks in `fst:feature:bookmarks` XML-comment markers, reusing the exact mechanism already used for the Dart wiring. The companion CLI change adds these two native-config files to its strip list, so the regions are removed whenever bookmarks is excluded.

- **`ios/Runner/Info.plist`** — wrap the 4 `NS*UsageDescription` keys.
- **`android/app/src/main/AndroidManifest.xml`** — wrap `CAMERA` + `RECORD_AUDIO`. `POST_NOTIFICATIONS` is left alone (it belongs to the `notifications` feature).
- **`published/cli`** — re-pinned to the matching CLI commit so the markers and the strip list ship together.
- **`test/architecture/ios_permission_strings_test.dart`** — new guard asserting every usage key stays inside the `fst:feature:bookmarks` region (so it can't drift out and silently defeat the strip).
- **`.github/workflows/ci.yml`** — `cli-smoke` matrix gains an `exclude-bookmarks` config and present/absent permission assertions across bookmarks-stripped (`no-backend`, `minimal`, `exclude-bookmarks`) and bookmarks-kept (`default`, `exclude-notifications`) configs.

## Verification

- `flutter analyze` → no issues; the architecture test passes (incl. the new marker guard; FST-2's three assertions still green).
- Scaffolded real projects from this checkout (`--exclude-feature bookmarks`, `--no-backend`): media keys + markers fully stripped, `Info.plist`/`AndroidManifest.xml` still well-formed (xmllint), `POST_NOTIFICATIONS` + `collections` retained; `default` keeps all permissions. The actual `cli-smoke` assertion script returns exit 0 for all configs.
- `fvm flutter build ios --flavor prod --dart-define-from-file=env/prod.json --no-codesign` → **success** — the comment markers are valid plist and don't affect the Xcode build.

## Notes

- **Stacked on #176** (FST-2, generic permission strings). GitHub will auto-retarget this PR to `main` once #176 merges.
- Paired CLI PR: kido-luci/flutter-starter-template-cli#18. **Please merge that one with a merge commit (not squash)** — this PR pins the submodule by SHA, and a squash would orphan the pin. After it lands I (or you) re-pin to the merged SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
