### PR TITLE
feat(ios,android): strip orphaned media permissions when bookmarks is removed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,6 +284,7 @@ jobs:
         include:
           - { name: default, flags: '' }
           - { name: exclude-notifications, flags: '--exclude-feature notifications' }
+          - { name: exclude-bookmarks, flags: '--exclude-feature bookmarks' }
           - { name: no-firebase, flags: '--no-firebase' }
           - { name: no-auth, flags: '--no-auth' }
           - { name: no-backend, flags: '--no-backend' }
@@ -352,16 +353,58 @@ jobs:
           bookmarks="$out/packages/features/bookmarks"
           notifications="$out/packages/features/notifications"
           profile_header="$out/packages/features/profile/lib/src/presentation/widgets/profile_header.dart"
+          infoplist="$out/ios/Runner/Info.plist"
+          manifest="$out/android/app/src/main/AndroidManifest.xml"
+
+          # The camera / microphone / photo-library permissions exist only for
+          # the bookmarks media-capture flow, so the CLI strips them (and their
+          # fst:feature:bookmarks markers) whenever bookmarks is removed. These
+          # helpers keep the native config from drifting into declaring — or
+          # over-stripping — those permissions.
+          assert_no_media_perms() {
+            local key
+            for key in NSCameraUsageDescription NSMicrophoneUsageDescription \
+                NSPhotoLibraryUsageDescription NSPhotoLibraryAddUsageDescription; do
+              if grep -q "$key" "$infoplist"; then
+                echo "::error::$key not stripped from Info.plist ($CONFIG)"; fail=1
+              fi
+            done
+            for key in android.permission.CAMERA android.permission.RECORD_AUDIO; do
+              if grep -q "$key" "$manifest"; then
+                echo "::error::$key not stripped from AndroidManifest ($CONFIG)"; fail=1
+              fi
+            done
+            if grep -q 'fst:feature:bookmarks' "$infoplist" "$manifest"; then
+              echo "::error::bookmarks permission markers survived ($CONFIG)"; fail=1
+            fi
+          }
+
+          assert_media_perms_present() {
+            grep -q 'NSCameraUsageDescription' "$infoplist" \
+              || { echo "::error::NSCameraUsageDescription wrongly stripped ($CONFIG)"; fail=1; }
+            grep -q 'NSPhotoLibraryUsageDescription' "$infoplist" \
+              || { echo "::error::NSPhotoLibraryUsageDescription wrongly stripped ($CONFIG)"; fail=1; }
+            grep -q 'android.permission.CAMERA' "$manifest" \
+              || { echo "::error::CAMERA permission wrongly stripped ($CONFIG)"; fail=1; }
+          }
 
           # ── Per-config structural assertions ──
           case "$CONFIG" in
             default)
               [ -d "$auth" ] || { echo "::error::auth removed in default"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks missing in default"; fail=1; }
+              assert_media_perms_present
               ;;
             exclude-notifications)
               [ ! -d "$notifications" ] || { echo "::error::notifications not removed"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks wrongly removed"; fail=1; }
+              assert_media_perms_present
+              ;;
+            exclude-bookmarks)
+              [ ! -d "$bookmarks" ] || { echo "::error::bookmarks not removed (exclude-bookmarks)"; fail=1; }
+              [ -d "$out/packages/features/collections" ] || { echo "::error::collections wrongly removed (exclude-bookmarks)"; fail=1; }
+              [ -d "$auth" ] || { echo "::error::auth wrongly removed (exclude-bookmarks)"; fail=1; }
+              assert_no_media_perms
               ;;
             no-firebase)
               [ -d "$auth" ] || { echo "::error::auth removed in no-firebase"; fail=1; }
@@ -386,6 +429,7 @@ jobs:
               if grep -rIq 'fst:backend:\|fst:auth:' "$out/lib" "$out/test" "$out/packages" 2>/dev/null; then
                 echo "::error::fst markers survived the strip ($CONFIG)"; fail=1
               fi
+              assert_no_media_perms
               ;;
           esac
           exit $fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,12 +380,16 @@ jobs:
           }
 
           assert_media_perms_present() {
-            grep -q 'NSCameraUsageDescription' "$infoplist" \
-              || { echo "::error::NSCameraUsageDescription wrongly stripped ($CONFIG)"; fail=1; }
-            grep -q 'NSPhotoLibraryUsageDescription' "$infoplist" \
-              || { echo "::error::NSPhotoLibraryUsageDescription wrongly stripped ($CONFIG)"; fail=1; }
-            grep -q 'android.permission.CAMERA' "$manifest" \
-              || { echo "::error::CAMERA permission wrongly stripped ($CONFIG)"; fail=1; }
+            local key
+            for key in NSCameraUsageDescription NSMicrophoneUsageDescription \
+                NSPhotoLibraryUsageDescription NSPhotoLibraryAddUsageDescription; do
+              grep -q "$key" "$infoplist" \
+                || { echo "::error::$key wrongly stripped ($CONFIG)"; fail=1; }
+            done
+            for key in android.permission.CAMERA android.permission.RECORD_AUDIO; do
+              grep -q "$key" "$manifest" \
+                || { echo "::error::$key wrongly stripped ($CONFIG)"; fail=1; }
+            done
           }
 
           # ── Per-config structural assertions ──
@@ -405,6 +409,8 @@ jobs:
               [ -d "$out/packages/features/collections" ] || { echo "::error::collections wrongly removed (exclude-bookmarks)"; fail=1; }
               [ -d "$auth" ] || { echo "::error::auth wrongly removed (exclude-bookmarks)"; fail=1; }
               assert_no_media_perms
+              grep -q 'android.permission.POST_NOTIFICATIONS' "$manifest" \
+                || { echo "::error::POST_NOTIFICATIONS wrongly stripped (exclude-bookmarks)"; fail=1; }
               ;;
             no-firebase)
               [ -d "$auth" ] || { echo "::error::auth removed in no-firebase"; fail=1; }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <!-- fst:feature:bookmarks:start -->
+    <!-- Media-capture permissions for the bookmarks feature; stripped by the
+         fst CLI when bookmarks is removed. -->
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- fst:feature:bookmarks:end -->
     <application
         android:label="@string/app_name"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -75,6 +75,10 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<!-- fst:feature:bookmarks:start -->
+	<!-- Media-capture permissions for the bookmarks feature. The fst CLI strips
+	     this block when bookmarks is removed (see test/architecture/
+	     ios_permission_strings_test.dart for the marker contract). -->
 	<key>NSCameraUsageDescription</key>
 	<string>$(APP_DISPLAY_NAME) uses the camera to let you take photos and videos.</string>
 	<key>NSMicrophoneUsageDescription</key>
@@ -83,5 +87,6 @@
 	<string>$(APP_DISPLAY_NAME) accesses your photo library so you can choose images and videos.</string>
 	<key>NSPhotoLibraryAddUsageDescription</key>
 	<string>$(APP_DISPLAY_NAME) saves images and videos to your photo library.</string>
+	<!-- fst:feature:bookmarks:end -->
 </dict>
 </plist>

--- a/test/architecture/ios_permission_strings_test.dart
+++ b/test/architecture/ios_permission_strings_test.dart
@@ -100,6 +100,45 @@ void main() {
       );
     },
   );
+
+  // These permissions exist only for the bookmarks media-capture flow. The
+  // `fst` CLI strips them when bookmarks is removed by stripping the
+  // `fst:feature:bookmarks` region — so every usage key must stay inside it,
+  // otherwise a trimmed app ships permissions it never requests.
+  test(
+    'every usage description sits inside an fst:feature:bookmarks region',
+    () {
+      final xml = infoPlist.readAsStringSync();
+      final start = xml.indexOf('fst:feature:bookmarks:start');
+      final end = xml.indexOf('fst:feature:bookmarks:end');
+
+      expect(
+        start,
+        greaterThanOrEqualTo(0),
+        reason:
+            'Missing the fst:feature:bookmarks:start marker. The CLI needs '
+            'it to strip the media permissions when bookmarks is removed.',
+      );
+      expect(
+        end,
+        greaterThan(start),
+        reason: 'fst:feature:bookmarks:end must follow its :start marker.',
+      );
+
+      final outside = usageKeys.where((key) {
+        final at = xml.indexOf('<key>$key</key>');
+        return at < start || at > end;
+      }).toList();
+      expect(
+        outside,
+        isEmpty,
+        reason:
+            'These usage keys are outside the fst:feature:bookmarks region, '
+            'so the CLI would leave them behind when bookmarks is stripped:\n\n'
+            '${outside.map((k) => '  $k').join('\n')}',
+      );
+    },
+  );
 }
 
 /// Extracts the `<key>NS…UsageDescription</key><string>…</string>` pairs from


### PR DESCRIPTION
## What & why

The camera / microphone / photo-library permission declarations in
`ios/Runner/Info.plist` and `android/.../AndroidManifest.xml` exist only for the
**bookmarks** media-capture flow. When bookmarks is stripped at scaffold time
(`--exclude-feature bookmarks` / `--no-backend` / `--minimal`), those permission
declarations were left behind — and Apple and Google both discourage declaring
permissions an app never requests.

This wraps them in `fst:feature:bookmarks` markers so the `fst` CLI strips them
(and the markers) together with the feature.

## Changes

- **`ios/Runner/Info.plist` / `AndroidManifest.xml`** — wrap the media permission
  declarations in `<!-- fst:feature:bookmarks:start/end -->` markers.
- **`published/cli`** — bump the submodule to the merged CLI commit
  ([cli#18](https://github.com/kido-luci/flutter-starter-template-cli/pull/18))
  that strips these marker regions from native config files (it just adds the two
  native files to the existing `removeFeatureRegions` set — same mechanism used
  for the Dart wiring).
- **Guardrail test** — assert every iOS usage description sits inside the
  `fst:feature:bookmarks` region, so a new permission can't be added outside it
  and survive the strip.
- **cli-smoke** — add an `exclude-bookmarks` matrix config and assert the media
  permissions + markers are stripped when bookmarks is removed (no-backend,
  minimal, exclude-bookmarks) and retained when it's kept (default,
  exclude-notifications).

## Context & verification

Recreates the closed **#179** on top of `main` — its base (the FST-2 branch) was
squash-merged, so the stacked PR couldn't merge directly. Pairs with the merged
CLI change (cli#18, which also gained photo-library test coverage during review).

Verified locally end-to-end: scaffolding `--exclude-feature bookmarks` from this
checkout strips **all** media permissions and markers from both the iOS
`Info.plist` and the `AndroidManifest.xml`, while keeping unrelated permissions
(e.g. `POST_NOTIFICATIONS`). `flutter analyze` + the guardrail tests pass; the
cli-smoke assert script is `bash -n`-clean and the workflow YAML is valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional app configuration that removes the bookmarks feature during build checks.
  * Updated mobile permission handling so bookmark-related permissions can be included or excluded more consistently across app variants.

* **Bug Fixes**
  * Improved validation to ensure stripped builds do not retain unnecessary native permission entries.
  * Added stronger checks so required permissions remain present when bookmarks are expected.

* **Tests**
  * Added coverage for iOS permission placement rules to catch incorrect permission marker placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->