### PR TITLE
feat(ci): fail-fast on missing release secrets + bootstrap script (FST-6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,47 @@ jobs:
       github.event.inputs.platform == 'android'
     runs-on: ubuntu-latest
     steps:
+      # Fail fast if the store-deploy secrets/vars aren't configured yet, so a
+      # tag push doesn't burn ~15 min cloning, installing the SDK and building
+      # only to die deep inside Fastlane on an empty base64 blob or an auth
+      # error. Bootstrap them in one shot with tool/ci-secrets-setup.sh. Secrets
+      # are mapped to env (not interpolated into the script) and read by
+      # indirect expansion, so this stays template-injection-safe (zizmor).
+      - name: Verify required Play secrets
+        env:
+          ANDROID_PACKAGE_NAME_BASE: ${{ vars.ANDROID_PACKAGE_NAME_BASE }}
+          PLAY_STORE_JSON_KEY: ${{ secrets.PLAY_STORE_JSON_KEY }}
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_GOOGLE_SERVICES_JSON: ${{ secrets.ANDROID_GOOGLE_SERVICES_JSON }}
+        run: |
+          set -euo pipefail
+          required=(
+            ANDROID_PACKAGE_NAME_BASE
+            PLAY_STORE_JSON_KEY
+            ANDROID_KEYSTORE_BASE64
+            ANDROID_KEYSTORE_PASSWORD
+            ANDROID_KEY_PASSWORD
+            ANDROID_KEY_ALIAS
+            ANDROID_GOOGLE_SERVICES_JSON
+          )
+          missing=()
+          for name in "${required[@]}"; do
+            [[ -z "${!name:-}" ]] && missing+=("$name")
+          done
+          if (( ${#missing[@]} )); then
+            {
+              echo "::error::Missing ${#missing[@]} required Play secret(s)/var(s): ${missing[*]}"
+              echo "Set them under Settings → Secrets and variables → Actions,"
+              echo "or bootstrap all at once: tool/ci-secrets-setup.sh"
+              echo "Full table: android/fastlane/README.md"
+            } >&2
+            exit 1
+          fi
+          echo "All required Play secrets are configured."
+
       - name: Checkout
         uses: actions/checkout@v7
 
@@ -138,6 +179,50 @@ jobs:
       github.event.inputs.platform == 'ios'
     runs-on: macos-15
     steps:
+      # Fail fast if the store-deploy secrets/vars aren't configured yet (see the
+      # Android job's note). MATCH_GIT_BASIC_AUTHORIZATION is optional — only
+      # HTTPS match repos need it — so it warns rather than fails.
+      - name: Verify required App Store secrets
+        env:
+          IOS_BUNDLE_ID_BASE: ${{ vars.IOS_BUNDLE_ID_BASE }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
+          MATCH_GIT_URL: ${{ secrets.MATCH_GIT_URL }}
+          MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
+          IOS_GOOGLE_SERVICE_INFO_PLIST: ${{ secrets.IOS_GOOGLE_SERVICE_INFO_PLIST }}
+          MATCH_GIT_BASIC_AUTHORIZATION: ${{ secrets.MATCH_GIT_BASIC_AUTHORIZATION }}
+        run: |
+          set -euo pipefail
+          required=(
+            IOS_BUNDLE_ID_BASE
+            APPLE_TEAM_ID
+            APP_STORE_CONNECT_API_KEY_ID
+            APP_STORE_CONNECT_API_ISSUER_ID
+            APP_STORE_CONNECT_API_KEY_CONTENT
+            MATCH_GIT_URL
+            MATCH_PASSWORD
+            IOS_GOOGLE_SERVICE_INFO_PLIST
+          )
+          missing=()
+          for name in "${required[@]}"; do
+            [[ -z "${!name:-}" ]] && missing+=("$name")
+          done
+          if (( ${#missing[@]} )); then
+            {
+              echo "::error::Missing ${#missing[@]} required App Store secret(s)/var(s): ${missing[*]}"
+              echo "Set them under Settings → Secrets and variables → Actions,"
+              echo "or bootstrap all at once: tool/ci-secrets-setup.sh"
+              echo "Full table: ios/fastlane/README.md"
+            } >&2
+            exit 1
+          fi
+          if [[ -z "${MATCH_GIT_BASIC_AUTHORIZATION:-}" ]]; then
+            echo "::warning::MATCH_GIT_BASIC_AUTHORIZATION is unset — fine for an SSH match repo, required for HTTPS."
+          fi
+          echo "All required App Store secrets are configured."
+
       - name: Checkout
         uses: actions/checkout@v7
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,8 +180,8 @@ jobs:
     runs-on: macos-15
     steps:
       # Fail fast if the store-deploy secrets/vars aren't configured yet (see the
-      # Android job's note). MATCH_GIT_BASIC_AUTHORIZATION is optional — only
-      # HTTPS match repos need it — so it warns rather than fails.
+      # Android job's note). MATCH_GIT_BASIC_AUTHORIZATION is gated on the
+      # MATCH_GIT_URL scheme: required for an HTTPS match repo, skipped for SSH.
       - name: Verify required App Store secrets
         env:
           IOS_BUNDLE_ID_BASE: ${{ vars.IOS_BUNDLE_ID_BASE }}
@@ -218,8 +218,15 @@ jobs:
             } >&2
             exit 1
           fi
-          if [[ -z "${MATCH_GIT_BASIC_AUTHORIZATION:-}" ]]; then
-            echo "::warning::MATCH_GIT_BASIC_AUTHORIZATION is unset — fine for an SSH match repo, required for HTTPS."
+          # An HTTPS match repo can't clone without basic-auth, so a missing
+          # token there is a hard fail too; SSH repos don't need it.
+          if [[ "$MATCH_GIT_URL" =~ ^https?:// ]]; then
+            if [[ -z "${MATCH_GIT_BASIC_AUTHORIZATION:-}" ]]; then
+              echo "::error::MATCH_GIT_BASIC_AUTHORIZATION is required when MATCH_GIT_URL is HTTPS (base64 user:token)." >&2
+              exit 1
+            fi
+          elif [[ -z "${MATCH_GIT_BASIC_AUTHORIZATION:-}" ]]; then
+            echo "::notice::MATCH_GIT_BASIC_AUTHORIZATION is unset — fine for an SSH match repo."
           fi
           echo "All required App Store secrets are configured."
 

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -89,6 +89,11 @@ the lane. Expected repository secrets/vars:
 | `ANDROID_KEY_ALIAS` | secret | Key alias |
 | `ANDROID_GOOGLE_SERVICES_JSON` | secret | base64 of `google-services.json` (git-ignored) |
 
+Push all of these in one shot with `tool/ci-secrets-setup.sh --platform android`
+instead of pasting them into the Settings UI by hand. The workflow also fails
+fast at the top of the job if any required secret is missing, naming exactly
+which.
+
 ## Troubleshooting (first real run)
 
 The lane is wired but has not been run end-to-end against a real account. Watch

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -89,10 +89,10 @@ the lane. Expected repository secrets/vars:
 | `ANDROID_KEY_ALIAS` | secret | Key alias |
 | `ANDROID_GOOGLE_SERVICES_JSON` | secret | base64 of `google-services.json` (git-ignored) |
 
-Push all of these in one shot with `tool/ci-secrets-setup.sh --platform android`
-instead of pasting them into the Settings UI by hand. The workflow also fails
-fast at the top of the job if any required secret is missing, naming exactly
-which.
+From the repository root, push all of these in one shot with
+`tool/ci-secrets-setup.sh --platform android` instead of pasting them into the
+Settings UI by hand. The workflow also fails fast at the top of the job if any
+required secret or variable is missing, naming exactly which.
 
 ## Troubleshooting (first real run)
 

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -90,6 +90,11 @@ required) on tag push / manual dispatch, with `FLUTTER_CMD=flutter` and
 | `MATCH_GIT_BASIC_AUTHORIZATION` | secret | base64 `user:token` for HTTPS clone (omit for SSH) |
 | `IOS_GOOGLE_SERVICE_INFO_PLIST` | secret | base64 of `GoogleService-Info.plist` (git-ignored) |
 
+Push all of these in one shot with `tool/ci-secrets-setup.sh --platform ios`
+instead of pasting them into the Settings UI by hand. The workflow also fails
+fast at the top of the job if any required secret is missing, naming exactly
+which.
+
 ## Troubleshooting (first real run)
 
 The lane is wired but has not been run end-to-end against a real account. Watch

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -90,10 +90,10 @@ required) on tag push / manual dispatch, with `FLUTTER_CMD=flutter` and
 | `MATCH_GIT_BASIC_AUTHORIZATION` | secret | base64 `user:token` for HTTPS clone (omit for SSH) |
 | `IOS_GOOGLE_SERVICE_INFO_PLIST` | secret | base64 of `GoogleService-Info.plist` (git-ignored) |
 
-Push all of these in one shot with `tool/ci-secrets-setup.sh --platform ios`
-instead of pasting them into the Settings UI by hand. The workflow also fails
-fast at the top of the job if any required secret is missing, naming exactly
-which.
+From the repository root, push all of these in one shot with
+`tool/ci-secrets-setup.sh --platform ios` instead of pasting them into the
+Settings UI by hand. The workflow also fails fast at the top of the job if any
+required secret or variable is missing, naming exactly which.
 
 ## Troubleshooting (first real run)
 

--- a/test/architecture/release_secrets_preflight_test.dart
+++ b/test/architecture/release_secrets_preflight_test.dart
@@ -1,12 +1,14 @@
 // Architecture guardrail: keeps the release workflow's fail-fast preflight in
-// sync with the secrets it actually consumes.
+// sync with the secrets it actually consumes — per job.
 //
 // .github/workflows/release.yml verifies every required store-deploy
 // secret/var at the top of each job (the `required=( … )` lists), so a
 // misconfigured repo fails in ~2s with a clear message instead of ~15 min into
-// a Fastlane build. If someone wires a new `secrets.X` / `vars.X` into a build
-// step but forgets to add it to a preflight list, that fail-fast guarantee
-// silently regresses — this test catches it.
+// a Fastlane build. The check is scoped per job: a name consumed by the Android
+// job must be guarded by the *Android* preflight, not merely by some list in
+// the iOS job. If someone wires a new `secrets.X` / `vars.X` into a build step
+// but forgets its job's preflight list, that fail-fast guarantee silently
+// regresses — this test catches it.
 //
 // Pure file-scan, no third-party dependency; runs in the normal
 // `fvm flutter test` / CI flow.
@@ -18,15 +20,18 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final workflow = File('.github/workflows/release.yml');
 
-  // Names intentionally left out of the required lists: the preflight warns
-  // instead of failing when they're unset. Keep this set tiny and justified.
-  const optional = <String>{
-    // Only HTTPS match repos need basic-auth; SSH setups don't.
-    'MATCH_GIT_BASIC_AUTHORIZATION',
+  // Names a job's preflight intentionally omits from its required list because
+  // the workflow gates them on a runtime condition this static test can't
+  // evaluate. Keyed by job. Keep each entry tiny and justified.
+  const optionalByJob = <String, Set<String>>{
+    // The iOS preflight requires MATCH_GIT_BASIC_AUTHORIZATION only when
+    // MATCH_GIT_URL is HTTPS — a runtime check — and skips it for SSH. The
+    // transport rule lives in the workflow; here we just exempt it from the
+    // static presence check.
+    'ios': {'MATCH_GIT_BASIC_AUTHORIZATION'},
   };
 
-  late final Set<String> referenced;
-  late final Set<String> guarded;
+  late final Map<String, String> jobs;
 
   setUpAll(() {
     expect(
@@ -36,50 +41,86 @@ void main() {
           'Expected .github/workflows/release.yml relative to the current '
           'directory. Run this test from the repository root.',
     );
-    final yaml = workflow.readAsStringSync();
-    referenced = _referencedSecretsAndVars(yaml);
-    guarded = _guardedNames(yaml);
+    jobs = _jobSections(workflow.readAsStringSync());
   });
 
-  test('release.yml references store-deploy secrets (sanity)', () {
-    expect(referenced, isNotEmpty);
+  test('release.yml exposes the android and ios jobs (sanity)', () {
+    expect(jobs.keys, containsAll(<String>['android', 'ios']));
   });
 
-  test('every secret/var consumed by release.yml is covered by a preflight '
-      'fail-fast check (or allow-listed as optional)', () {
-    final unguarded =
-        referenced
-            .where(
-              (name) => !guarded.contains(name) && !optional.contains(name),
-            )
-            .toList()
-          ..sort();
+  test('each job guards every secret/var it consumes with its own preflight '
+      'fail-fast list (or a justified optional)', () {
+    final problems = <String>[];
+    jobs.forEach((job, body) {
+      final referenced = _referencedSecretsAndVars(body);
+      final guarded = _guardedNames(body);
+      final optional = optionalByJob[job] ?? const <String>{};
+      final unguarded =
+          referenced
+              .where((n) => !guarded.contains(n) && !optional.contains(n))
+              .map((n) => '[$job] $n')
+              .toList()
+            ..sort();
+      problems.addAll(unguarded);
+    });
     expect(
-      unguarded,
+      problems,
       isEmpty,
       reason:
-          'These secrets/vars are used by release.yml but no "Verify '
-          'required …" preflight step guards them, so a misconfigured repo '
-          'would fail deep inside the build instead of fast. Add each to a '
-          'required=( … ) list in the relevant job (or, if genuinely '
-          'optional, to the allowlist in this test):\n\n'
-          '${unguarded.join('\n')}',
+          'These secrets/vars are consumed by a release.yml job but are not '
+          "covered by that job's preflight required=( … ) list, so a "
+          'misconfigured repo would fail deep in the build instead of fast. '
+          'Add each to the right job (or, if gated on a runtime condition, to '
+          'optionalByJob in this test):\n\n${problems.join('\n')}',
     );
   });
 }
 
-/// Every distinct `secrets.X` / `vars.X` name referenced anywhere in the
-/// workflow, minus `GITHUB_TOKEN` (provided automatically by Actions, never
-/// user-configured).
-Set<String> _referencedSecretsAndVars(String yaml) {
-  final pattern = RegExp(r'\$\{\{\s*(?:secrets|vars)\.(\w+)\s*\}\}');
-  return {
-    for (final match in pattern.allMatches(yaml)) match.group(1)!,
-  }..remove('GITHUB_TOKEN');
+/// Slices release.yml into `{jobName: jobBody}` for the top-level jobs — the
+/// 2-space-indented keys under `jobs:` — so coverage is checked per job rather
+/// than against the union of every job's references and lists.
+Map<String, String> _jobSections(String yaml) {
+  final lines = yaml.split('\n');
+  final jobsStart = lines.indexWhere((line) => line == 'jobs:');
+  expect(
+    jobsStart,
+    isNonNegative,
+    reason: 'release.yml has no top-level `jobs:` key.',
+  );
+
+  final header = RegExp(r'^  ([A-Za-z0-9_-]+):\s*$');
+  final sections = <String, String>{};
+  String? current;
+  final buffer = StringBuffer();
+  void flush() {
+    final name = current;
+    if (name != null) sections[name] = buffer.toString();
+    buffer.clear();
+  }
+
+  for (final line in lines.skip(jobsStart + 1)) {
+    final match = header.firstMatch(line);
+    if (match != null) {
+      flush();
+      current = match.group(1);
+    } else if (current != null) {
+      buffer.writeln(line);
+    }
+  }
+  flush();
+  return sections;
 }
 
-/// The names listed inside every `required=( … )` bash array across the
-/// preflight steps — the workflow's own source of truth for what it checks.
+/// Every distinct `secrets.X` / `vars.X` name referenced in [yaml], minus
+/// `GITHUB_TOKEN` (provided automatically by Actions, never user-configured).
+Set<String> _referencedSecretsAndVars(String yaml) {
+  final pattern = RegExp(r'\$\{\{\s*(?:secrets|vars)\.(\w+)\s*\}\}');
+  return {for (final match in pattern.allMatches(yaml)) match.group(1)!}
+    ..remove('GITHUB_TOKEN');
+}
+
+/// The names listed inside every `required=( … )` bash array in [yaml] — the
+/// workflow's own source of truth for what each preflight checks.
 Set<String> _guardedNames(String yaml) {
   final blocks = RegExp(r'required=\(([^)]*)\)');
   final names = <String>{};

--- a/test/architecture/release_secrets_preflight_test.dart
+++ b/test/architecture/release_secrets_preflight_test.dart
@@ -1,0 +1,93 @@
+// Architecture guardrail: keeps the release workflow's fail-fast preflight in
+// sync with the secrets it actually consumes.
+//
+// .github/workflows/release.yml verifies every required store-deploy
+// secret/var at the top of each job (the `required=( … )` lists), so a
+// misconfigured repo fails in ~2s with a clear message instead of ~15 min into
+// a Fastlane build. If someone wires a new `secrets.X` / `vars.X` into a build
+// step but forgets to add it to a preflight list, that fail-fast guarantee
+// silently regresses — this test catches it.
+//
+// Pure file-scan, no third-party dependency; runs in the normal
+// `fvm flutter test` / CI flow.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final workflow = File('.github/workflows/release.yml');
+
+  // Names intentionally left out of the required lists: the preflight warns
+  // instead of failing when they're unset. Keep this set tiny and justified.
+  const optional = <String>{
+    // Only HTTPS match repos need basic-auth; SSH setups don't.
+    'MATCH_GIT_BASIC_AUTHORIZATION',
+  };
+
+  late final Set<String> referenced;
+  late final Set<String> guarded;
+
+  setUpAll(() {
+    expect(
+      workflow.existsSync(),
+      isTrue,
+      reason:
+          'Expected .github/workflows/release.yml relative to the current '
+          'directory. Run this test from the repository root.',
+    );
+    final yaml = workflow.readAsStringSync();
+    referenced = _referencedSecretsAndVars(yaml);
+    guarded = _guardedNames(yaml);
+  });
+
+  test('release.yml references store-deploy secrets (sanity)', () {
+    expect(referenced, isNotEmpty);
+  });
+
+  test('every secret/var consumed by release.yml is covered by a preflight '
+      'fail-fast check (or allow-listed as optional)', () {
+    final unguarded =
+        referenced
+            .where(
+              (name) => !guarded.contains(name) && !optional.contains(name),
+            )
+            .toList()
+          ..sort();
+    expect(
+      unguarded,
+      isEmpty,
+      reason:
+          'These secrets/vars are used by release.yml but no "Verify '
+          'required …" preflight step guards them, so a misconfigured repo '
+          'would fail deep inside the build instead of fast. Add each to a '
+          'required=( … ) list in the relevant job (or, if genuinely '
+          'optional, to the allowlist in this test):\n\n'
+          '${unguarded.join('\n')}',
+    );
+  });
+}
+
+/// Every distinct `secrets.X` / `vars.X` name referenced anywhere in the
+/// workflow, minus `GITHUB_TOKEN` (provided automatically by Actions, never
+/// user-configured).
+Set<String> _referencedSecretsAndVars(String yaml) {
+  final pattern = RegExp(r'\$\{\{\s*(?:secrets|vars)\.(\w+)\s*\}\}');
+  return {
+    for (final match in pattern.allMatches(yaml)) match.group(1)!,
+  }..remove('GITHUB_TOKEN');
+}
+
+/// The names listed inside every `required=( … )` bash array across the
+/// preflight steps — the workflow's own source of truth for what it checks.
+Set<String> _guardedNames(String yaml) {
+  final blocks = RegExp(r'required=\(([^)]*)\)');
+  final names = <String>{};
+  for (final block in blocks.allMatches(yaml)) {
+    for (final line in block.group(1)!.split('\n')) {
+      final name = line.trim();
+      if (name.isNotEmpty) names.add(name);
+    }
+  }
+  return names;
+}

--- a/test/architecture/release_secrets_preflight_test.dart
+++ b/test/architecture/release_secrets_preflight_test.dart
@@ -10,6 +10,12 @@
 // but forgets its job's preflight list, that fail-fast guarantee silently
 // regresses — this test catches it.
 //
+// A name can also be exempt from a job's `required=( … )` list when the job
+// gates it on a runtime condition this static test can't evaluate (e.g.
+// MATCH_GIT_BASIC_AUTHORIZATION is required only for an HTTPS match repo). Such
+// exemptions are *earned*: they hold only while the job body still contains the
+// runtime guard, so deleting the guard re-arms the static check.
+//
 // Pure file-scan, no third-party dependency; runs in the normal
 // `fvm flutter test` / CI flow.
 
@@ -17,19 +23,23 @@ import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 
+/// An exemption from a job's `required=( … )` list, valid only while every
+/// guard pattern still matches the job body. If the runtime guard is removed,
+/// the exemption lapses and the name must return to `required=( … )`.
+const _exemptions = <({String job, String name, List<String> guards})>[
+  (
+    job: 'ios',
+    name: 'MATCH_GIT_BASIC_AUTHORIZATION',
+    // The iOS preflight requires the token only for HTTPS match repos and
+    // hard-fails (`exit 1`) when it's missing under that branch; SSH repos
+    // don't need it. The transport rule lives in the workflow — this test only
+    // confirms the guard exists before honoring the exemption.
+    guards: [r'MATCH_GIT_URL"?\s*=~\s*\^https\?://', r'exit\s+1'],
+  ),
+];
+
 void main() {
   final workflow = File('.github/workflows/release.yml');
-
-  // Names a job's preflight intentionally omits from its required list because
-  // the workflow gates them on a runtime condition this static test can't
-  // evaluate. Keyed by job. Keep each entry tiny and justified.
-  const optionalByJob = <String, Set<String>>{
-    // The iOS preflight requires MATCH_GIT_BASIC_AUTHORIZATION only when
-    // MATCH_GIT_URL is HTTPS — a runtime check — and skips it for SSH. The
-    // transport rule lives in the workflow; here we just exempt it from the
-    // static presence check.
-    'ios': {'MATCH_GIT_BASIC_AUTHORIZATION'},
-  };
 
   late final Map<String, String> jobs;
 
@@ -49,15 +59,16 @@ void main() {
   });
 
   test('each job guards every secret/var it consumes with its own preflight '
-      'fail-fast list (or a justified optional)', () {
+      'fail-fast list (or an earned runtime exemption)', () {
     final problems = <String>[];
     jobs.forEach((job, body) {
       final referenced = _referencedSecretsAndVars(body);
       final guarded = _guardedNames(body);
-      final optional = optionalByJob[job] ?? const <String>{};
       final unguarded =
           referenced
-              .where((n) => !guarded.contains(n) && !optional.contains(n))
+              .where(
+                (n) => !guarded.contains(n) && !_isExempt(job, n, body),
+              )
               .map((n) => '[$job] $n')
               .toList()
             ..sort();
@@ -68,13 +79,40 @@ void main() {
       isEmpty,
       reason:
           'These secrets/vars are consumed by a release.yml job but are not '
-          "covered by that job's preflight required=( … ) list, so a "
-          'misconfigured repo would fail deep in the build instead of fast. '
-          'Add each to the right job (or, if gated on a runtime condition, to '
-          'optionalByJob in this test):\n\n${problems.join('\n')}',
+          "covered by that job's preflight required=( … ) list (nor an earned "
+          'runtime exemption), so a misconfigured repo would fail deep in the '
+          'build instead of fast. Add each to the right job (or, if gated on a '
+          'runtime condition, register an exemption in this test):\n\n'
+          '${problems.join('\n')}',
     );
   });
+
+  test("every runtime exemption is still earned by its job's guard", () {
+    for (final exemption in _exemptions) {
+      final body = jobs[exemption.job] ?? '';
+      for (final guard in exemption.guards) {
+        expect(
+          RegExp(guard).hasMatch(body),
+          isTrue,
+          reason:
+              'The ${exemption.job} preflight no longer matches /$guard/, '
+              'so the ${exemption.name} exemption is unjustified. Restore the '
+              'runtime guard, or move ${exemption.name} back into '
+              'required=( … ).',
+        );
+      }
+    }
+  });
 }
+
+/// Whether [name] is exempt from job [job]'s required list because the job
+/// [body] still carries every guard the exemption depends on.
+bool _isExempt(String job, String name, String body) => _exemptions.any(
+  (e) =>
+      e.job == job &&
+      e.name == name &&
+      e.guards.every((pattern) => RegExp(pattern).hasMatch(body)),
+);
 
 /// Slices release.yml into `{jobName: jobBody}` for the top-level jobs — the
 /// 2-space-indented keys under `jobs:` — so coverage is checked per job rather

--- a/test/architecture/release_secrets_preflight_test.dart
+++ b/test/architecture/release_secrets_preflight_test.dart
@@ -31,10 +31,14 @@ const _exemptions = <({String job, String name, List<String> guards})>[
     job: 'ios',
     name: 'MATCH_GIT_BASIC_AUTHORIZATION',
     // The iOS preflight requires the token only for HTTPS match repos and
-    // hard-fails (`exit 1`) when it's missing under that branch; SSH repos
-    // don't need it. The transport rule lives in the workflow — this test only
-    // confirms the guard exists before honoring the exemption.
-    guards: [r'MATCH_GIT_URL"?\s*=~\s*\^https\?://', r'exit\s+1'],
+    // hard-fails when it's missing under that branch; SSH repos don't need it.
+    // The guard matches the whole hard-fail path in order — the HTTPS scheme
+    // test, then the MATCH_GIT_BASIC_AUTHORIZATION check, then `exit 1` — so the
+    // exemption lapses if that specific path is removed. (A stray `exit 1`
+    // elsewhere in the job — e.g. the missing-secrets block — no longer counts.)
+    guards: [
+      r'MATCH_GIT_URL"?\s*=~\s*\^https\?://[\s\S]*?MATCH_GIT_BASIC_AUTHORIZATION[\s\S]*?exit\s+1',
+    ],
   ),
 ];
 

--- a/tool/ci-secrets-setup.sh
+++ b/tool/ci-secrets-setup.sh
@@ -77,7 +77,8 @@ secret_from_file() {  # NAME PROMPT base64|raw
   path="${path/#\~/$HOME}"
   if [[ -z "$path" ]]; then echo "  ↳ skipped $name"; return; fi
   if [[ ! -f "$path" ]]; then
-    echo "  ↳ error: no file at '$path' — skipped $name" >&2; return
+    echo "  ↳ error: no file at '$path' — aborting setup for $name" >&2
+    return 1
   fi
   if [[ "$encode" == base64 ]]; then
     base64 < "$path" | gh secret set "$name" --repo "$repo"

--- a/tool/ci-secrets-setup.sh
+++ b/tool/ci-secrets-setup.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+#
+# Bootstrap the GitHub Actions secrets/variables that
+# .github/workflows/release.yml needs to deploy to the App Store and Google
+# Play, pushing them with the `gh` CLI so you configure them once instead of
+# pasting ~15 values into Settings → Secrets by hand.
+#
+# Targets the repo `gh` is pointed at (override with --repo owner/name). Pick a
+# platform with --platform ios|android|both (default both). Re-runnable: setting
+# a secret again just overwrites it. Leave any prompt blank to skip that entry
+# (an optional secret, or one you already set). Nothing is written to disk —
+# file inputs are read and piped straight to `gh`.
+#
+# Usage: tool/ci-secrets-setup.sh [--repo owner/name] [--platform ios|android|both]
+set -euo pipefail
+
+repo=""
+platform="both"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo) repo="${2:?--repo needs owner/name}"; shift 2 ;;
+    --platform) platform="${2:?--platform needs ios|android|both}"; shift 2 ;;
+    -h|--help) sed -n '3,14p' "$0" | sed 's/^#\{0,1\} \{0,1\}//'; exit 0 ;;
+    *) echo "error: unknown argument '$1' (try --help)" >&2; exit 1 ;;
+  esac
+done
+
+case "$platform" in ios|android|both) ;; *)
+  echo "error: --platform must be ios, android, or both" >&2; exit 1 ;;
+esac
+
+command -v gh >/dev/null 2>&1 || {
+  echo "error: GitHub CLI (gh) not found — see https://cli.github.com" >&2
+  exit 1
+}
+gh auth status >/dev/null 2>&1 || {
+  echo "error: gh is not authenticated — run 'gh auth login' first" >&2
+  exit 1
+}
+
+if [[ -z "$repo" ]]; then
+  repo="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+fi
+echo "Target repo: $repo"
+echo "Leave a prompt blank to skip it."
+echo
+
+# A repository variable (non-secret, e.g. a bundle-id base).
+var_from_input() {  # NAME PROMPT
+  local name="$1" prompt="$2" value
+  read -r -p "  $prompt: " value || true
+  if [[ -z "$value" ]]; then echo "  ↳ skipped $name"; return; fi
+  gh variable set "$name" --repo "$repo" --body "$value"
+  echo "  ↳ set variable $name"
+}
+
+# A repository secret typed in directly. Pass a third arg of `hidden` to mask
+# the input (passwords); omit it for non-sensitive ids stored as secrets.
+secret_from_input() {  # NAME PROMPT [hidden]
+  local name="$1" prompt="$2" hidden="${3:-}" value
+  if [[ "$hidden" == hidden ]]; then
+    read -rs -p "  $prompt: " value || true; echo
+  else
+    read -r -p "  $prompt: " value || true
+  fi
+  if [[ -z "$value" ]]; then echo "  ↳ skipped $name"; return; fi
+  printf '%s' "$value" | gh secret set "$name" --repo "$repo"
+  echo "  ↳ set secret $name"
+}
+
+# A repository secret read from a file. encode=base64 for binary blobs the
+# workflow base64-decodes (keystore, plists); encode=raw for text stored
+# verbatim (the Play service-account JSON).
+secret_from_file() {  # NAME PROMPT base64|raw
+  local name="$1" prompt="$2" encode="$3" path
+  read -r -p "  $prompt: " path || true
+  path="${path/#\~/$HOME}"
+  if [[ -z "$path" ]]; then echo "  ↳ skipped $name"; return; fi
+  if [[ ! -f "$path" ]]; then
+    echo "  ↳ error: no file at '$path' — skipped $name" >&2; return
+  fi
+  if [[ "$encode" == base64 ]]; then
+    base64 < "$path" | gh secret set "$name" --repo "$repo"
+  else
+    gh secret set "$name" --repo "$repo" < "$path"
+  fi
+  echo "  ↳ set secret $name (from $path)"
+}
+
+if [[ "$platform" == both || "$platform" == android ]]; then
+  echo "Android → Google Play"
+  var_from_input    ANDROID_PACKAGE_NAME_BASE    "Base applicationId (e.g. com.acme.app)"
+  secret_from_file  ANDROID_GOOGLE_SERVICES_JSON "Path to google-services.json" base64
+  secret_from_file  ANDROID_KEYSTORE_BASE64      "Path to the upload keystore (.jks)" base64
+  secret_from_input ANDROID_KEYSTORE_PASSWORD    "Keystore password" hidden
+  secret_from_input ANDROID_KEY_PASSWORD         "Key password" hidden
+  secret_from_input ANDROID_KEY_ALIAS            "Key alias"
+  secret_from_file  PLAY_STORE_JSON_KEY          "Path to the Play service-account JSON" raw
+  echo
+fi
+
+if [[ "$platform" == both || "$platform" == ios ]]; then
+  echo "iOS → App Store"
+  var_from_input    IOS_BUNDLE_ID_BASE                 "Base bundle id (e.g. com.acme.app)"
+  secret_from_input APPLE_TEAM_ID                      "Apple Developer Team ID"
+  secret_from_input APP_STORE_CONNECT_API_KEY_ID       "App Store Connect API key id"
+  secret_from_input APP_STORE_CONNECT_API_ISSUER_ID    "App Store Connect API issuer id"
+  secret_from_file  APP_STORE_CONNECT_API_KEY_CONTENT  "Path to the AuthKey_*.p8" base64
+  secret_from_file  IOS_GOOGLE_SERVICE_INFO_PLIST      "Path to GoogleService-Info.plist" base64
+  secret_from_input MATCH_GIT_URL                      "match signing-assets repo URL"
+  secret_from_input MATCH_PASSWORD                     "match encryption passphrase" hidden
+  secret_from_input MATCH_GIT_BASIC_AUTHORIZATION      "match HTTPS auth, base64 user:token (blank for SSH)" hidden
+  echo
+fi
+
+echo "Done. The release workflow's preflight step lists anything still missing."


### PR DESCRIPTION
## FST-6 — CI secrets bootstrap + fail-fast

Last Sprint 1 (store pipeline) ticket. Before this, `release.yml` only failed
**deep inside Fastlane** (cryptic empty-base64 / auth errors, ~15 min into a
build) when a repo's store-deploy secrets weren't configured yet. Two halves fix
the DX:

### Fail-fast preflight (`.github/workflows/release.yml`)
A `Verify required …` step at the **top of each job** (before checkout/SDK
install) maps the store-deploy secrets/vars to `env` and checks them by indirect
expansion. Missing ones are listed in one `::error::` and the job exits in ~2s,
pointing at the bootstrap script and the fastlane README.

- **Android** — 6 secrets + `ANDROID_PACKAGE_NAME_BASE` var required.
- **iOS** — 7 secrets + `IOS_BUNDLE_ID_BASE` var required;
  `MATCH_GIT_BASIC_AUTHORIZATION` is **optional** (warns — only HTTPS `match`
  repos need it).
- Hard-fail by design (the ticket's "fail-fast" half). A single-platform app
  already saw the other platform's job go red — now it goes red in 2s with a
  clear reason instead of mid-build.
- Secrets are referenced via `env:` and read with `${!name}`, never
  interpolated into the `run:` script → template-injection-safe (zizmor).

### Bootstrap script (`tool/ci-secrets-setup.sh`)
Pushes every secret/var with the `gh` CLI in one shot instead of pasting ~15
values into the Settings UI: file blobs are base64-encoded (keystore, plists,
`.p8`) or sent raw (Play JSON), scalars are prompted (hidden for passwords),
optional entries are skippable. `--repo` / `--platform ios|android|both`,
idempotent, nothing written to disk.

### Guardrail (`test/architecture/release_secrets_preflight_test.dart`)
Scans every `secrets.X` / `vars.X` in `release.yml` and asserts each is covered
by a preflight `required=( … )` list (or the tiny optional allowlist) — so a
newly wired secret can't silently bypass fail-fast.

### Docs
Both fastlane READMEs now point at the bootstrap script next to their secret
tables.

## Verification
- Preflight logic run under real **bash** (incl. macOS bash 3.2): all set →
  exit 0; one missing → lists it, exit 1.
- `release.yml` parses as valid YAML (ruby/psych); `bash -n` + `--help` + bad-arg
  paths OK.
- Guardrail test passes; `flutter analyze` clean; `dart format` applied.
- No app/native code touched — no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “fail fast” preflight validation to Android and iOS release jobs to stop early and clearly report which required secrets/variables are missing.
  * Added a one-command script to bootstrap required release secrets/variables for Android, iOS, or both.
* **Documentation**
  * Updated Android and iOS CI guides to use the new setup command and note the early-failure behavior.
* **Tests**
  * Added/expanded a guardrail test to keep workflow-referenced secrets/variables aligned with each job’s required preflight list, including runtime exemption checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->