### PR TITLE
fix(ci): skip release jobs cleanly until the platform is configured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,12 @@ name: Release
 #     Android → internal track, with a chosen flavor/platform.
 #
 # Store-deploy is opt-in: configure the secrets and variables listed under each
-# job's `env:` (Settings → Secrets and variables → Actions) first. This workflow
-# only does the CI plumbing; the lane logic lives in ios/fastlane/Fastfile and
-# android/fastlane/Fastfile. See the fastlane READMEs.
+# job's `env:` (Settings → Secrets and variables → Actions) first. Each job runs
+# only when its platform identity variable (ANDROID_PACKAGE_NAME_BASE /
+# IOS_BUNDLE_ID_BASE) is set, so a repo that hasn't been configured — the
+# template itself, or a fresh scaffold — skips on a tag push instead of failing.
+# This workflow only does the CI plumbing; the lane logic lives in
+# ios/fastlane/Fastfile and android/fastlane/Fastfile. See the fastlane READMEs.
 
 on:
   push:
@@ -48,10 +51,18 @@ permissions:
 jobs:
   android:
     name: Android → Play
+    # Skip cleanly (no red run) until this platform is configured: the job runs
+    # only once its identity variable is set — which the build needs anyway and
+    # which tool/ci-secrets-setup.sh sets. A repo with no Play account (the
+    # template, a fresh scaffold) therefore skips on a tag push instead of
+    # failing the preflight; once configured, a missing *secret* still fails fast
+    # (the Verify step below). `vars` is readable in `if:`, secrets aren't —
+    # hence gating on the identity variable.
     if: >-
+      vars.ANDROID_PACKAGE_NAME_BASE != '' && (
       github.event_name == 'push' ||
       github.event.inputs.platform == 'both' ||
-      github.event.inputs.platform == 'android'
+      github.event.inputs.platform == 'android' )
     runs-on: ubuntu-latest
     steps:
       # Fail fast if the store-deploy secrets/vars aren't configured yet, so a
@@ -173,10 +184,14 @@ jobs:
 
   ios:
     name: iOS → TestFlight
+    # Skip cleanly until configured — see the Android job's note. Gated on the
+    # iOS identity variable so an unconfigured repo's tag push skips instead of
+    # failing the preflight.
     if: >-
+      vars.IOS_BUNDLE_ID_BASE != '' && (
       github.event_name == 'push' ||
       github.event.inputs.platform == 'both' ||
-      github.event.inputs.platform == 'ios'
+      github.event.inputs.platform == 'ios' )
     runs-on: macos-15
     steps:
       # Fail fast if the store-deploy secrets/vars aren't configured yet (see the

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -91,8 +91,10 @@ the lane. Expected repository secrets/vars:
 
 From the repository root, push all of these in one shot with
 `tool/ci-secrets-setup.sh --platform android` instead of pasting them into the
-Settings UI by hand. The workflow also fails fast at the top of the job if any
-required secret or variable is missing, naming exactly which.
+Settings UI by hand. The Android job runs only once `ANDROID_PACKAGE_NAME_BASE`
+is set, so a repo that hasn't configured Play skips on a tag push instead of
+failing; once it's set, the job fails fast if any required secret is still
+missing, naming exactly which.
 
 ## Troubleshooting (first real run)
 

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -92,8 +92,10 @@ required) on tag push / manual dispatch, with `FLUTTER_CMD=flutter` and
 
 From the repository root, push all of these in one shot with
 `tool/ci-secrets-setup.sh --platform ios` instead of pasting them into the
-Settings UI by hand. The workflow also fails fast at the top of the job if any
-required secret or variable is missing, naming exactly which.
+Settings UI by hand. The iOS job runs only once `IOS_BUNDLE_ID_BASE` is set, so
+a repo that hasn't configured the App Store skips on a tag push instead of
+failing; once it's set, the job fails fast if any required secret is still
+missing, naming exactly which.
 
 ## Troubleshooting (first real run)
 

--- a/test/architecture/release_secrets_preflight_test.dart
+++ b/test/architecture/release_secrets_preflight_test.dart
@@ -107,6 +107,27 @@ void main() {
       }
     }
   });
+
+  test('each deploy job is gated on its platform identity variable so an '
+      'unconfigured repo skips a tag push instead of failing', () {
+    const identityVarByJob = <String, String>{
+      'android': 'ANDROID_PACKAGE_NAME_BASE',
+      'ios': 'IOS_BUNDLE_ID_BASE',
+    };
+    identityVarByJob.forEach((job, identityVar) {
+      final body = jobs[job] ?? '';
+      expect(
+        body.contains("vars.$identityVar != ''"),
+        isTrue,
+        reason:
+            "The $job job's `if:` must gate on `vars.$identityVar != ''` so a "
+            'repo without $job store credentials skips on a tag push instead '
+            'of firing a red deploy run. (`vars` is readable in `if:`; secrets '
+            'are not — and the identity variable is what the build needs '
+            'anyway.)',
+      );
+    });
+  });
 }
 
 /// Whether [name] is exempt from job [job]'s required list because the job

--- a/test/architecture/release_secrets_preflight_test.dart
+++ b/test/architecture/release_secrets_preflight_test.dart
@@ -116,8 +116,12 @@ void main() {
     };
     identityVarByJob.forEach((job, identityVar) {
       final body = jobs[job] ?? '';
+      // Only the job header (everything before `runs-on:`) holds the job-level
+      // `if:`; scanning the whole body would also pass on a step-level `if:`,
+      // missing the exact regression this guards against.
+      final header = body.split(RegExp(r'^\s*runs-on:', multiLine: true)).first;
       expect(
-        body.contains("vars.$identityVar != ''"),
+        header.contains("vars.$identityVar != ''"),
         isTrue,
         reason:
             "The $job job's `if:` must gate on `vars.$identityVar != ''` so a "


### PR DESCRIPTION
## Skip release jobs cleanly until the platform is configured

Follow-up to the Sprint 1 store pipeline. FST-5 (#181) made `vX.Y.Z` tags
trigger `release.yml`, and FST-6 (#182) hard-fails the job when required store
secrets are missing. Combined, the **template's own version tags** (it has no
App Store / Play account) now fire a **red deploy run** — and so would every
freshly-scaffolded app on its first tag.

### Fix
Gate each deploy job on its platform **identity variable**:

- `android` `if:` → `vars.ANDROID_PACKAGE_NAME_BASE != '' && ( … )`
- `ios` `if:` → `vars.IOS_BUNDLE_ID_BASE != '' && ( … )`

`vars` is readable in a job `if:` (secrets are not), and the identity variable
is what the build needs anyway — so configuring a platform implicitly enables
it. The OR group is parenthesised so `&&`/`||` precedence is correct.

Behaviour, by state:

| State | Result |
|---|---|
| Not configured (template, fresh scaffold) | job **skips** → run is **not red** |
| Configured but a secret is missing | preflight **fails fast** (FST-6 preserved) |
| Fully configured | deploys |

`tool/ci-secrets-setup.sh` already sets these identity variables, so running it
to configure a platform also enables its release job — no separate flag.

### Also
- Refresh the `release.yml` opt-in header comment.
- Document the identity-variable gate in both fastlane READMEs.
- `release_secrets_preflight_test.dart`: assert each deploy job is gated on its
  identity variable, so the skip-when-unconfigured behaviour can't silently
  regress.

### Verification
- `release.yml` parses as valid YAML; the rendered `if:` expressions are
  `vars.<ID> != '' && ( github.event_name == 'push' || … )`.
- `flutter analyze` clean; guardrail test 4/4 (incl. the new gate assertion).
- No app/native code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Android and iOS release jobs now conditionally run only when the required platform identity settings are configured, skipping cleanly otherwise.
  * Tag-based releases behave more predictably for repositories without platform release configuration.

* **Documentation**
  * Updated Android and iOS CI documentation to explain skip vs fail-fast behavior after configuration changes.

* **Tests**
  * Added a test to verify Android/iOS deploy jobs are gated by their respective identity variables in the workflow job conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->