### PR TITLE
chore(release): 1.9.0 — store release pipeline (Sprint 1)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.8.0+1
+version: 1.9.0+1
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
Cuts **v1.9.0**, capturing Sprint 1 — the mobile **store release pipeline** — plus the iOS privacy/permission work landed since v1.8.0.

Only `pubspec.yaml` changes here (`1.8.0+1 → 1.9.0+1`); the tag + GitHub Release follow once this merges. `published/cli` stays at `ac4ff2d` (already CLI main tip since #180) — no re-point needed this cycle.

### What's in 1.9.0
- **FST-1** (#174): app-level iOS Privacy Manifest (ITMS-91053 compliance).
- **FST-2** (#176, #180): generic, app-name-aware permission usage strings; strip orphaned media permissions when the bookmarks feature is removed.
- **FST-4** (#178): App Store / Play **production** Fastlane lanes + store metadata.
- **FST-5** (#181): tag-triggered production release; version name stamped from the tag.
- **FST-6** (#182): fail-fast preflight on missing release secrets + `tool/ci-secrets-setup.sh` bootstrap.
- **#183**: deploy jobs skip cleanly until the platform is configured — an unconfigured repo's tag push no longer fires a red run.
- Dependency bumps: faraday (#175), firebase_messaging (#166), actions/cache (#165); cli-smoke iOS guard (#177).

### After merge
Tag `v1.9.0` on the merge commit → push → create the GitHub Release. The tag push exercises `release.yml`; with no store vars/secrets configured, both deploy jobs **skip cleanly** (validating #183) rather than failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app/package version from `1.8.0+1` to `1.9.0+1`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->