### PR TITLE
chore(release): 1.10.0 — Drift/SQLite database support (FST-7)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.9.0+1
+version: 1.10.0+1
 
 environment:
   sdk: ^3.12.0


### PR DESCRIPTION
## Summary

- Bumps template `version` to `1.10.0+1` in `pubspec.yaml`
- Re-pins `published/cli` to CLI 1.3.0 release commit (`2e2ddc6`)

### What's in 1.10.0

**FST-7 — Drift/SQLite database support**

- New `packages/database_drift/` package: Drift tables (Bookmarks, Collections, Notifications, Activities, SyncCursors), entity classes implementing `Syncable` where applicable, `AppDatabase` with `factory AppDatabase.open()`, generated binding committed and un-ignored in `.gitignore`.
- `fst:db:objectbox` / `fst:db:drift` marker regions in `pubspec.yaml` and `test/architecture/package_layering_test.dart`.
- `published/cli` re-pinned to CLI v1.3.0 which adds `fst create --database drift`: renames `packages/database_drift` → `packages/database`, deletes ObjectBox files, writes `DriftModule` DI module + optional `DriftSyncCursorStore`, and overwrites the three demo-feature data-source files with Drift-backed implementations.

## Test plan

- [ ] CI: Analyze & Test, all CLI scaffold variants, Android + iOS builds, golden tests all green
- [ ] Tag `v1.10.0` after merge to trigger the production release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)