### PR TITLE
fix: make every scaffold configuration compile, analyze and test clean

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,12 @@ jobs:
         run: |
           ./tool/codegen.sh
           (cd packages/database && dart run build_runner build --delete-conflicting-outputs)
+          drift_files="packages/database_drift/lib/src/app_database.g.dart packages/database_drift/drift_schemas"
+          if ! git diff --quiet --exit-code -- $drift_files; then
+            echo "::error::Drift generated files are out of date. Run tool/codegen.sh and commit the regenerated binding + schema snapshot."
+            git diff --stat -- $drift_files
+            exit 1
+          fi
           objectbox_files="packages/database/lib/objectbox.g.dart packages/database/lib/objectbox-model.json"
           if ! git diff --quiet --exit-code -- $objectbox_files; then
             echo "::error::ObjectBox generated files are out of date. Run 'dart run build_runner build --delete-conflicting-outputs' inside packages/database and commit the binding + model."
@@ -289,6 +295,12 @@ jobs:
           - { name: no-auth, flags: '--no-auth' }
           - { name: no-backend, flags: '--no-backend' }
           - { name: minimal, flags: '--minimal' }
+          # Drift diverges from ObjectBox in what it can strip — it drops
+          # per-feature tables and the sync engine, ObjectBox keeps both — so
+          # the configs where that shows have to be covered on both engines.
+          - { name: default-drift, flags: '--database drift' }
+          - { name: exclude-bookmarks-drift, flags: '--exclude-feature bookmarks --database drift' }
+          - { name: minimal-drift, flags: '--minimal --database drift' }
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -338,8 +350,6 @@ jobs:
             || { echo "::error::dev submodule published/cli leaked"; fail=1; }
           [ ! -d "$out/simple_backend_server" ] \
             || { echo "::error::dev submodule simple_backend_server leaked"; fail=1; }
-          [ -d "$out/published/rev_sync" ] \
-            || { echo "::error::rev_sync path-dependency missing"; fail=1; }
           [ -d "$out/.git" ] \
             || { echo "::error::no fresh git repo was initialised"; fail=1; }
           if grep -rIl 'flutter_starter_template\|lucistudio\|Luci Studio' \
@@ -392,53 +402,177 @@ jobs:
             done
           }
 
+          # rev_sync is a path dependency, so a scaffold that keeps it must
+          # keep the directory — and one that sheds it must shed both. Only
+          # `--database drift` with the backend off can: ObjectBox entities
+          # implement `Syncable`, so on that path the engine always stays.
+          assert_rev_sync_present() {
+            [ -d "$out/published/rev_sync" ] \
+              || { echo "::error::rev_sync path-dependency missing ($CONFIG)"; fail=1; }
+            grep -q 'rev_sync' "$out/pubspec.yaml" \
+              || { echo "::error::rev_sync dependency wrongly stripped ($CONFIG)"; fail=1; }
+          }
+
+          assert_rev_sync_absent() {
+            [ ! -d "$out/published/rev_sync" ] \
+              || { echo "::error::rev_sync directory not removed ($CONFIG)"; fail=1; }
+            if grep -q 'rev_sync' "$out/pubspec.yaml"; then
+              echo "::error::rev_sync dependency left behind, pub get will fail ($CONFIG)"; fail=1
+            fi
+          }
+
+          # A table whose feature is gone is dead schema: created on every
+          # install, replayed in every migration.
+          assert_drift_table_absent() {
+            local table="$1"
+            [ ! -f "$out/packages/database/lib/src/tables/${table}_table.dart" ] \
+              || { echo "::error::${table} table not removed ($CONFIG)"; fail=1; }
+            if grep -q "${table}_table" "$out/packages/database/lib/src/app_database.dart"; then
+              echo "::error::${table} still registered in AppDatabase ($CONFIG)"; fail=1
+            fi
+          }
+
           # ── Per-config structural assertions ──
           case "$CONFIG" in
-            default)
+            default|default-drift)
               [ -d "$auth" ] || { echo "::error::auth removed in default"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks missing in default"; fail=1; }
               assert_media_perms_present
+              assert_rev_sync_present
               ;;
             exclude-notifications)
               [ ! -d "$notifications" ] || { echo "::error::notifications not removed"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks wrongly removed"; fail=1; }
               assert_media_perms_present
+              assert_rev_sync_present
               ;;
-            exclude-bookmarks)
+            exclude-bookmarks|exclude-bookmarks-drift)
               [ ! -d "$bookmarks" ] || { echo "::error::bookmarks not removed (exclude-bookmarks)"; fail=1; }
               [ -d "$out/packages/features/collections" ] || { echo "::error::collections wrongly removed (exclude-bookmarks)"; fail=1; }
               [ -d "$auth" ] || { echo "::error::auth wrongly removed (exclude-bookmarks)"; fail=1; }
               assert_no_media_perms
+              assert_rev_sync_present
               grep -q 'android.permission.POST_NOTIFICATIONS' "$manifest" \
                 || { echo "::error::POST_NOTIFICATIONS wrongly stripped (exclude-bookmarks)"; fail=1; }
+              if [ "$CONFIG" = exclude-bookmarks-drift ]; then
+                assert_drift_table_absent bookmarks
+                [ -f "$out/packages/database/lib/src/tables/collections_table.dart" ] \
+                  || { echo "::error::collections table wrongly removed ($CONFIG)"; fail=1; }
+              fi
               ;;
             no-firebase)
               [ -d "$auth" ] || { echo "::error::auth removed in no-firebase"; fail=1; }
               [ ! -f "$out/android/app/google-services.json" ] || { echo "::error::firebase config left in no-firebase"; fail=1; }
+              assert_rev_sync_present
               ;;
             no-auth)
               [ ! -d "$auth" ] || { echo "::error::auth package not removed (no-auth)"; fail=1; }
               [ ! -f "$profile_header" ] || { echo "::error::profile_header not removed (no-auth)"; fail=1; }
               [ -d "$bookmarks" ] || { echo "::error::bookmarks wrongly removed (no-auth)"; fail=1; }
+              assert_rev_sync_present
               if grep -rIq 'fst:auth:' "$out/lib" "$out/test" "$out/packages" 2>/dev/null; then
                 echo "::error::fst:auth markers survived the strip (no-auth)"; fail=1
               fi
               ;;
-            no-backend|minimal)
+            no-backend|minimal|minimal-drift)
               [ ! -d "$auth" ] || { echo "::error::auth not removed ($CONFIG)"; fail=1; }
               [ ! -d "$network" ] || { echo "::error::network not removed ($CONFIG)"; fail=1; }
               [ ! -d "$syncconn" ] || { echo "::error::sync_connectivity_plus not removed ($CONFIG)"; fail=1; }
               [ ! -d "$bookmarks" ] || { echo "::error::bookmarks not removed ($CONFIG)"; fail=1; }
               [ ! -d "$out/packages/features/collections" ] || { echo "::error::collections not removed ($CONFIG)"; fail=1; }
               [ ! -d "$notifications" ] || { echo "::error::notifications not removed ($CONFIG)"; fail=1; }
-              [ -d "$out/published/rev_sync" ] || { echo "::error::rev_sync wrongly removed ($CONFIG)"; fail=1; }
               if grep -rIq 'fst:backend:\|fst:auth:' "$out/lib" "$out/test" "$out/packages" 2>/dev/null; then
                 echo "::error::fst markers survived the strip ($CONFIG)"; fail=1
               fi
               assert_no_media_perms
+              [ ! -d "$out/integration_test" ] \
+                || { echo "::error::demo e2e suite not removed ($CONFIG)"; fail=1; }
+              if [ "$CONFIG" = minimal-drift ]; then
+                assert_rev_sync_absent
+                for t in bookmarks collections notifications activities sync_cursors; do
+                  assert_drift_table_absent "$t"
+                done
+              else
+                assert_rev_sync_present
+              fi
               ;;
           esac
           exit $fail
+
+  # The assertions above prove the right files are gone; only the analyzer
+  # proves what's left still compiles. That gap is exactly how a --minimal
+  # scaffold once shipped with 39 analyzer errors — every strip target was
+  # correctly removed, and the source still referencing it was not.
+  #
+  # Deliberately a separate job from cli-smoke: this one needs the Flutter SDK
+  # and a full codegen run per config, so it is minutes rather than seconds.
+  # The matrix is therefore the four corners — both engines at their fullest
+  # and their emptiest — rather than every flag combination.
+  cli-scaffold-analyze:
+    name: CLI scaffold analyzes (${{ matrix.name }})
+    needs: changes
+    if: needs.changes.outputs.cli == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: default, flags: '' }
+          - { name: default-drift, flags: '--database drift' }
+          - { name: minimal, flags: '--minimal' }
+          - { name: minimal-drift, flags: '--minimal --database drift' }
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Check out CLI + rev_sync submodules
+        run: git submodule update --init published/cli published/rev_sync
+
+      # Same SDK as .fvmrc (3.44.0); bump together. Provides the `dart` the CLI
+      # runs on too, so no separate setup-dart step is needed.
+      - name: Set up Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: 3.44.0
+          channel: stable
+          cache: true
+
+      - name: Resolve CLI dependencies
+        working-directory: published/cli
+        run: dart pub get
+
+      - name: Scaffold a project from this checkout
+        working-directory: published/cli
+        run: |
+          dart run bin/fst.dart create \
+            --yes \
+            --name "Smoke App" \
+            --package-name smoke_app \
+            --bundle-id com.example.smoke \
+            --org "Smoke Org" \
+            --template-path "$GITHUB_WORKSPACE" \
+            --output-dir "$RUNNER_TEMP/analyze-smoke" \
+            --no-setup \
+            ${{ matrix.flags }}
+
+      # Runs the scaffold's own bootstrap rather than open-coding the steps, so
+      # a break in tool/setup.sh fails here too. --no-hooks keeps CI out of the
+      # pre-push gate; --no-backend skips Go deps the analyzer doesn't need.
+      # Generated code is git-ignored, so a scaffold from a fresh checkout has
+      # none and cannot be analyzed until this has run.
+      - name: Bootstrap the scaffold
+        working-directory: ${{ runner.temp }}/analyze-smoke
+        run: ./tool/setup.sh --no-hooks --no-backend
+
+      - name: Analyze the scaffold
+        working-directory: ${{ runner.temp }}/analyze-smoke
+        run: flutter analyze
+
+      - name: Test the scaffold
+        working-directory: ${{ runner.temp }}/analyze-smoke
+        run: flutter test
 
   # Compile smoke-test: `flutter analyze` type-checks Dart but never assembles
   # the app, so Gradle/plugin/asset/manifest regressions slip past it and only

--- a/README.md
+++ b/README.md
@@ -421,9 +421,15 @@ cd flutter-starter-template
 ```bash
 fvm flutter pub get
 fvm dart run build_runner build --delete-conflicting-outputs
+fvm dart fix --apply --code=directives_ordering .      # see below
 fvm flutter config --no-enable-swift-package-manager   # macOS only — see below
 git config core.hooksPath .githooks                    # enable the pre-push gate
 ```
+
+The `dart fix` step matters in a scaffolded project, not in this repo:
+`fst create` renames the app package, which moves its own imports in the
+alphabetical order `directives_ordering` expects. Re-sorting with the
+analyzer's own fix is exact, and a no-op here.
 
 </details>
 
@@ -1030,20 +1036,30 @@ Until you do, your IDE/analyzer will show errors for the missing generated
 sources. This keeps PR diffs free of generated noise and avoids
 generated-file merge conflicts.
 
-**ObjectBox is the one deliberate exception** — `lib/objectbox.g.dart` **and**
-`lib/objectbox-model.json` stay version-controlled (the `.gitignore` negates
-the binding; the model file matches no glob). Together they hold the stable
-entity/property **UIDs** that keep on-device data intact across schema
-migrations, so regenerating them from scratch would risk a destructive schema
-change. Both are source-of-truth files.
+**The database packages are the deliberate exceptions.** ObjectBox's
+`lib/objectbox.g.dart` **and** `lib/objectbox-model.json` stay
+version-controlled (the `.gitignore` negates the binding; the model file
+matches no glob). Together they hold the stable entity/property **UIDs** that
+keep on-device data intact across schema migrations, so regenerating them from
+scratch would risk a destructive schema change. Drift's
+`lib/src/app_database.g.dart` and its `drift_schemas/` snapshots are tracked
+for a related reason: the snapshots are the only record of what each released
+`schemaVersion` looked like, and every migration test replays from them. All
+are source-of-truth files.
+
+That difference in UID stability is also why only the Drift package is
+regenerated at scaffold time: `fst create` can remove a feature's table, so
+the binding has to be rebuilt against what survived. ObjectBox keeps its
+entities instead — see [`drift_schemas/README.md`](packages/database_drift/drift_schemas/README.md)
+for the schema-change workflow.
 
 How the pieces stay consistent:
 
 - **CI** ([`.github/workflows/ci.yml`](.github/workflows/ci.yml)) runs
   `build_runner` before analyze/test (producing the ignored files), and the
   _"Generate code & verify ObjectBox binding is up to date"_ step fails if the
-  tracked ObjectBox files drift — i.e. someone changed an `@Entity` without
-  committing the regenerated binding.
+  tracked database files drift — i.e. someone changed an `@Entity` or a Drift
+  table without committing the regenerated binding.
 - **Release lanes** ([`.github/workflows/release.yml`](.github/workflows/release.yml))
   run `build_runner` before the Fastlane build, since `flutter build` does not.
 - **`.dart_tool/build` is intentionally not cached** in CI/release. Because the

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
+    <!-- Lets NotificationsService.scheduleDaily survive a reboot: Android
+         drops every pending alarm on shutdown, so the plugin re-registers
+         them from its boot receiver below. -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <!-- fst:feature:bookmarks:start -->
     <!-- Media-capture permissions for the bookmarks feature; stripped by the
          fst CLI when bookmarks is removed. -->
@@ -45,6 +49,18 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Re-arms scheduled notifications after a reboot or an app update.
+             Required by flutter_local_notifications' zonedSchedule. -->
+        <receiver
+            android:name="com.dexterous.flutterlocalnotifications.ScheduledNotificationBootReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED"/>
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED"/>
+                <action android:name="android.intent.action.QUICKBOOT_POWERON"/>
+                <action android:name="com.htc.intent.action.QUICKBOOT_POWERON"/>
+            </intent-filter>
+        </receiver>
     </application>
     <queries>
         <intent>

--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -60,9 +60,11 @@ class _AppState extends State<App> {
   // fst:auth:end
   late final ThemeBloc _themeBloc;
   Session? _session;
+  // fst:auth:start
   // Whether this State created _session (and so must dispose it). An injected
   // widget.session is owned by the caller and must outlive this widget.
   bool _ownsSession = false;
+  // fst:auth:end
   late final GoRouter _router;
   late final DeepLinkState _deepLink;
   late final List<FeatureSyncController> _syncControllers;
@@ -152,9 +154,11 @@ class _AppState extends State<App> {
         }),
       );
     }
+    // fst:auth:start
     if (_ownsSession) {
       _session?.dispose();
     }
+    // fst:auth:end
     _router.dispose();
     super.dispose();
   }

--- a/packages/app_platform/lib/src/notifications/notifications_service.dart
+++ b/packages/app_platform/lib/src/notifications/notifications_service.dart
@@ -1,5 +1,8 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:injectable/injectable.dart';
+import 'package:timezone/data/latest_all.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
 
 import '../permissions/permission_service.dart';
 
@@ -29,6 +32,13 @@ class NotificationsService {
 
   Future<void> init() async {
     if (_initialized) return;
+    // Load the IANA database and pin `tz.local` to the device's zone. Without
+    // this `tz.local` is UTC, so [scheduleDaily] would fire at the wrong wall
+    // time for everyone outside it.
+    tz_data.initializeTimeZones();
+    final localZone = await FlutterTimezone.getLocalTimezone();
+    tz.setLocalLocation(tz.getLocation(localZone.identifier));
+
     const initSettings = InitializationSettings(
       android: AndroidInitializationSettings('@mipmap/ic_launcher'),
       iOS: DarwinInitializationSettings(
@@ -78,6 +88,71 @@ class NotificationsService {
       ),
       payload: payload,
     );
+  }
+
+  /// Schedules [id] to fire every day at [hour]:[minute] device-local time.
+  ///
+  /// Scheduling the same [id] again replaces the pending one, so calling this
+  /// whenever the user picks a new time needs no [cancel] first. The schedule
+  /// survives reboots on both platforms; it does not survive an app
+  /// reinstall, so re-arm it on startup from whatever stores the preference.
+  ///
+  /// [init] must have run first — it pins the local timezone.
+  ///
+  /// Android uses an inexact alarm so the app needs no `SCHEDULE_EXACT_ALARM`
+  /// permission (Google rejects it for anything but alarms and calendars).
+  /// Delivery may drift by a few minutes, which is the right trade for a
+  /// reminder; a wake-the-user alarm would need [AndroidScheduleMode.alarmClock]
+  /// and that permission.
+  Future<void> scheduleDaily({
+    required int id,
+    required String title,
+    required String body,
+    required int hour,
+    required int minute,
+    String? payload,
+  }) {
+    return _plugin.zonedSchedule(
+      id: id,
+      title: title,
+      body: body,
+      scheduledDate: _nextInstanceOf(hour: hour, minute: minute),
+      notificationDetails: NotificationDetails(
+        android: AndroidNotificationDetails(
+          _defaultChannel.id,
+          _defaultChannel.name,
+          channelDescription: _defaultChannel.description,
+          importance: _defaultChannel.importance,
+        ),
+        iOS: const DarwinNotificationDetails(),
+        macOS: const DarwinNotificationDetails(),
+      ),
+      androidScheduleMode: AndroidScheduleMode.inexactAllowWhileIdle,
+      // Repeats daily by matching only the time-of-day components.
+      matchDateTimeComponents: DateTimeComponents.time,
+      payload: payload,
+    );
+  }
+
+  /// The next [hour]:[minute] in the device's zone — today when it is still
+  /// ahead, otherwise tomorrow.
+  ///
+  /// Uses `!isAfter` rather than `isBefore` so scheduling for the current
+  /// minute lands tomorrow instead of firing immediately.
+  static tz.TZDateTime _nextInstanceOf({
+    required int hour,
+    required int minute,
+  }) {
+    final now = tz.TZDateTime.now(tz.local);
+    final today = tz.TZDateTime(
+      tz.local,
+      now.year,
+      now.month,
+      now.day,
+      hour,
+      minute,
+    );
+    return today.isAfter(now) ? today : today.add(const Duration(days: 1));
   }
 
   Future<void> cancel(int id) => _plugin.cancel(id: id);

--- a/packages/app_platform/lib/src/notifications/notifications_service.dart
+++ b/packages/app_platform/lib/src/notifications/notifications_service.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_timezone/flutter_timezone.dart';
 import 'package:injectable/injectable.dart';
@@ -116,7 +117,11 @@ class NotificationsService {
       id: id,
       title: title,
       body: body,
-      scheduledDate: _nextInstanceOf(hour: hour, minute: minute),
+      scheduledDate: nextDailyInstance(
+        now: tz.TZDateTime.now(tz.local),
+        hour: hour,
+        minute: minute,
+      ),
       notificationDetails: NotificationDetails(
         android: AndroidNotificationDetails(
           _defaultChannel.id,
@@ -134,28 +139,47 @@ class NotificationsService {
     );
   }
 
-  /// The next [hour]:[minute] in the device's zone — today when it is still
-  /// ahead, otherwise tomorrow.
-  ///
-  /// Uses `!isAfter` rather than `isBefore` so scheduling for the current
-  /// minute lands tomorrow instead of firing immediately.
-  static tz.TZDateTime _nextInstanceOf({
-    required int hour,
-    required int minute,
-  }) {
-    final now = tz.TZDateTime.now(tz.local);
-    final today = tz.TZDateTime(
-      tz.local,
-      now.year,
-      now.month,
-      now.day,
-      hour,
-      minute,
-    );
-    return today.isAfter(now) ? today : today.add(const Duration(days: 1));
-  }
-
   Future<void> cancel(int id) => _plugin.cancel(id: id);
 
   Future<void> cancelAll() => _plugin.cancelAll();
+}
+
+/// The next [hour]:[minute] after [now] in `now`'s zone — today when it is
+/// still ahead, otherwise tomorrow.
+///
+/// Tomorrow is built from calendar fields rather than `now.add(Duration(days:
+/// 1))`, because `Duration` is absolute elapsed time: a day that crosses a
+/// daylight-saving transition is 23 or 25 hours long, so adding exactly 24
+/// would shift the reminder an hour off the time the user picked.
+///
+/// Compares with `isAfter` rather than `isBefore` so scheduling for the
+/// current minute lands tomorrow instead of firing immediately.
+///
+/// Top-level and visible for testing because the interesting behaviour is
+/// entirely a function of [now], which the service reads from the clock.
+@visibleForTesting
+tz.TZDateTime nextDailyInstance({
+  required tz.TZDateTime now,
+  required int hour,
+  required int minute,
+}) {
+  final today = tz.TZDateTime(
+    now.location,
+    now.year,
+    now.month,
+    now.day,
+    hour,
+    minute,
+  );
+  if (today.isAfter(now)) return today;
+  // TZDateTime normalises an overflowing day the way DateTime does, so this
+  // rolls into the next month or year on its own.
+  return tz.TZDateTime(
+    now.location,
+    now.year,
+    now.month,
+    now.day + 1,
+    hour,
+    minute,
+  );
 }

--- a/packages/app_platform/pubspec.yaml
+++ b/packages/app_platform/pubspec.yaml
@@ -24,6 +24,8 @@ dependencies:
   permission_handler: ^12.0.3
   share_plus: ^13.1.0
   video_player: ^2.11.1
+  timezone: ^0.11.1
+  flutter_timezone: ^5.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/app_platform/test/notifications/notifications_service_test.dart
+++ b/packages/app_platform/test/notifications/notifications_service_test.dart
@@ -1,0 +1,150 @@
+// Covers the scheduling maths behind `scheduleDaily` — the part that decides
+// *when* a reminder lands. `init()` is deliberately not exercised: it reads the
+// device zone over a method channel, which no unit test can answer, so the
+// local zone is pinned here instead and the plugin call is captured.
+
+import 'package:app_platform/app_platform.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_utils/test_utils.dart';
+import 'package:timezone/data/latest_all.dart' as tz_data;
+import 'package:timezone/timezone.dart' as tz;
+
+class _MockPlugin extends Mock implements FlutterLocalNotificationsPlugin {}
+
+class _FakePermissionService extends PermissionService {
+  _FakePermissionService()
+    : super.custom(
+        () async => PermissionStatus.granted,
+        () async => PermissionStatus.granted,
+        () async => false,
+        () async => false,
+      );
+}
+
+void main() {
+  late _MockPlugin plugin;
+  late NotificationsService service;
+
+  setUpAll(() {
+    tz_data.initializeTimeZones();
+    // A fixed non-UTC zone: a bug that silently schedules in UTC would still
+    // look correct if the test ran in UTC.
+    tz.setLocalLocation(tz.getLocation('Asia/Ho_Chi_Minh'));
+    registerFallbackValue(const NotificationDetails());
+    registerFallbackValue(AndroidScheduleMode.inexactAllowWhileIdle);
+    registerFallbackValue(tz.TZDateTime.now(tz.local));
+  });
+
+  void stubSchedule() {
+    when(
+      () => plugin.zonedSchedule(
+        id: any(named: 'id'),
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        scheduledDate: any(named: 'scheduledDate'),
+        notificationDetails: any(named: 'notificationDetails'),
+        androidScheduleMode: any(named: 'androidScheduleMode'),
+        matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+        payload: any(named: 'payload'),
+      ),
+    ).thenAnswer((_) async {});
+  }
+
+  setUp(() {
+    plugin = _MockPlugin();
+    service = NotificationsService(plugin, _FakePermissionService());
+    stubSchedule();
+  });
+
+  Future<tz.TZDateTime> scheduledDateFor({
+    required int hour,
+    required int minute,
+  }) async {
+    await service.scheduleDaily(
+      id: 1,
+      title: 'Time to review',
+      body: '12 cards are due',
+      hour: hour,
+      minute: minute,
+    );
+    final captured = verify(
+      () => plugin.zonedSchedule(
+        id: any(named: 'id'),
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        scheduledDate: captureAny(named: 'scheduledDate'),
+        notificationDetails: any(named: 'notificationDetails'),
+        androidScheduleMode: any(named: 'androidScheduleMode'),
+        matchDateTimeComponents: any(named: 'matchDateTimeComponents'),
+        payload: any(named: 'payload'),
+      ),
+    ).captured;
+    return captured.single as tz.TZDateTime;
+  }
+
+  test('schedules the requested wall-clock time in the local zone', () async {
+    final scheduled = await scheduledDateFor(hour: 7, minute: 30);
+
+    expect(scheduled.hour, 7);
+    expect(scheduled.minute, 30);
+    expect(scheduled.location, tz.local);
+  });
+
+  test('always lands in the future, within the next 24 hours', () async {
+    // Covers both branches without a fake clock: whichever side of `now` the
+    // requested time falls on, the result must still be ahead and no more than
+    // a day out. An off-by-one that scheduled in the past would fire instantly.
+    for (final offset in const [
+      Duration(hours: -6),
+      Duration(minutes: -1),
+      Duration(minutes: 1),
+      Duration(hours: 6),
+    ]) {
+      final target = tz.TZDateTime.now(tz.local).add(offset);
+      final scheduled = await scheduledDateFor(
+        hour: target.hour,
+        minute: target.minute,
+      );
+      final now = tz.TZDateTime.now(tz.local);
+
+      expect(
+        scheduled.isAfter(now),
+        isTrue,
+        reason: 'offset $offset scheduled $scheduled, which is not after $now',
+      );
+      expect(
+        scheduled.difference(now),
+        lessThanOrEqualTo(const Duration(days: 1)),
+      );
+      // `verify` consumes the recorded call, so start each offset clean.
+      reset(plugin);
+      stubSchedule();
+    }
+  });
+
+  test('repeats daily without requiring an exact-alarm permission', () async {
+    await service.scheduleDaily(
+      id: 1,
+      title: 't',
+      body: 'b',
+      hour: 9,
+      minute: 0,
+    );
+
+    final captured = verify(
+      () => plugin.zonedSchedule(
+        id: any(named: 'id'),
+        title: any(named: 'title'),
+        body: any(named: 'body'),
+        scheduledDate: any(named: 'scheduledDate'),
+        notificationDetails: any(named: 'notificationDetails'),
+        androidScheduleMode: captureAny(named: 'androidScheduleMode'),
+        matchDateTimeComponents: captureAny(named: 'matchDateTimeComponents'),
+        payload: any(named: 'payload'),
+      ),
+    ).captured;
+
+    expect(captured[0], AndroidScheduleMode.inexactAllowWhileIdle);
+    expect(captured[1], DateTimeComponents.time);
+  });
+}

--- a/packages/app_platform/test/notifications/notifications_service_test.dart
+++ b/packages/app_platform/test/notifications/notifications_service_test.dart
@@ -25,11 +25,14 @@ void main() {
   late _MockPlugin plugin;
   late NotificationsService service;
 
+  // Loaded before any group body runs — `tz.getLocation` throws until the
+  // database is initialised, and group bodies execute at declaration time.
+  tz_data.initializeTimeZones();
+  // A fixed non-UTC zone: a bug that silently schedules in UTC would still
+  // look correct if the test happened to run in UTC.
+  tz.setLocalLocation(tz.getLocation('Asia/Ho_Chi_Minh'));
+
   setUpAll(() {
-    tz_data.initializeTimeZones();
-    // A fixed non-UTC zone: a bug that silently schedules in UTC would still
-    // look correct if the test ran in UTC.
-    tz.setLocalLocation(tz.getLocation('Asia/Ho_Chi_Minh'));
     registerFallbackValue(const NotificationDetails());
     registerFallbackValue(AndroidScheduleMode.inexactAllowWhileIdle);
     registerFallbackValue(tz.TZDateTime.now(tz.local));
@@ -120,6 +123,66 @@ void main() {
       reset(plugin);
       stubSchedule();
     }
+  });
+
+  group('nextDailyInstance', () {
+    // A zone that actually observes DST, unlike the fixed-offset one above:
+    // 2026-03-08 02:00 EST jumps to 03:00 EDT, so that calendar day is 23
+    // hours long. Adding a 24-hour Duration would land at 10:00 instead of
+    // the 09:00 the user asked for.
+    final newYork = tz.getLocation('America/New_York');
+
+    test('keeps the wall-clock time when tomorrow loses an hour', () {
+      final now = tz.TZDateTime(newYork, 2026, 3, 7, 10);
+
+      final next = nextDailyInstance(now: now, hour: 9, minute: 0);
+
+      expect(next.year, 2026);
+      expect(next.month, 3);
+      expect(next.day, 8);
+      expect(next.hour, 9);
+      expect(next.minute, 0);
+    });
+
+    test('keeps the wall-clock time when tomorrow gains an hour', () {
+      // 2026-11-01 02:00 EDT falls back to 01:00 EST — a 25-hour day.
+      final now = tz.TZDateTime(newYork, 2026, 10, 31, 10);
+
+      final next = nextDailyInstance(now: now, hour: 9, minute: 0);
+
+      expect(next.day, 1);
+      expect(next.month, 11);
+      expect(next.hour, 9);
+    });
+
+    test('stays today when the time is still ahead', () {
+      final now = tz.TZDateTime(newYork, 2026, 6, 10, 8);
+
+      final next = nextDailyInstance(now: now, hour: 9, minute: 30);
+
+      expect(next.day, 10);
+      expect(next.hour, 9);
+      expect(next.minute, 30);
+    });
+
+    test('rolls into the next month, and the next year', () {
+      final endOfMonth = tz.TZDateTime(newYork, 2026, 6, 30, 10);
+      expect(nextDailyInstance(now: endOfMonth, hour: 9, minute: 0).month, 7);
+
+      final endOfYear = tz.TZDateTime(newYork, 2026, 12, 31, 10);
+      final next = nextDailyInstance(now: endOfYear, hour: 9, minute: 0);
+      expect(next.year, 2027);
+      expect(next.month, 1);
+      expect(next.day, 1);
+    });
+
+    test('schedules tomorrow when the requested minute is the current one', () {
+      final now = tz.TZDateTime(newYork, 2026, 6, 10, 9, 30);
+
+      final next = nextDailyInstance(now: now, hour: 9, minute: 30);
+
+      expect(next.day, 11);
+    });
   });
 
   test('repeats daily without requiring an exact-alarm permission', () async {

--- a/packages/database_drift/drift_schemas/README.md
+++ b/packages/database_drift/drift_schemas/README.md
@@ -1,0 +1,42 @@
+# Drift schema snapshots
+
+One JSON file per released `schemaVersion` of `AppDatabase`. They are the only
+record of what the schema looked like at a given version — once the Dart table
+definitions move on, an old shape cannot be reconstructed from them. **Commit
+every dump, and never edit one by hand.**
+
+They exist so migration tests can start a database at an old version, run the
+real `onUpgrade`, and assert the result matches what a fresh install of the new
+version would have created.
+
+## Changing the schema
+
+1. Edit the table under `lib/src/tables/`.
+2. Bump `schemaVersion` in `lib/src/app_database.dart`.
+3. Add the upgrade step to `MigrationStrategy.onUpgrade`, guarded by the
+   version it was introduced in (`if (from < 2) …`) so an install that skipped
+   releases replays every step in order.
+4. Regenerate the Drift bindings:
+
+   ```bash
+   dart run build_runner build --delete-conflicting-outputs
+   ```
+
+5. Dump the new version:
+
+   ```bash
+   dart run drift_dev schema dump lib/src/app_database.dart drift_schemas/
+   ```
+
+6. Commit the new `drift_schema_v<n>.json` alongside the code change.
+
+## Writing a migration test
+
+Once a second version exists, generate the step helpers and use
+`SchemaVerifier` to exercise each upgrade path:
+
+```bash
+dart run drift_dev schema generate drift_schemas/ test/generated_migrations/
+```
+
+See the [drift migration testing guide](https://drift.simonbinder.eu/Migrations/tests/).

--- a/packages/database_drift/drift_schemas/drift_schema_v1.json
+++ b/packages/database_drift/drift_schemas/drift_schema_v1.json
@@ -1,0 +1,596 @@
+{
+  "_meta": {
+    "description": "This file contains a serialized version of schema entities for drift.",
+    "version": "1.3.0"
+  },
+  "options": {
+    "store_date_time_values_as_text": false
+  },
+  "entities": [
+    {
+      "id": 0,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "bookmarks",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "uuid",
+            "getter_name": "uuid",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "title",
+            "getter_name": "title",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "url",
+            "getter_name": "url",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "tags_json",
+            "getter_name": "tagsJson",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'[]\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "image_urls_json",
+            "getter_name": "imageUrlsJson",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'[]\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "video_url",
+            "getter_name": "videoUrl",
+            "moor_type": "string",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at_us",
+            "getter_name": "createdAtUs",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at_us",
+            "getter_name": "updatedAtUs",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "server_updated_at_us",
+            "getter_name": "serverUpdatedAtUs",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "rev",
+            "getter_name": "rev",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "sync_state_code",
+            "getter_name": "syncStateCode",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 1,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "collections",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "uuid",
+            "getter_name": "uuid",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "name",
+            "getter_name": "name",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "icon",
+            "getter_name": "icon",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "color",
+            "getter_name": "color",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "bookmark_ids_json",
+            "getter_name": "bookmarkIdsJson",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('\\'[]\\'')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at_us",
+            "getter_name": "createdAtUs",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "updated_at_us",
+            "getter_name": "updatedAtUs",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "server_updated_at_us",
+            "getter_name": "serverUpdatedAtUs",
+            "moor_type": "int",
+            "nullable": true,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "rev",
+            "getter_name": "rev",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "sync_state_code",
+            "getter_name": "syncStateCode",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 2,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "notifications",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "uuid",
+            "getter_name": "uuid",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "title",
+            "getter_name": "title",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "body",
+            "getter_name": "body",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "is_read",
+            "getter_name": "isRead",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"is_read\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"is_read\" IN (0, 1))"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at_us",
+            "getter_name": "createdAtUs",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "pending_read",
+            "getter_name": "pendingRead",
+            "moor_type": "bool",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "CHECK (\"pending_read\" IN (0, 1))",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "CHECK (\"pending_read\" IN (0, 1))"
+            },
+            "default_dart": "const CustomExpression('0')",
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 3,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "activities",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "uuid",
+            "getter_name": "uuid",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "description",
+            "getter_name": "description",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "type",
+            "getter_name": "type",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          },
+          {
+            "name": "created_at_us",
+            "getter_name": "createdAtUs",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    },
+    {
+      "id": 4,
+      "references": [],
+      "type": "table",
+      "data": {
+        "name": "sync_cursors",
+        "was_declared_in_moor": false,
+        "columns": [
+          {
+            "name": "id",
+            "getter_name": "id",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "PRIMARY KEY AUTOINCREMENT",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "PRIMARY KEY AUTOINCREMENT"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "auto-increment"
+            ]
+          },
+          {
+            "name": "resource",
+            "getter_name": "resource",
+            "moor_type": "string",
+            "nullable": false,
+            "customConstraints": null,
+            "defaultConstraints": "UNIQUE",
+            "dialectAwareDefaultConstraints": {
+              "sqlite": "UNIQUE"
+            },
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": [
+              "unique"
+            ]
+          },
+          {
+            "name": "rev",
+            "getter_name": "rev",
+            "moor_type": "int",
+            "nullable": false,
+            "customConstraints": null,
+            "default_dart": null,
+            "default_client_dart": null,
+            "dsl_features": []
+          }
+        ],
+        "is_virtual": false,
+        "without_rowid": false,
+        "constraints": []
+      }
+    }
+  ],
+  "fixed_sql": [
+    {
+      "name": "bookmarks",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"bookmarks\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"uuid\" TEXT NOT NULL UNIQUE, \"title\" TEXT NOT NULL, \"url\" TEXT NOT NULL, \"description\" TEXT NOT NULL, \"tags_json\" TEXT NOT NULL DEFAULT '[]', \"image_urls_json\" TEXT NOT NULL DEFAULT '[]', \"video_url\" TEXT NULL, \"created_at_us\" INTEGER NOT NULL, \"updated_at_us\" INTEGER NOT NULL, \"server_updated_at_us\" INTEGER NULL, \"rev\" INTEGER NOT NULL DEFAULT 0, \"sync_state_code\" INTEGER NOT NULL DEFAULT 0);"
+        }
+      ]
+    },
+    {
+      "name": "collections",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"collections\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"uuid\" TEXT NOT NULL UNIQUE, \"name\" TEXT NOT NULL, \"icon\" TEXT NOT NULL, \"color\" INTEGER NOT NULL, \"bookmark_ids_json\" TEXT NOT NULL DEFAULT '[]', \"created_at_us\" INTEGER NOT NULL, \"updated_at_us\" INTEGER NOT NULL, \"server_updated_at_us\" INTEGER NULL, \"rev\" INTEGER NOT NULL DEFAULT 0, \"sync_state_code\" INTEGER NOT NULL DEFAULT 0);"
+        }
+      ]
+    },
+    {
+      "name": "notifications",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"notifications\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"uuid\" TEXT NOT NULL UNIQUE, \"title\" TEXT NOT NULL, \"body\" TEXT NOT NULL, \"type\" TEXT NOT NULL, \"is_read\" INTEGER NOT NULL CHECK (\"is_read\" IN (0, 1)), \"created_at_us\" INTEGER NOT NULL, \"pending_read\" INTEGER NOT NULL DEFAULT 0 CHECK (\"pending_read\" IN (0, 1)));"
+        }
+      ]
+    },
+    {
+      "name": "activities",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"activities\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"uuid\" TEXT NOT NULL UNIQUE, \"description\" TEXT NOT NULL, \"type\" TEXT NOT NULL, \"created_at_us\" INTEGER NOT NULL);"
+        }
+      ]
+    },
+    {
+      "name": "sync_cursors",
+      "sql": [
+        {
+          "dialect": "sqlite",
+          "sql": "CREATE TABLE IF NOT EXISTS \"sync_cursors\" (\"id\" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT, \"resource\" TEXT NOT NULL UNIQUE, \"rev\" INTEGER NOT NULL);"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/database_drift/lib/database.dart
+++ b/packages/database_drift/lib/database.dart
@@ -25,4 +25,5 @@ export 'src/entities/notification_entity.dart';
 // fst:feature:notifications:end
 // fst:backend:start
 export 'src/entities/sync_cursor_entity.dart';
+
 // fst:backend:end

--- a/packages/database_drift/lib/database.dart
+++ b/packages/database_drift/lib/database.dart
@@ -11,8 +11,18 @@ export 'dart:convert' show jsonDecode, jsonEncode;
 export 'package:drift/drift.dart' show OrderingTerm, Value;
 
 export 'src/app_database.dart';
+// fst:feature:notifications:start
 export 'src/entities/activity_entity.dart';
+// fst:feature:notifications:end
+// fst:feature:bookmarks:start
 export 'src/entities/bookmark_entity.dart';
+// fst:feature:bookmarks:end
+// fst:feature:collections:start
 export 'src/entities/collection_entity.dart';
+// fst:feature:collections:end
+// fst:feature:notifications:start
 export 'src/entities/notification_entity.dart';
+// fst:feature:notifications:end
+// fst:backend:start
 export 'src/entities/sync_cursor_entity.dart';
+// fst:backend:end

--- a/packages/database_drift/lib/src/app_database.dart
+++ b/packages/database_drift/lib/src/app_database.dart
@@ -22,4 +22,29 @@ class AppDatabase extends _$AppDatabase {
 
   @override
   int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+    onCreate: (m) => m.createAll(),
+    onUpgrade: (m, from, to) async {
+      // Still at version 1, so nothing has to migrate yet.
+      //
+      // To evolve the schema: change the table, bump [schemaVersion], dump
+      // the new version (see `drift_schemas/README.md`), then add a branch
+      // here — guarded by the version it was introduced in, never by `to`,
+      // so an install that skipped releases replays every step in order:
+      //
+      //     if (from < 2) await m.addColumn(bookmarks, bookmarks.archivedAt);
+      //     if (from < 3) await m.createTable(tags);
+      //
+      // `test/migration_test.dart` then verifies each upgrade path lands on
+      // exactly the schema a fresh install would have created.
+    },
+    beforeOpen: (details) async {
+      // SQLite disables foreign-key enforcement by default, and the setting
+      // is per-connection — so it has to be re-applied on every open, not
+      // just at creation.
+      await customStatement('PRAGMA foreign_keys = ON');
+    },
+  );
 }

--- a/packages/database_drift/lib/src/app_database.dart
+++ b/packages/database_drift/lib/src/app_database.dart
@@ -1,18 +1,45 @@
 import 'package:drift/drift.dart';
 import 'package:drift_flutter/drift_flutter.dart';
 
+// fst:feature:notifications:start
 import 'tables/activities_table.dart';
+// fst:feature:notifications:end
+// fst:feature:bookmarks:start
 import 'tables/bookmarks_table.dart';
+// fst:feature:bookmarks:end
+// fst:feature:collections:start
 import 'tables/collections_table.dart';
+// fst:feature:collections:end
+// fst:feature:notifications:start
 import 'tables/notifications_table.dart';
+// fst:feature:notifications:end
+// fst:backend:start
 import 'tables/sync_cursors_table.dart';
+// fst:backend:end
 
 part 'app_database.g.dart';
 
 /// Single Drift database for the app. Feature data layers receive this via DI
 /// and access their respective table accessors.
+///
+/// One table per line so `fst create` can strip an excluded feature's table
+/// without rewriting the list.
 @DriftDatabase(
-  tables: [Bookmarks, Collections, Notifications, Activities, SyncCursors],
+  tables: [
+    // fst:feature:bookmarks:start
+    Bookmarks,
+    // fst:feature:bookmarks:end
+    // fst:feature:collections:start
+    Collections,
+    // fst:feature:collections:end
+    // fst:feature:notifications:start
+    Notifications,
+    Activities,
+    // fst:feature:notifications:end
+    // fst:backend:start
+    SyncCursors,
+    // fst:backend:end
+  ],
 )
 class AppDatabase extends _$AppDatabase {
   AppDatabase(super.e);

--- a/packages/database_drift/pubspec.yaml
+++ b/packages/database_drift/pubspec.yaml
@@ -16,8 +16,11 @@ dependencies:
   flutter:
     sdk: flutter
 
+  # fst:revsync:start
+  # Only the sync-aware entities need this, and they go with the backend.
   rev_sync:
     path: ../../published/rev_sync
+  # fst:revsync:end
   drift: ^2.22.0
   drift_flutter: ^0.2.2
 

--- a/packages/database_drift/test/app_database_test.dart
+++ b/packages/database_drift/test/app_database_test.dart
@@ -1,0 +1,29 @@
+// Guards the database's opening contract: a fresh install must land on the
+// schema the generated bindings expect, and every connection must enforce
+// foreign keys. Both are silent failures otherwise — a drifted schema only
+// surfaces as a query error in production, and SQLite happily ignores foreign
+// keys when the pragma is left at its default.
+
+import 'package:database_drift/database.dart';
+import 'package:drift/native.dart';
+import 'package:drift_dev/api/migrations_native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  late AppDatabase db;
+
+  setUp(() => db = AppDatabase(NativeDatabase.memory()));
+  tearDown(() => db.close());
+
+  test('a fresh database matches the schema drift generated', () async {
+    // Fails if a table was edited without regenerating the bindings, or if a
+    // hand-written migration step drifted from the table definitions.
+    await db.validateDatabaseSchema();
+  });
+
+  test('foreign key enforcement is on for the connection', () async {
+    final result = await db.customSelect('PRAGMA foreign_keys').getSingle();
+
+    expect(result.data.values.first, 1);
+  });
+}

--- a/packages/features/profile/lib/src/presentation/widgets/profile_widgets.dart
+++ b/packages/features/profile/lib/src/presentation/widgets/profile_widgets.dart
@@ -5,10 +5,16 @@ import 'package:app_ui/app_ui.dart';
 import 'package:feature_auth/feature_auth.dart';
 // fst:auth:end
 import 'package:flutter/material.dart';
+// fst:auth:start
+// Only `profile_header.dart` (an auth-only part) uses Clipboard.
 import 'package:flutter/services.dart';
+// fst:auth:end
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+// fst:auth:start
+// Only `profile_account.dart` (an auth-only part) navigates.
 import 'package:go_router/go_router.dart';
+// fst:auth:end
 import 'package:localization/localization.dart';
 // fst:auth:start
 import 'package:shared_ui/shared_ui.dart';

--- a/packages/features/profile/pubspec.yaml
+++ b/packages/features/profile/pubspec.yaml
@@ -31,7 +31,10 @@ dependencies:
   # Third-party.
   flutter_bloc: ^9.1.1
   bloc_concurrency: ^0.3.0
+  # fst:auth:start
+  # Only the auth-only `profile_account.dart` part navigates.
   go_router: ^17.3.0
+  # fst:auth:end
   injectable: ^3.0.0
   get_it: ^9.2.1
   package_info_plus: ^10.1.0

--- a/packages/features/profile/test/presentation/widgets/profile_screen_test.dart
+++ b/packages/features/profile/test/presentation/widgets/profile_screen_test.dart
@@ -4,10 +4,13 @@
 // confirmation. The harness mirrors delete_account_flow_test (mocked blocs +
 // FakeSession) with a tall surface so every settings card is hit-testable.
 
+// fst:auth:start
+// AppButton is only reached by the sign-out tests below.
 import 'package:app_ui/app_ui.dart';
 // Deliberate cross-feature capability import: profile surfaces auth's
 // delete-account flow (see the capability exception in CLAUDE.md).
 import 'package:feature_auth/feature_auth.dart';
+// fst:auth:end
 import 'package:feature_profile/src/presentation/bloc/profile_bloc.dart';
 import 'package:feature_profile/src/presentation/bloc/profile_state.dart';
 import 'package:feature_profile/src/presentation/widgets/profile_widgets.dart';
@@ -15,7 +18,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:localization/localization.dart';
+// fst:auth:start
 import 'package:shared_ui/shared_ui.dart';
+// fst:auth:end
 import 'package:theme/theme.dart';
 
 import '../../support.dart';
@@ -24,23 +29,33 @@ class MockThemeBloc extends Mock implements ThemeBloc {}
 
 class MockProfileBloc extends Mock implements ProfileBloc {}
 
+// fst:auth:start
 class MockDeleteAccountCubit extends Mock implements DeleteAccountCubit {}
+// fst:auth:end
 
 void main() {
+  // fst:auth:start
   late FakeSession session;
+  // fst:auth:end
   late MockThemeBloc themeBloc;
   late MockProfileBloc profileBloc;
+  // fst:auth:start
   late MockDeleteAccountCubit deleteAccountCubit;
+  // fst:auth:end
 
   setUpAll(() {
     registerFallbackValue(const ThemeModeChanged(ThemeMode.system));
   });
 
   setUp(() {
+    // fst:auth:start
     session = FakeSession(currentUser: testUser);
+    // fst:auth:end
     themeBloc = MockThemeBloc();
     profileBloc = MockProfileBloc();
+    // fst:auth:start
     deleteAccountCubit = MockDeleteAccountCubit();
+    // fst:auth:end
 
     const themeState = ThemeState(
       mode: ThemeMode.system,
@@ -53,12 +68,14 @@ void main() {
     when(() => profileBloc.state).thenReturn(profileState);
     when(() => profileBloc.stream).thenAnswer((_) => const Stream.empty());
 
+    // fst:auth:start
     when(
       () => deleteAccountCubit.state,
     ).thenReturn(const DeleteAccountState.initial());
     when(
       () => deleteAccountCubit.stream,
     ).thenAnswer((_) => const Stream.empty());
+    // fst:auth:end
   });
 
   Future<void> pumpProfile(WidgetTester tester) async {
@@ -66,32 +83,40 @@ void main() {
     tester.view.devicePixelRatio = 1;
     addTearDown(tester.view.reset);
 
+    // Mirrors how `App` composes the tree: providers first, then the auth-only
+    // SessionScope wrapped around them.
+    Widget home = MultiBlocProvider(
+      providers: [
+        BlocProvider<ThemeBloc>.value(value: themeBloc),
+        BlocProvider<ProfileBloc>.value(value: profileBloc),
+        // fst:auth:start
+        BlocProvider<DeleteAccountCubit>.value(value: deleteAccountCubit),
+        // fst:auth:end
+      ],
+      child: const ProfileBody(),
+    );
+    // fst:auth:start
+    home = SessionScope(session: session, child: home);
+    // fst:auth:end
+
     await tester.pumpWidget(
       MaterialApp(
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
-        home: SessionScope(
-          session: session,
-          child: MultiBlocProvider(
-            providers: [
-              BlocProvider<ThemeBloc>.value(value: themeBloc),
-              BlocProvider<ProfileBloc>.value(value: profileBloc),
-              BlocProvider<DeleteAccountCubit>.value(value: deleteAccountCubit),
-            ],
-            child: const ProfileBody(),
-          ),
-        ),
+        home: home,
       ),
     );
     await tester.pumpAndSettle();
   }
 
+  // fst:auth:start
   testWidgets('header shows the signed-in user identity', (tester) async {
     await pumpProfile(tester);
 
     expect(find.text(testUser.username), findsOneWidget); // 'alice'
     expect(find.text(testUser.id), findsOneWidget); // 'user-1'
   });
+  // fst:auth:end
 
   testWidgets('selecting a theme mode dispatches ThemeModeChanged', (
     tester,
@@ -119,6 +144,7 @@ void main() {
     ).called(1);
   });
 
+  // fst:auth:start
   testWidgets('confirming sign-out clears the session', (tester) async {
     await pumpProfile(tester);
     expect(session.currentUser, isNotNull);
@@ -153,4 +179,5 @@ void main() {
 
     expect(session.currentUser, isNotNull);
   });
+  // fst:auth:end
 }

--- a/packages/features/splash/test/presentation/screens/splash_screen_test.dart
+++ b/packages/features/splash/test/presentation/screens/splash_screen_test.dart
@@ -7,6 +7,7 @@ import 'package:feature_splash/feature_splash.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:localization/localization.dart';
+// fst:auth:start
 import 'package:shared_ui/shared_ui.dart';
 import 'package:test_utils/test_utils.dart';
 
@@ -19,25 +20,32 @@ class _RecordingSession extends FakeSession {
     restoreCalls++;
   }
 }
+// fst:auth:end
 
 void main() {
-  Widget host(
-    _RecordingSession session,
-    void Function(BuildContext context) onRestored,
-  ) {
+  // fst:auth:start
+  late _RecordingSession session;
+
+  setUp(() => session = _RecordingSession());
+  // fst:auth:end
+
+  // Kept session-free at the call site so the harness reads the same with and
+  // without the auth pillar — only the SessionScope wrapper differs.
+  Widget host(void Function(BuildContext context) onRestored) {
+    Widget home = SplashScreen(onRestored: onRestored);
+    // fst:auth:start
+    home = SessionScope(session: session, child: home);
+    // fst:auth:end
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
-      home: SessionScope(
-        session: session,
-        child: SplashScreen(onRestored: onRestored),
-      ),
+      home: home,
     );
   }
 
+  // fst:auth:start
   testWidgets('restores the session on the first frame', (tester) async {
-    final session = _RecordingSession();
-    await tester.pumpWidget(host(session, (_) {}));
+    await tester.pumpWidget(host((_) {}));
 
     await tester.pump(); // fire the post-frame callback → bootstrap
     expect(session.restoreCalls, 1);
@@ -46,13 +54,13 @@ void main() {
     await tester.pump(const Duration(seconds: 2));
     await tester.pump();
   });
+  // fst:auth:end
 
   testWidgets('calls onRestored only after the minimum display time', (
     tester,
   ) async {
-    final session = _RecordingSession();
     var restoredCalls = 0;
-    await tester.pumpWidget(host(session, (_) => restoredCalls++));
+    await tester.pumpWidget(host((_) => restoredCalls++));
 
     await tester.pump(); // start bootstrap
     await tester.pump(const Duration(milliseconds: 1900)); // just before 2s
@@ -64,8 +72,7 @@ void main() {
   });
 
   testWidgets('shows the splash content while bootstrapping', (tester) async {
-    final session = _RecordingSession();
-    await tester.pumpWidget(host(session, (_) {}));
+    await tester.pumpWidget(host((_) {}));
     await tester.pump();
 
     expect(find.byType(SplashContent), findsOneWidget);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -449,6 +449,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.8"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: "3bce007a596ff8b3119c45d68aaef631272537c03d30e5d4534dd24bf4c5eaa2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   fake_async:
     dependency: transitive
     description:
@@ -893,6 +901,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_timezone:
+    dependency: transitive
+    description:
+      name: flutter_timezone
+      sha256: "869677426fde92dbe170fb7d2d4929f2a8343c2f5f62f08b0bb64f908630b073"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.0"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -1924,10 +1940,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
+      sha256: "981d1020d6ef8fe1e7b3de5054e5b25579ae7c403d7734adc508ffc47668e9cb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.0"
+    version: "0.11.1"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -78,8 +78,12 @@ dependencies:
   # fst:backend:end
   app_platform: ^0.1.0
   storage: ^0.1.0
+  # fst:revsync:start
+  # Kept on the ObjectBox path even without a backend: its entities implement
+  # `Syncable`. Only `--database drift --no-backend` can shed it.
   rev_sync:
     path: published/rev_sync
+  # fst:revsync:end
   # fst:backend:start
   sync_connectivity_plus: ^0.1.0
   # fst:backend:end

--- a/test/architecture/ios_permission_strings_test.dart
+++ b/test/architecture/ios_permission_strings_test.dart
@@ -41,7 +41,15 @@ void main() {
     );
   });
 
-  // The permission usage-description keys whose copy must stay generic.
+  // The permission usage-description keys whose copy must stay generic. All
+  // four are declared for the bookmarks media-capture flow, so a project
+  // scaffolded without that feature declares none of them — the assertions
+  // that require them are marked, the rest hold either way.
+  //
+  // This list is deliberately NOT inside a marker region: the region test
+  // below needs it, and that test cannot be marked because its own source
+  // contains the marker strings it searches for — the stripper matches by
+  // substring and would close the region on them.
   const usageKeys = <String>[
     'NSCameraUsageDescription',
     'NSMicrophoneUsageDescription',
@@ -53,6 +61,7 @@ void main() {
   // for an app scaffolded from this template.
   const bannedTerms = <String>['bookmark', 'collection'];
 
+  // fst:feature:bookmarks:start
   test('every declared usage description is present and non-empty', () {
     for (final key in usageKeys) {
       expect(
@@ -62,6 +71,7 @@ void main() {
       );
     }
   });
+  // fst:feature:bookmarks:end
 
   test('usage descriptions name no template-specific demo feature', () {
     final offenders = <String>[];
@@ -83,6 +93,7 @@ void main() {
     );
   });
 
+  // fst:feature:bookmarks:start
   test(
     r'usage descriptions interpolate the app name via $(APP_DISPLAY_NAME)',
     () {
@@ -100,6 +111,7 @@ void main() {
       );
     },
   );
+  // fst:feature:bookmarks:end
 
   // These permissions exist only for the bookmarks media-capture flow. The
   // `fst` CLI strips them when bookmarks is removed by stripping the
@@ -109,23 +121,36 @@ void main() {
     'every usage description sits inside an fst:feature:bookmarks region',
     () {
       final xml = infoPlist.readAsStringSync();
-      final start = xml.indexOf('fst:feature:bookmarks:start');
-      final end = xml.indexOf('fst:feature:bookmarks:end');
+      // Built by interpolation on purpose. The CLI's stripper matches marker
+      // needles by plain substring, so a source line spelling one out in full
+      // would open or close a region in this very file.
+      const marker = 'fst:feature:bookmarks';
+      final start = xml.indexOf('$marker:start');
+      final end = xml.indexOf('$marker:end');
+
+      // A project scaffolded without bookmarks declares none of these keys,
+      // so there is nothing left to keep inside a region and the invariant
+      // holds vacuously. Asserted rather than assumed: if any key survived
+      // without its region, the checks below still run and catch it.
+      final declared = usageKeys
+          .where((key) => xml.contains('<key>$key</key>'))
+          .toList();
+      if (declared.isEmpty) return;
 
       expect(
         start,
         greaterThanOrEqualTo(0),
         reason:
-            'Missing the fst:feature:bookmarks:start marker. The CLI needs '
-            'it to strip the media permissions when bookmarks is removed.',
+            'Missing the $marker start marker. The CLI needs it to strip the '
+            'media permissions when bookmarks is removed.',
       );
       expect(
         end,
         greaterThan(start),
-        reason: 'fst:feature:bookmarks:end must follow its :start marker.',
+        reason: 'The $marker end marker must follow its start marker.',
       );
 
-      final outside = usageKeys.where((key) {
+      final outside = declared.where((key) {
         final at = xml.indexOf('<key>$key</key>');
         return at < start || at > end;
       }).toList();

--- a/tool/codegen.sh
+++ b/tool/codegen.sh
@@ -41,6 +41,29 @@ for pkg in packages/features/*/; do
   run_pkg "${pkg%/}"
 done
 
+# The Drift package owns build_runner output (app_database.g.dart) that the
+# app-root build cannot reach, and `fst create` may have removed tables with
+# their feature — so the committed binding has to be rebuilt against whatever
+# tables survived. Detected by app_database.dart rather than by directory name,
+# because `--database drift` renames the package to `database`. The ObjectBox
+# package stays excluded: its binding holds stable schema UIDs and is
+# regenerated + verified separately in CI.
+for db in packages/database packages/database_drift; do
+  [ -f "$db/lib/src/app_database.dart" ] || continue
+  run_pkg "$db"
+
+  # Re-dump the v1 schema. `fst create` may have removed tables, which would
+  # leave the committed snapshot describing a schema this project never had —
+  # and every future migration test replays from it. A no-op once the project
+  # has its own history, since only the current version is ever re-dumped.
+  if [ -d "$db/drift_schemas" ]; then
+    echo "::group::drift schema dump: $db"
+    (cd "$db" && dart run drift_dev schema dump \
+      lib/src/app_database.dart drift_schemas/)
+    echo "::endgroup::"
+  fi
+done
+
 echo "::group::build_runner: app root"
 dart run build_runner build --delete-conflicting-outputs
 echo "::endgroup::"

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -5,7 +5,8 @@
 #
 # It chains the steps documented in the README Quick Start and the iOS one-time
 # setup note: submodules, FVM SDK, disabling Swift Package Manager (macOS),
-# dependencies, code generation, backend deps, and the pre-push hook.
+# dependencies, code generation, import ordering, backend deps, and the
+# pre-push hook.
 #
 # Usage: tool/setup.sh [options]
 #   --no-hooks      Don't enable the .githooks pre-push gate (enabled by default).
@@ -132,7 +133,17 @@ else
     "until you run build_runner."
 fi
 
-# --- 7. backend dependencies ------------------------------------------------
+# --- 7. import ordering -----------------------------------------------------
+# `fst create` renames the app package, which moves its own imports in the
+# alphabetical order `directives_ordering` expects — so a freshly scaffolded
+# project trips the lint through no fault of its source. Re-sorting with the
+# real analyzer fix is exact and idempotent (a no-op in this template, whose
+# imports are already sorted for its own package name).
+echo "▶ setup: sorting import directives…"
+dart fix --apply --code=directives_ordering . >/dev/null
+echo "✓ imports sorted"
+
+# --- 8. backend dependencies ------------------------------------------------
 if [[ "$setup_backend" -eq 1 ]]; then
   if command -v go >/dev/null 2>&1 && [[ -f "$backend_dir/go.mod" ]]; then
     echo "▶ setup: fetching backend Go dependencies…"
@@ -143,7 +154,7 @@ if [[ "$setup_backend" -eq 1 ]]; then
   fi
 fi
 
-# --- 8. git hooks (opt-in, default on) --------------------------------------
+# --- 9. git hooks (opt-in, default on) --------------------------------------
 if [[ "$enable_hooks" -eq 1 ]]; then
   current_hooks_path="$(git config --get core.hooksPath || true)"
   if [[ "$current_hooks_path" != ".githooks" ]]; then
@@ -155,7 +166,7 @@ if [[ "$enable_hooks" -eq 1 ]]; then
   fi
 fi
 
-# --- 9. Firebase reminder ---------------------------------------------------
+# --- 10. Firebase reminder ---------------------------------------------------
 if [[ ! -f "$repo_root/android/app/google-services.json" ]] ||
   [[ ! -f "$repo_root/ios/Runner/GoogleService-Info.plist" ]]; then
   echo "• Firebase config is git-ignored and missing. The app builds with"
@@ -163,7 +174,7 @@ if [[ ! -f "$repo_root/android/app/google-services.json" ]] ||
   echo "  drop google-services.json / GoogleService-Info.plist into place."
 fi
 
-# --- 10. summary ------------------------------------------------------------
+# --- 11. summary ------------------------------------------------------------
 fvm_prefix=""
 [[ "$has_fvm" -eq 1 ]] && fvm_prefix="fvm "
 cat <<EOF


### PR DESCRIPTION
## Why

`fst create --minimal --database drift` produced a project with **68 analyzer
issues, 39 of them errors** — a scaffold that fails its own CI before the first
commit. Investigating that turned up several more defects in the same area.

`cli-smoke` never caught it: the job asserts which files a strip deleted, but
never resolves, compiles, or runs the result. This PR closes that gap and fixes
what it exposes.

## What changed

**Stripped scaffolds analyze clean** — two independent causes.

1. *Strip left dangling references.* Marked the auth-dependent regions the
   strippers were missing: `_ownsSession` and its `dispose` branch in
   `app.dart`; the `services` / `go_router` imports in `profile_widgets.dart`
   (used only by auth-only part widgets) plus `go_router` in profile's pubspec.
   `profile_screen_test.dart` and `splash_screen_test.dart` were restructured so
   the session wrapper is the only auth-shaped difference — a no-auth project
   keeps its theme-mode and minimum-display-time coverage instead of losing the
   files wholesale.

2. *Renaming the app package* moves its own imports in the alphabetical order
   `directives_ordering` expects, so **every** scaffold tripped the lint
   regardless of flags. `tool/setup.sh` now re-sorts with
   `dart fix --apply --code=directives_ordering` — exact, because it is the
   analyzer's own fix, and a no-op here.

**`AppDatabase` has a migration strategy.** It declared `schemaVersion => 1`
with no `migration` getter, so the first schema change would have shipped with
no upgrade path — a gap that only surfaces once real users hold real data.
Adds `onCreate`, a documented `onUpgrade` skeleton (steps guarded on `from`,
not `to`, so installs that skipped releases replay every step), and
`beforeOpen` enabling foreign keys, which SQLite leaves off per connection.
The v1 schema snapshot is committed: it is the only record of this shape once
the tables move on, and every future migration test replays from it.

**Trimmed scaffolds drop dead schema.** Each table's import, `@DriftDatabase`
entry and entity export now carries its owning feature's marker; the
sync-cursor table takes the backend marker. `rev_sync` gets its own
`fst:revsync` marker rather than reusing `fst:backend`, because ObjectBox
entities implement `Syncable` and must keep it even in a local-only app.
`tool/codegen.sh` builds the Drift package and re-dumps its schema — the
binding is committed but unreachable from the app-root build, so after a strip
it would still declare removed tables.

**Local notifications can recur.** `NotificationsService` wrapped
`flutter_local_notifications` but exposed only `show`/`cancel`/`cancelAll`, so
a daily reminder was out of reach. Adds `scheduleDaily`, pins `tz.local` to the
device zone in `init` (without it every reminder outside UTC fires at the wrong
hour), and declares `RECEIVE_BOOT_COMPLETED` plus the plugin's boot receiver —
Android drops pending alarms on shutdown, so without them the reminder silently
stops after the first reboot. Android uses an inexact alarm deliberately:
exact alarms need `SCHEDULE_EXACT_ALARM`, which Google rejects for anything but
alarm and calendar apps.

**CI compiles the scaffold.** New `cli-scaffold-analyze` job scaffolds, runs the
project's own `tool/setup.sh`, then `flutter analyze` and `flutter test`.
Bootstrapping through `setup.sh` rather than open-coding the steps means a break
in it fails here too. It is a separate job from `cli-smoke` because it needs the
Flutter SDK and a full codegen run, so its matrix is the four corners — both
engines at their fullest and emptiest — rather than every flag combination.
`cli-smoke` gains the three Drift configs where the engines diverge.

Running that new job immediately surfaced a real failure it was built to catch:
`ios_permission_strings_test` asserted the bookmarks media permissions always
exist, so **every** scaffold without bookmarks failed three tests. Its
bookmarks-specific assertions are now marked. The marker-region test itself
cannot be — its own source spells out the needles it searches for, and the
stripper matches by substring, so it would close the region on itself. It
builds them by interpolation instead.

## Verification

Ten configurations scaffolded from this checkout — default, `--no-auth`,
`--no-firebase`, `--no-backend`, `--minimal`, `--exclude-feature notifications`,
`--exclude-feature bookmarks`, and the Drift variants of default /
exclude-bookmarks / minimal. **Every one passes `flutter analyze` and
`flutter test`.**

`--minimal --database drift` yields an empty table list, no `rev_sync` and no
`published/`; `--exclude-feature bookmarks --database drift` drops only the
bookmarks table; both ObjectBox configurations are untouched. This repo
analyzes clean with all 45 root tests and every package suite green.

## Known limitation

**ObjectBox cannot shed its demo entities or `rev_sync`**, even though it is the
default engine. Its binding and model are committed for stable schema UIDs and
are deliberately not regenerated at scaffold time, so deleting an entity would
leave a project that cannot compile — and those entities implement `Syncable`.
Fixing it properly means regenerating the ObjectBox binding during scaffolding,
which reverses a decision documented in `tool/codegen.sh` and CI, so it is left
for a separate discussion. Drift is fully trimmed.

## Merge order

The `published/cli` pointer here references
kido-luci/flutter-starter-template-cli#21. **Merge the CLI PR first, then
re-point this submodule** — a squash-merge there orphans the SHA this pins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a device-local–timezone `scheduleDaily` notifications API.
  * Re-armed scheduled notifications after reboot/app update/quick-boot via a new Android receiver.
* **Bug Fixes**
  * Improved daily notification timing, including DST and “next occurrence” edge cases.
  * Enabled SQLite foreign-key enforcement during database connections.
* **Documentation**
  * Expanded setup/import-ordering guidance and Drift schema snapshot/migration documentation.
* **Tests / CI / Chores**
  * Added scheduling and database initialization tests; CI now enforces Drift codegen/schema snapshot consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->