### PR TITLE
fix: leave scaffolds formatted, and gate on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,6 +570,14 @@ jobs:
         working-directory: ${{ runner.temp }}/analyze-smoke
         run: flutter analyze
 
+      # The scaffold ships with a pre-push hook and a CI format gate of its
+      # own, so unformatted output blocks the project's first push. Stripping a
+      # marker region leaves the blank lines that surrounded it, which is
+      # exactly the kind of damage `analyze` is blind to.
+      - name: Check the scaffold's formatting
+        working-directory: ${{ runner.temp }}/analyze-smoke
+        run: dart format --output=none --set-exit-if-changed .
+
       - name: Test the scaffold
         working-directory: ${{ runner.temp }}/analyze-smoke
         run: flutter test

--- a/tool/setup.sh
+++ b/tool/setup.sh
@@ -5,7 +5,7 @@
 #
 # It chains the steps documented in the README Quick Start and the iOS one-time
 # setup note: submodules, FVM SDK, disabling Swift Package Manager (macOS),
-# dependencies, code generation, import ordering, backend deps, and the
+# dependencies, code generation, source normalisation, backend deps, and the
 # pre-push hook.
 #
 # Usage: tool/setup.sh [options]
@@ -133,15 +133,24 @@ else
     "until you run build_runner."
 fi
 
-# --- 7. import ordering -----------------------------------------------------
-# `fst create` renames the app package, which moves its own imports in the
-# alphabetical order `directives_ordering` expects — so a freshly scaffolded
-# project trips the lint through no fault of its source. Re-sorting with the
-# real analyzer fix is exact and idempotent (a no-op in this template, whose
-# imports are already sorted for its own package name).
-echo "▶ setup: sorting import directives…"
+# --- 7. source normalisation ------------------------------------------------
+# Two things `fst create` unavoidably disturbs, both fixed with the real tools
+# rather than by trying to emit perfect output:
+#
+#   * Renaming the app package moves its own imports in the alphabetical order
+#     `directives_ordering` expects, so a scaffold trips the lint through no
+#     fault of its source.
+#   * Stripping an `fst:` marker region leaves the blank lines that surrounded
+#     it — a leading blank line, or three in a row where two regions were
+#     adjacent — which `dart format` rejects.
+#
+# Left alone, a fresh scaffold fails its own pre-push hook and CI format gate
+# on the very first push. Both steps are exact and idempotent: no-ops in this
+# template, whose own source is already sorted and formatted.
+echo "▶ setup: normalising sources (imports, formatting)…"
 dart fix --apply --code=directives_ordering . >/dev/null
-echo "✓ imports sorted"
+dart format . >/dev/null
+echo "✓ sources normalised"
 
 # --- 8. backend dependencies ------------------------------------------------
 if [[ "$setup_backend" -eq 1 ]]; then


### PR DESCRIPTION
## Why

A freshly scaffolded project failed **its own pre-push hook and its own CI
format gate on the very first push** — 35 unformatted files in a
`--minimal --database drift` scaffold.

Every one of them had `fst:` marker regions stripped out. Removing a region
leaves the blank lines that surrounded it: a leading blank line, or three in a
row where two regions were adjacent. `dart format` rejects that. Nothing is
wrong with the source — the strip simply cannot know what spacing the result
should end up with.

This is the same shape as the import-ordering defect fixed in #194: a
mechanical rewrite disturbs something only the real tool can settle.

## What changed

- `tool/setup.sh` runs `dart format` alongside the `dart fix` import re-sort it
  already did — same step, same reasoning. Both are no-ops in this template,
  whose own source is already sorted and formatted.
- `cli-scaffold-analyze` now checks the scaffold's formatting.

That second point is the important one. **That job exists precisely to catch
this class of defect, and it missed this one** — it ran `analyze` and `test`,
and the analyzer is blind to whitespace. The gate was one assertion short.

## Verification

Scaffolded `--minimal --database drift` from this checkout:

| | files needing formatting |
|---|---|
| before `tool/setup.sh` | 35 |
| after `tool/setup.sh` | 0 |

`flutter analyze` clean and all 21 tests pass in the scaffold; `dart format
--set-exit-if-changed .` reports 0 changed on this repo, confirming the new
step is a no-op here.

Found while scaffolding a real app from the template, which hit the failing
gate on its first commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scaffold validation by detecting formatting differences during CI.
  * Updated setup processing to apply full source formatting, reducing failures caused by formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->