### PR TITLE
fix(ci): mark the scaffolding that only this repository needs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,7 @@ updates:
         patterns:
           - "*"
 
+  # fst:template-only:start
   # Git submodules (simple_backend_server + published/cli). Dependabot watches each
   # submodule's default branch and opens the parent pointer-bump PR when it
   # moves, so the embedded backend and CLI stay in sync without a manual bump.
@@ -58,3 +59,4 @@ updates:
     labels:
       - dependencies
       - submodules
+  # fst:template-only:end

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      # fst:template-only:start
       cli: ${{ steps.cli_filter.outputs.cli }}
+      # fst:template-only:end
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -83,9 +85,12 @@ jobs:
               # change can't affect these jobs. (published/rev_sync is deliberately
               # NOT excluded: it's a path-dependency of the build, is checked out,
               # and its bumps must trigger these jobs.)
+              # fst:template-only:start
               - '!simple_backend_server'
               - '!published/cli'
+              # fst:template-only:end
 
+      # fst:template-only:start
       # A separate filter (default `some`/OR quantifier — NOT `every`) for the
       # CLI scaffold smoke-test: it must run whenever the CLI submodule OR any
       # template surface the CLI rewrites changes (the workspace pubspec, the app
@@ -109,6 +114,7 @@ jobs:
               - 'test/test_utils/**'
               - 'test/architecture/**'
               - '.github/workflows/ci.yml'
+      # fst:template-only:end
 
   analyze-and-test:
     name: Analyze & Test
@@ -121,11 +127,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # fst:template-only:start
       # rev_sync is a published package vendored as a submodule but consumed as
       # a path dependency, so unlike the Go backend / CLI submodules it must be
       # checked out for `flutter pub get` to resolve. Fetch only that submodule.
       - name: Check out rev_sync submodule
         run: git submodule update --init published/rev_sync
+      # fst:template-only:end
 
       # Pin to the same Flutter SDK as .fvmrc (3.44.0). Bump both together.
       - name: Set up Flutter
@@ -270,6 +278,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
 
+  # fst:template-only:start
   # Scaffold-drift smoke-test (matrix over optional-pillar configs): runs the
   # `fst` CLI's `create` against THIS checkout (via --template-path) for each
   # pillar combination and asserts the generated project is coherent. Catches
@@ -581,6 +590,7 @@ jobs:
       - name: Test the scaffold
         working-directory: ${{ runner.temp }}/analyze-smoke
         run: flutter test
+  # fst:template-only:end
 
   # Compile smoke-test: `flutter analyze` type-checks Dart but never assembles
   # the app, so Gradle/plugin/asset/manifest regressions slip past it and only
@@ -600,11 +610,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # fst:template-only:start
       # rev_sync is a published package vendored as a submodule but consumed as
       # a path dependency, so unlike the Go backend / CLI submodules it must be
       # checked out for `flutter pub get` to resolve. Fetch only that submodule.
       - name: Check out rev_sync submodule
         run: git submodule update --init published/rev_sync
+      # fst:template-only:end
 
       # Pin to the same Flutter SDK as .fvmrc (3.44.0). Bump both together.
       - name: Set up Flutter
@@ -700,11 +712,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # fst:template-only:start
       # rev_sync is a published package vendored as a submodule but consumed as
       # a path dependency, so unlike the Go backend / CLI submodules it must be
       # checked out for `flutter pub get` to resolve. Fetch only that submodule.
       - name: Check out rev_sync submodule
         run: git submodule update --init published/rev_sync
+      # fst:template-only:end
 
       # connectivity_plus 7.x compiles against the iOS 26 SDK: it references
       # NWPath.isUltraConstrained behind an `if #available(iOS 26.0, *)`, but
@@ -865,11 +879,13 @@ jobs:
         with:
           persist-credentials: false
 
+      # fst:template-only:start
       # rev_sync is a published package vendored as a submodule but consumed as
       # a path dependency, so unlike the Go backend / CLI submodules it must be
       # checked out for `flutter pub get` to resolve. Fetch only that submodule.
       - name: Check out rev_sync submodule
         run: git submodule update --init published/rev_sync
+      # fst:template-only:end
 
       # Pin to the same Flutter SDK as .fvmrc (3.44.0). Bump both together.
       - name: Set up Flutter

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # fst:template-only:start
       # rev_sync is a path-dependency of the build, vendored as a submodule, so
       # it must be checked out for `flutter pub get` to resolve.
       - name: Check out rev_sync submodule
         run: git submodule update --init published/rev_sync
+      # fst:template-only:end
 
       # On a tag push, stamp the published version name from the tag (e.g.
       # v1.2.3 → 1.2.3); the build number stays the CI run number. The lanes
@@ -248,10 +250,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      # fst:template-only:start
       # rev_sync is a path-dependency of the build, vendored as a submodule, so
       # it must be checked out for `flutter pub get` to resolve.
       - name: Check out rev_sync submodule
         run: git submodule update --init published/rev_sync
+      # fst:template-only:end
 
       # On a tag push, stamp the published version name from the tag (e.g.
       # v1.2.3 → 1.2.3); the build number stays the CI run number. The lanes


### PR DESCRIPTION
## Why

**Every project scaffolded from this template shipped a broken CI and a broken
release pipeline, in every configuration.**

This repository vendors `published/rev_sync` and `published/cli` as git
submodules. A scaffold gets plain copied directories and no `.gitmodules`, so:

```
$ git submodule update --init published/rev_sync
error: pathspec 'published/rev_sync' did not match any file(s) known to git
$ echo $?
1
```

That step appears in **four CI jobs and both release lanes** — every workflow a
scaffolded project has. Analyze, both device builds, golden tests, and shipping
to either store all failed at checkout.

It stayed invisible because this repository's CI is green — it genuinely has
those submodules — and `cli-smoke` / `cli-scaffold-analyze` check a scaffold's
*source*, never its *workflows*.

## What changed

New `fst:template-only` marker family, for regions that describe how **this
repository** is developed rather than how a project built from it is. Wrapped:

- the six `Check out … submodule` steps across `ci.yml` and `release.yml`
- the `cli-smoke` and `cli-scaffold-analyze` jobs, plus the `cli` output and
  filter step they depend on — they scaffold this checkout and mean nothing in
  a derived project, yet their filter includes `pubspec.yaml`, so any
  Dependabot PR would have fired them
- the Dependabot `gitsubmodule` ecosystem, watching submodules a scaffold does
  not have (that update run failed too)

**Nothing changes for this repository.** It keeps every step, both jobs, and
the ecosystem — the markers are inert here. Only `fst create` removes them, via
kido-luci/flutter-starter-template-cli#22.

## Verification

Scaffolded `--minimal --database drift`: zero `git submodule update` steps in
either workflow, jobs reduced to `changes` / `analyze-and-test` /
`build-android` / `build-ios` / `golden-tests`, `changes` down to its `code`
output, no `gitsubmodule` ecosystem, and no marker left behind. The result
bootstraps (`tool/setup.sh` exit 0), analyzes clean, passes the format gate,
and runs all 21 tests.

This repository's own workflows still parse with all seven jobs and both
release lanes intact.

## How it was found

By scaffolding a real app from the template and pushing it. Its very first CI
run was red — and the jobs that would have explained why were skipped, because
the one ahead of them died first.

## Merge order

The `published/cli` pointer here references
kido-luci/flutter-starter-template-cli#22. **Merge the CLI PR first, then
re-point this submodule** — a squash-merge there orphans the SHA this pins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal CI and release workflow template handling by adding marker annotations to relevant workflow sections.
  * Updated the command-line tooling reference to a newer revision.
  * No user-facing changes to application behavior, configuration, or release outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->