### PR TITLE
fix(ci): mark the placeholder-credential steps as Firebase-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
+      # fst:firebase:start
       # The com.google.gms.google-services Gradle plugin parses
       # google-services.json at build time (it never contacts Firebase), and
       # the file is git-ignored — so a fresh checkout has none and Gradle fails
@@ -685,6 +686,7 @@ jobs:
       # job, we do NOT cache .dart_tool/build: with the outputs git-ignored, a
       # restored cache makes build_runner skip files it believes exist,
       # producing a broken tree.
+      # fst:firebase:end
       - name: Generate code
         run: |
           flutter pub get --enforce-lockfile
@@ -758,6 +760,7 @@ jobs:
       - name: Disable Swift Package Manager
         run: flutter config --no-enable-swift-package-manager
 
+      # fst:firebase:start
       # GoogleService-Info.plist is git-ignored but the Xcode project references
       # it as a bundled resource, so a fresh checkout fails with "Build input
       # file cannot be found". As on Android, write a placeholder rather than
@@ -796,7 +799,9 @@ jobs:
           </dict>
           </plist>
           EOF
+      # fst:firebase:end
 
+      # fst:firebase:start
       # firebase.json (git-ignored) drives the FlutterFire Crashlytics build
       # phase. Write a placeholder with "uploadDebugSymbols": false so the
       # `flutterfire upload-crashlytics-symbols` phase reads it and skips the
@@ -843,6 +848,7 @@ jobs:
       # building. As elsewhere, we do NOT cache .dart_tool/build: a restored
       # cache makes build_runner skip files it believes exist, producing a
       # broken tree.
+      # fst:firebase:end
       - name: Generate code
         run: |
           flutter pub get --enforce-lockfile


### PR DESCRIPTION
Three CI steps fabricate placeholder `google-services.json`,
`GoogleService-Info.plist` and `firebase.json` before building. They exist
because the native projects reference those files and git-ignores them — so a
scaffold that drops Firebase has no use for them.

Wrapped in the new `fst:firebase` marker family.

**Nothing changes for this repository.** It has Firebase, so the markers are
inert and every step still runs. `fst create` strips the regions with
`--no-firebase` and expands the markers otherwise, so neither kind of scaffold
ships them.

## The bug on the other side of this

Pairs with kido-luci/flutter-starter-template-cli#23, which fixes something
worse: `--no-firebase` deleted `GoogleService-Info.plist` but left the Xcode
project referencing it, so **every Firebase-free scaffold failed to build for
iOS**:

```
Error (Xcode): Build input file cannot be found:
'.../ios/Runner/GoogleService-Info.plist'
```

This repository's own CI could never see it — the placeholder step above runs
first. That is exactly why those steps are worth marking rather than leaving to
paper over a scaffold's missing files.

Found by writing an end-to-end test for a real app scaffolded from this
template and running it on a simulator.

## Merge order

The `published/cli` pointer here references
kido-luci/flutter-starter-template-cli#23. **Merge the CLI PR first, then
re-point this submodule.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved mobile CI for Android and iOS debug builds to better manage Firebase configuration placeholders and the following generated-code steps.
  * Refreshed the bundled command-line tooling to a newer revision for the latest improvements and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->