### PR TITLE
chore(deps): bump the pub-minor-and-patch group, capping drift at 2.34.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,17 @@ updates:
     labels:
       - dependencies
       - dart
+    ignore:
+      # Held at <2.34.1, matching the caps in packages/database_drift/pubspec.yaml.
+      # `objectbox_generator` pins `analyzer <11.0.0` for the whole workspace,
+      # which holds `drift_dev` at 2.34.0, and that version's schema verifier
+      # does not compile against drift >=2.34.1. Without this, the weekly group
+      # PR keeps proposing a drift bump that cannot build. Drop both this entry
+      # and the pubspec caps once objectbox_generator supports analyzer >=11.
+      - dependency-name: drift
+        versions: [">=2.34.1"]
+      - dependency-name: drift_dev
+        versions: [">=2.34.1"]
     groups:
       # Bundle all non-major pub bumps into a single PR.
       pub-minor-and-patch:

--- a/packages/analytics/pubspec.yaml
+++ b/packages/analytics/pubspec.yaml
@@ -13,13 +13,13 @@ dependencies:
     sdk: flutter
 
   architecture: ^0.1.0
-  firebase_analytics: ^12.4.3
+  firebase_analytics: ^12.4.5
   injectable: ^3.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2
   test_utils: ^0.1.0

--- a/packages/app_platform/pubspec.yaml
+++ b/packages/app_platform/pubspec.yaml
@@ -19,11 +19,11 @@ dependencies:
   camera: ^0.12.0+1
   firebase_crashlytics: ^5.2.4
   firebase_messaging: ^16.4.1
-  flutter_local_notifications: ^22.0.1
-  image_picker: ^1.2.2
+  flutter_local_notifications: ^22.2.0
+  image_picker: ^1.2.3
   permission_handler: ^12.0.3
-  share_plus: ^13.1.0
-  video_player: ^2.11.1
+  share_plus: ^13.3.0
+  video_player: ^2.13.0
   timezone: ^0.11.1
   flutter_timezone: ^5.1.0
 
@@ -31,6 +31,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2
   test_utils: ^0.1.0

--- a/packages/app_ui/pubspec.yaml
+++ b/packages/app_ui/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   photo_view: ^0.15.0
   cached_network_image: ^3.4.1
   carousel_slider: ^5.1.2
-  google_fonts: ^8.1.0
+  google_fonts: ^8.2.0
   font_awesome_flutter: ^11.0.0
 
 dev_dependencies:

--- a/packages/config/pubspec.yaml
+++ b/packages/config/pubspec.yaml
@@ -19,6 +19,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2
   test_utils: ^0.1.0

--- a/packages/database/pubspec.yaml
+++ b/packages/database/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path_provider: ^2.1.6
 
 dev_dependencies:
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   objectbox_generator: ^5.3.2
   flutter_test:
     sdk: flutter

--- a/packages/database_drift/pubspec.yaml
+++ b/packages/database_drift/pubspec.yaml
@@ -21,11 +21,17 @@ dependencies:
   rev_sync:
     path: ../../published/rev_sync
   # fst:revsync:end
-  drift: ^2.22.0
-  drift_flutter: ^0.2.2
+  # Held below 2.34.1 together with drift_dev: `objectbox_generator` (see
+  # packages/database) caps `analyzer` at <11.0.0 for the whole workspace, which
+  # in turn caps drift_dev at 2.34.0 — and 2.34.0's schema verifier does not
+  # compile against drift >=2.34.1, which dropped `allSchemaEntities` from the
+  # drift3 preview. Lift both caps once objectbox_generator allows analyzer >=11.
+  drift: ">=2.22.0 <2.34.1"
+  drift_flutter: ^0.3.1
 
 dev_dependencies:
-  build_runner: ^2.15.0
-  drift_dev: ^2.22.0
+  build_runner: ^2.15.1
+  # See the drift cap above — these two must move together.
+  drift_dev: ">=2.22.0 <2.34.1"
   flutter_test:
     sdk: flutter

--- a/packages/features/auth/pubspec.yaml
+++ b/packages/features/auth/pubspec.yaml
@@ -39,10 +39,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   freezed: ^3.2.5
   json_serializable: ^6.14.0
-  retrofit_generator: ^10.2.7
+  retrofit_generator: ^10.2.8
   injectable_generator: ^3.0.2
   bloc_test: ^10.0.0
   mocktail: ^1.0.5

--- a/packages/features/bookmarks/pubspec.yaml
+++ b/packages/features/bookmarks/pubspec.yaml
@@ -36,9 +36,9 @@ dependencies:
   injectable: ^3.0.0
   get_it: ^9.2.1
   go_router: ^17.3.0
-  uuid: ^4.5.3
+  uuid: ^4.6.0
   url_launcher: ^6.3.2
-  connectivity_plus: ^7.1.1
+  connectivity_plus: ^7.3.1
   font_awesome_flutter: ^11.0.0
   flutter_staggered_grid_view: ^0.7.0
   intl: ^0.20.2
@@ -50,10 +50,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   freezed: ^3.2.5
   json_serializable: ^6.14.0
-  retrofit_generator: ^10.2.7
+  retrofit_generator: ^10.2.8
   injectable_generator: ^3.0.2
   bloc_test: ^10.0.0
   mocktail: ^1.0.5

--- a/packages/features/collections/pubspec.yaml
+++ b/packages/features/collections/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   injectable: ^3.0.0
   get_it: ^9.2.1
   go_router: ^17.3.0
-  uuid: ^4.5.3
+  uuid: ^4.6.0
   font_awesome_flutter: ^11.0.0
   freezed_annotation: ^3.1.0
   json_annotation: ^4.12.0
@@ -43,10 +43,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   freezed: ^3.2.5
   json_serializable: ^6.14.0
-  retrofit_generator: ^10.2.7
+  retrofit_generator: ^10.2.8
   injectable_generator: ^3.0.2
   bloc_test: ^10.0.0
   mocktail: ^1.0.5

--- a/packages/features/home/pubspec.yaml
+++ b/packages/features/home/pubspec.yaml
@@ -36,6 +36,6 @@ dev_dependencies:
 
   test_utils: ^0.1.0
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   freezed: ^3.2.5
   injectable_generator: ^3.0.2

--- a/packages/features/notifications/pubspec.yaml
+++ b/packages/features/notifications/pubspec.yaml
@@ -37,10 +37,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   freezed: ^3.2.5
   json_serializable: ^6.14.0
-  retrofit_generator: ^10.2.7
+  retrofit_generator: ^10.2.8
   injectable_generator: ^3.0.2
   bloc_test: ^10.0.0
   mocktail: ^1.0.5

--- a/packages/features/profile/pubspec.yaml
+++ b/packages/features/profile/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   # fst:auth:end
   injectable: ^3.0.0
   get_it: ^9.2.1
-  package_info_plus: ^10.1.0
+  package_info_plus: ^10.2.1
   font_awesome_flutter: ^11.0.0
   freezed_annotation: ^3.1.0
 
@@ -47,6 +47,6 @@ dev_dependencies:
 
   test_utils: ^0.1.0
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   freezed: ^3.2.5
   injectable_generator: ^3.0.2

--- a/packages/network/lib/src/retry_interceptor.dart
+++ b/packages/network/lib/src/retry_interceptor.dart
@@ -90,6 +90,12 @@ class RetryInterceptor extends Interceptor {
         // process the request, so it's safe to retry regardless of method.
         final status = err.response?.statusCode;
         return status != null && _retryableStatusCodes.contains(status);
+      case DioExceptionType.transformTimeout:
+        // The response already arrived and the server has processed the
+        // request — only the local decode of the body ran past its budget.
+        // Replaying would re-run the same deterministic work on the same
+        // payload, and for a non-idempotent method it would double-fire.
+        return false;
       case DioExceptionType.cancel:
       case DioExceptionType.badCertificate:
       case DioExceptionType.unknown:

--- a/packages/network/pubspec.yaml
+++ b/packages/network/pubspec.yaml
@@ -10,7 +10,7 @@ resolution: workspace
 
 dependencies:
   config: ^0.1.0
-  dio: ^5.9.2
+  dio: ^5.11.0
   firebase_performance: ^0.11.4+1
   injectable: ^3.0.0
   retrofit: ^4.9.2
@@ -20,6 +20,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2
   test_utils: ^0.1.0

--- a/packages/network/test/retry_interceptor_test.dart
+++ b/packages/network/test/retry_interceptor_test.dart
@@ -131,6 +131,23 @@ void main() {
       expect(adapter.calls, 1);
     });
 
+    test('does not retry a transform timeout', () async {
+      // The response arrived and the server has already processed the request
+      // — only the local decode overran its budget. Replaying would repeat the
+      // same deterministic work, so even a GET is left alone.
+      final adapter = _ScriptedAdapter([
+        DioException(
+          requestOptions: RequestOptions(path: '/'),
+          type: DioExceptionType.transformTimeout,
+        ),
+        ok(),
+      ]);
+      final dio = buildDio(adapter);
+
+      await expectLater(dio.get<dynamic>('/'), throwsA(isA<DioException>()));
+      expect(adapter.calls, 1);
+    });
+
     test('does NOT retry a POST on an ambiguous transport failure', () async {
       // A timed-out POST may already have been processed; replaying it could
       // duplicate the side effect, so it must not be retried.

--- a/packages/shared_contracts/pubspec.yaml
+++ b/packages/shared_contracts/pubspec.yaml
@@ -19,5 +19,5 @@ dependencies:
   injectable: ^3.0.0
 
 dev_dependencies:
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2

--- a/packages/storage/pubspec.yaml
+++ b/packages/storage/pubspec.yaml
@@ -17,6 +17,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2
   test_utils: ^0.1.0

--- a/packages/sync_connectivity_plus/pubspec.yaml
+++ b/packages/sync_connectivity_plus/pubspec.yaml
@@ -11,11 +11,11 @@ environment:
 resolution: workspace
 
 dependencies:
-  connectivity_plus: ^7.1.1
+  connectivity_plus: ^7.3.1
   injectable: ^3.0.0
   rev_sync:
     path: ../../published/rev_sync
 
 dev_dependencies:
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2

--- a/packages/theme/pubspec.yaml
+++ b/packages/theme/pubspec.yaml
@@ -25,6 +25,6 @@ dev_dependencies:
     sdk: flutter
 
   bloc_test: ^10.0.0
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
   injectable_generator: ^3.0.2
   test_utils: ^0.1.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "78f98c1f9c4dbbd22c2bb7b7f17c4a5c06150e8b2cb791a0947979ad0d3dabd5"
+      sha256: "460e9e684edb461d85498fc166ff8416f303f22216838d302d80676b348c6a4c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.73"
+    version: "1.3.75"
   analyzer:
     dependency: transitive
     description:
@@ -101,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: a156715e7cd728130c592f30552575908aae5b100005fbc1f0fb16b3c03a3d10
+      sha256: "45d14a0fb23e018d8287c32fc98d726ce466b231928ed9b9200f29bd3ccd39ae"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "4.0.7"
   build_config:
     dependency: transitive
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "1523ce62448ebac2c15a8ba5fbad8acac169788658a7dd2a1c2d9c2a9318b9a6"
+      sha256: "5367e521935b102bdf1e735d2aab461e36b2edca6517662d088dd04cc39f8d16"
       url: "https://pub.dev"
     source: hosted
-    version: "2.15.0"
+    version: "2.15.1"
   build_verify:
     dependency: "direct dev"
     description:
@@ -317,10 +317,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "62ffa266d9a23b79fb3fcbc206afc00bb979417ba57b1324c546b5aab95ba057"
+      sha256: "762c99f890ca8bf87f7337236f99edd42793843bc6c3631da294a76653a54bd0"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.1"
+    version: "7.3.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -413,10 +413,10 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
       url: "https://pub.dev"
     source: hosted
-    version: "5.9.2"
+    version: "5.11.0"
   dio_web_adapter:
     dependency: transitive
     description:
@@ -429,26 +429,26 @@ packages:
     dependency: transitive
     description:
       name: drift
-      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      sha256: "6cc0b623c0e83f7080524d8396e9301b1d78b9c66a4fdceeb0f798211303254c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   drift_dev:
     dependency: transitive
     description:
       name: drift_dev
-      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
+      sha256: "9cfff1576b49725da0d32c040651a41ae195e8c4af8d8da301593e41d7abc2f7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.31.0"
+    version: "2.34.0"
   drift_flutter:
     dependency: transitive
     description:
       name: drift_flutter
-      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
+      sha256: "91acf4bee7c3c84467cba46455aa70e5292a3b889f4582645d74f2e5a8c106f2"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.8"
+    version: "0.3.1"
   equatable:
     dependency: transitive
     description:
@@ -525,138 +525,138 @@ packages:
     dependency: transitive
     description:
       name: firebase_analytics
-      sha256: "1c46136d9226e7e070013582097d997248a34cf94856c7e95f4fdf346bf4a397"
+      sha256: "47b68927bc4abd6d7b4e2ddfe7c64fe087cca5f96d0c2b8d9d6deb6120c10ad6"
       url: "https://pub.dev"
     source: hosted
-    version: "12.4.3"
+    version: "12.4.5"
   firebase_analytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_analytics_platform_interface
-      sha256: "0b4ae09407352ec462a2403b8addf18bdf94a35e0e0c9dda198274516c32456a"
+      sha256: "36ce5feb5a996381e6411792eaa00e89178e75943e54ac8f14a8296b6e9a3e88"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.0.5"
   firebase_analytics_web:
     dependency: transitive
     description:
       name: firebase_analytics_web
-      sha256: e66c02ab6491393767b197dfb37908178295cfdb1c5d30e33cad9d7276d1c5fa
+      sha256: c12358983c927093cd40d42feb0cb05c8594d3a9b56ab5ad303bec2b8838d252
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1+9"
+    version: "0.6.1+11"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: d2625088d8f8836a7a74a7eb94a5372d70ad88382602ba2dcc02805c294d0d16
+      sha256: "6f22d1c62e0c20976f02cd842c7b7cd3c0f561cc2052586411871045c08860c9"
       url: "https://pub.dev"
     source: hosted
-    version: "4.11.0"
+    version: "4.12.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "913e7c96ef83a80ad7e1c3f8a059167b3de23b5d5e07fa3ed8f11abe24de98b6"
+      sha256: f74d1d6fabccf7743b0144c2ed363d81049e258e22428ebb6fb0faec2fa7d938
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "8.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "30ba3ae56f5beb2cea836033201570612c911661889f815eca73b6056c7b55bf"
+      sha256: ddab99d709b8c27dd47576eb05a1e719e07a2aa45c009a49ae92ac4d2a8ca555
       url: "https://pub.dev"
     source: hosted
-    version: "3.9.0"
+    version: "3.9.1"
   firebase_crashlytics:
     dependency: transitive
     description:
       name: firebase_crashlytics
-      sha256: "2d9c791abef1cfd66c2572f5a4e172aa9f43476961af49742b1511dd327611df"
+      sha256: "9855d3e2286c3e4439cf7d48c740bdf282ac165f29c7551dcdaf121925c59a28"
       url: "https://pub.dev"
     source: hosted
-    version: "5.2.4"
+    version: "5.2.6"
   firebase_crashlytics_platform_interface:
     dependency: transitive
     description:
       name: firebase_crashlytics_platform_interface
-      sha256: cbedfe34081c4ad5c4e0558165383d4fa6b8fd70ae6e696190aad345adbb346c
+      sha256: aab14de92555ccf8c8616fc1b649272aef04dadb07f986e166e1d36d158f7bd1
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.24"
+    version: "3.8.26"
   firebase_messaging:
     dependency: transitive
     description:
       name: firebase_messaging
-      sha256: ce21a510e5a9aed67a0404476981e19ec0361a0301eeba547dc93dc2e7dec99a
+      sha256: "30ad2d59bcd86117dc49d278c8998a0fb390c5a3202f6e43e4bd215d3f1d0556"
       url: "https://pub.dev"
     source: hosted
-    version: "16.4.1"
+    version: "16.4.3"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: e10f6d521e7ed663d0ea2f4ec7de4c6729f8c2ce25d32faf6d6b4219da8515c2
+      sha256: "4d144cb42b9a5a42855596be2d7682d32c50169f42e7df2cb3278ecf935e7d63"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.9.2"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "7ab45dfaf8efcd1a769baa9b8debbd0da281f5d3fc07274296b564396a980292"
+      sha256: fcd25d0b9da55766ef4d28ae05a7460f5189635d6b42607adcd9f08818fd35f0
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.1"
+    version: "4.2.3"
   firebase_performance:
     dependency: transitive
     description:
       name: firebase_performance
-      sha256: "24016f683d46b7131dc3bb369b1e6e43c1493150f5c39b9a0f30642f90f59001"
+      sha256: f48a585a2ef61ed8d809da4aca80799ad588519bbd63121d9a27fdfbef296958
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.4+1"
+    version: "0.11.4+5"
   firebase_performance_platform_interface:
     dependency: transitive
     description:
       name: firebase_performance_platform_interface
-      sha256: "66aed4fd56584feb73857e9b12732f5e5558a44ad7dc9ae5d923a00505b5339f"
+      sha256: "3a7691d88e31a52215e15c88ded570754b233a1a53dadc5efe3634efab0fd1ec"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0+1"
+    version: "0.2.0+5"
   firebase_performance_web:
     dependency: transitive
     description:
       name: firebase_performance_web
-      sha256: "5ca9c7ce627c743607509ccafc4882c9f124651183044987c5cbeb9b44a7b780"
+      sha256: "50f0b19c21acd3a8866e05eb02efe1831ed7c595a20451c0446774e61b862082"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.8+7"
+    version: "0.1.8+11"
   firebase_remote_config:
     dependency: transitive
     description:
       name: firebase_remote_config
-      sha256: "6f310b2dfbb84d781992ac5e4be741be5606c3e971741517869b21099a1a82b0"
+      sha256: d642fe803397a142199d1d1f45683021d822af59f989a78ba8f050d9ebede382
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.3"
+    version: "6.5.5"
   firebase_remote_config_platform_interface:
     dependency: transitive
     description:
       name: firebase_remote_config_platform_interface
-      sha256: "59a20db282c7f6166b02d5158e6bcd998937b1c1711307af8f55cb5da110bb2a"
+      sha256: "04ccfae1e90e218096f5251da42c5aa520b1ef4858b0dcb5f0c9eec0dee58715"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   firebase_remote_config_web:
     dependency: transitive
     description:
       name: firebase_remote_config_web
-      sha256: a97dced4db76235b1680cf647e8a23528dff1b94fab6e7ed1cfc3e2f9d9f4b72
+      sha256: a81e9495eabde81f3ae93fe5d132384522925d6f2cce869510ebef7fe43b1c50
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.10"
+    version: "1.10.12"
   fixnum:
     dependency: transitive
     description:
@@ -735,18 +735,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_gen_core
-      sha256: "1413fbd0b67f76ac17800989013438caec3b64564c9ffd1eea6cd7e170d9b0e5"
+      sha256: "8ccb1f809642b34eb4857d8d7c4e5b41430a8cba8206177aae2ffe9d72b5eef3"
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.1"
+    version: "5.15.0"
   flutter_gen_runner:
     dependency: "direct dev"
     description:
       name: flutter_gen_runner
-      sha256: db00922dd5f4c1aa33aeab7f74117f1cd224e7a1e8bea1e312b8d09b8101a909
+      sha256: "2b0fff517a75a14ed2eff749c1da2d6b8b568e542ad2b1c967356669a4c29bb2"
       url: "https://pub.dev"
     source: hosted
-    version: "5.14.1"
+    version: "5.15.0"
   flutter_launcher_icons:
     dependency: "direct dev"
     description:
@@ -767,10 +767,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications
-      sha256: a0d7141f14cabcee42967470a858dfc99dd6cfb70d3cab404bacfcafa9e84e70
+      sha256: "9375211fd7df9c070504ac4db7047c7fae857e238291433b770cfe696b5c357a"
       url: "https://pub.dev"
     source: hosted
-    version: "22.0.1"
+    version: "22.2.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
@@ -783,10 +783,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: ff0013eae795e8dc8fad4a8992a209e64d3ba2fbd8bf5e43c36bf448f95bd814
+      sha256: "945a438a4779f3aca3a948718d8a4048cbe9f9c8c797492c00abd5d39112bf37"
       url: "https://pub.dev"
     source: hosted
-    version: "12.0.0"
+    version: "12.1.0"
   flutter_local_notifications_web:
     dependency: transitive
     description:
@@ -979,18 +979,18 @@ packages:
     dependency: "direct dev"
     description:
       name: go_router_builder
-      sha256: "52c0403e3fc80db4058d44088f28227f4ecf046f9b8ccbea0e325d3c7b4bb7f5"
+      sha256: "53253ae5bd3d3bfc38c5488ca844f6b054c4b905683667db4544e7ab995fddcc"
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.4.0"
   google_fonts:
     dependency: transitive
     description:
       name: google_fonts
-      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
+      sha256: e3cb3ee6b47fd2472c23de6da5744796a4da195137759ddb3fbcc9467b7b3c7d
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.2.1"
   graphs:
     dependency: transitive
     description:
@@ -1067,10 +1067,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker
-      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.2"
+    version: "1.2.3"
   image_picker_android:
     dependency: transitive
     description:
@@ -1284,6 +1284,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  native_toolchain_c:
+    dependency: transitive
+    description:
+      name: native_toolchain_c
+      sha256: "49c147aa4a5905ec12028e2b7bfe360eace6cb91fe4cf08a3fe76e309592acae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   nested:
     dependency: transitive
     description:
@@ -1360,10 +1368,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"
+      sha256: "127e1751e37ffb2ff4658beeaca77bad0c27bf5f932bd3a501c2296926d4b481"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.2.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1616,10 +1624,10 @@ packages:
     dependency: transitive
     description:
       name: retrofit_generator
-      sha256: "0c6468f776e449de3886b0d68fa668943e005d884e618487fdf8b1323becdf88"
+      sha256: e836270d06083ff3e90a0428732c750ed4a7ef2e99ff26d1af9865a3aa20968a
       url: "https://pub.dev"
     source: hosted
-    version: "10.2.7"
+    version: "10.2.8"
   rev_sync:
     dependency: "direct main"
     description:
@@ -1639,18 +1647,18 @@ packages:
     dependency: transitive
     description:
       name: share_plus
-      sha256: a857d8b1479250aff6b57a51b2c02d31ca05848d441817c43f1640c885c286c0
+      sha256: "34f00f9becd2743c1fb05363d624f9f70d37f7ccdcdda47450bc0b8c9d327b8c"
       url: "https://pub.dev"
     source: hosted
-    version: "13.1.0"
+    version: "13.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "7f7ae28cf400d13f811e297ff37742dba83b79e0a6f5dce14eec0248274e6ce9"
+      sha256: "365ef7379fc22507256adda3385152942ffce08935452bc972c2e52a0bebae41"
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.0"
   shared_preferences:
     dependency: transitive
     description:
@@ -1824,30 +1832,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
+  sqlcipher_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlcipher_flutter_libs
+      sha256: "38d62d659d2fb8739bf25a42c9a350d1fdd6c29a5a61f13a946778ec75d27929"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.7.0+eol"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.4"
+    version: "3.5.0"
   sqlite3_flutter_libs:
     dependency: transitive
     description:
       name: sqlite3_flutter_libs
-      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      sha256: "3ed7553eee7bb368f8950f58ba29f634e06e813c029aff6a0d60862b96de8454"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.42"
+    version: "0.6.0+eol"
   sqlparser:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
+      sha256: "40bdddb306a727be9ce510bd2d2b9a6c9db6c586d846ef7b22e3990a2b24f02d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.43.1"
+    version: "0.44.5"
   stack_trace:
     dependency: transitive
     description:
@@ -2020,10 +2036,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.3"
+    version: "4.6.0"
   vector_graphics:
     dependency: "direct main"
     description:
@@ -2068,34 +2084,34 @@ packages:
     dependency: transitive
     description:
       name: video_player
-      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
+      sha256: "20ef311160e2ced020a62f38e4cc399a1bf289e722fc5fe37c9d7b18e44c9e8d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.13.0"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
+      sha256: e229676f8fade3e0124482495aaa2b548872cc4018b6268adfca4868be16aa74
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.5"
+    version: "2.12.0"
   video_player_avfoundation:
     dependency: transitive
     description:
       name: video_player_avfoundation
-      sha256: "9338f3ec22774f88146b22f13273a446719b1da010fd200c4d1d97802156ac58"
+      sha256: c238f5f0a26845cd0bcc2956049b63065a4d3c40ddfc22c3414cd170bef7fff9
       url: "https://pub.dev"
     source: hosted
-    version: "2.9.7"
+    version: "2.11.0"
   video_player_platform_interface:
     dependency: transitive
     description:
       name: video_player_platform_interface
-      sha256: "16eaed5268c571c31840dc58ef8da5f0cd4db2a98490c3b8f1cf70122546c6e0"
+      sha256: "92c0fbabe20c788e71fd10d26cea998d0d253282e65d145aed0818731cf593ce"
       url: "https://pub.dev"
     source: hosted
-    version: "6.7.0"
+    version: "6.9.0"
   video_player_web:
     dependency: transitive
     description:
@@ -2202,4 +2218,4 @@ packages:
     version: "3.1.3"
 sdks:
   dart: ">=3.12.0 <4.0.0"
-  flutter: ">=3.38.4"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -149,9 +149,9 @@ dependencies:
 
   # Client-side UUID generation for offline-first creates: the app mints a
   # stable id locally and the server accepts it on POST /api/bookmarks.
-  uuid: ^4.5.3
+  uuid: ^4.6.0
 
-  package_info_plus: ^10.1.0
+  package_info_plus: ^10.2.1
 
   # SVG rendering. Pairs with flutter_gen_runner: SVGs placed in assets/icons/
   # get typed accessors that expose a ready-to-use SvgPicture widget.
@@ -178,11 +178,11 @@ dev_dependencies:
   bloc_test: ^10.0.0
 
   # Codegen for typed route classes (TypedGoRoute) — strongly-typed navigation.
-  go_router_builder: ^4.3.0
+  go_router_builder: ^4.4.0
 
   # Codegen driver. Runs every generator below.
   # Run: dart run build_runner build --delete-conflicting-outputs
-  build_runner: ^2.15.0
+  build_runner: ^2.15.1
 
   # CI guard: fails the build if generated files are stale
   # (i.e. someone forgot to re-run build_runner).
@@ -195,7 +195,7 @@ dev_dependencies:
   # Generates type-safe references to assets and fonts declared below
   # (output: lib/gen/assets.gen.dart). Use e.g. Assets.images.logo instead
   # of raw 'assets/images/logo.png' strings.
-  flutter_gen_runner: ^5.14.1
+  flutter_gen_runner: ^5.15.0
   very_good_analysis: ^10.3.0
 
   # Generates native launcher icons for all platforms from a single source


### PR DESCRIPTION
Supersedes #197, the weekly `pub-minor-and-patch` group PR, which had six failing checks. Those failures came from **two independent incompatibilities** in the proposed group, not from one bad package.

## What was actually broken

### 1. `dio` 5.11.0 — new enum value broke an exhaustive switch

`dio` 5.10.0 added `DioExceptionType.transformTimeout`, which bounds long-running response transformations. `RetryInterceptor._shouldRetry` switches exhaustively over `DioExceptionType` with no `default`, so the new value turned it into an analyzer error:

```
error • The type 'DioExceptionType' isn't exhaustively matched by the switch cases
  since it doesn't match the pattern 'DioExceptionType.transformTimeout'
  • packages/network/lib/src/retry_interceptor.dart:80:5 • non_exhaustive_switch_statement
```

That is what failed **CLI scaffold analyzes (default)**.

**Fix:** handle the new case explicitly rather than adding a `default:`, so the switch keeps failing loudly the next time dio grows a variant. A transform timeout is **not retried**: the response already arrived and the server has processed the request — only the local decode overran its budget. Replaying would repeat the same deterministic work on the same payload, and for a non-idempotent method it would double-fire the side effect. A test pins that behaviour.

### 2. `drift` 2.34.3 — incompatible with the only resolvable `drift_dev`

`drift` 2.34.1 dropped `allSchemaEntities` from its drift3 preview, but `drift_dev` 2.34.0's schema verifier still calls it, so `drift_dev schema dump` in `tool/codegen.sh` failed to compile:

```
drift_dev-2.34.0/lib/src/services/schema/verifier_common.dart:340:13:
  Error: The non-abstract class '_GenerateFromScratchDrift3' is missing
  implementations for these members: - GeneratedDatabase.schema
drift_dev-2.34.0/.../verifier_common.dart:45:28:
  Error: The getter 'allSchemaEntities' isn't defined for the type 'GeneratedDatabase'.
```

That single compile failure is what failed the other five checks — **Analyze & Test**, **Build Android (debug)**, **Build iOS (debug, no codesign)**, **CLI scaffold analyzes (default-drift)** and **(minimal-drift)** — because every one of them runs codegen first.

The obvious fix (a newer `drift_dev`, currently 2.34.5, which moved that code out of the verifier) **is not available to us**: every `drift_dev` above 2.34.0 requires analyzer 13, and `objectbox_generator` pins `analyzer >=8.1.1 <11.0.0` for the whole pub workspace. No published `objectbox_generator` — including the 6.0.0 previews — lifts that cap, so `drift_dev` 2.34.0 is the ceiling until ObjectBox moves.

**Fix:** cap `drift` and `drift_dev` together at `<2.34.1` — the newest pair that actually resolves and builds. That still takes drift and drift_dev from 2.31.0 to 2.34.0, just not to 2.34.3. The reason is recorded at both caps in `packages/database_drift/pubspec.yaml` and mirrored as a Dependabot `ignore`, so the weekly group PR stops reproposing a bump that cannot build. Both should be dropped together once `objectbox_generator` supports analyzer >= 11.

## What landed

Every other bump in the group is taken as Dependabot proposed it, including `drift_flutter` 0.3.1, which only requires `drift ^2.30.0` and so is unaffected by the cap.

| | From | To |
|---|---|---|
| dio | 5.9.2 | **5.11.0** |
| drift / drift_dev | 2.31.0 | **2.34.0** (capped, was 2.34.3) |
| drift_flutter | 0.2.8 | **0.3.1** |
| build_runner | 2.15.0 | 2.15.1 |
| connectivity_plus | 7.1.1 | 7.3.1 |
| video_player | 2.11.1 | 2.13.0 |
| share_plus | 13.1.0 | 13.3.0 |
| flutter_local_notifications | 22.0.1 | 22.2.0 |
| package_info_plus | 10.1.0 | 10.2.1 |
| uuid | 4.5.3 | 4.6.0 |
| google_fonts | 8.1.0 | 8.2.1 |
| …and the rest of the group | | |

## Verification (local, Flutter 3.44.0)

- `./tool/codegen.sh` — clean, **including the `drift schema dump` step that was failing**. The gated generated files (`app_database.g.dart`, `drift_schemas`, the ObjectBox binding, l10n) are all unchanged.
- `flutter analyze` — *No issues found!*
- `dart format --set-exit-if-changed .` — 0 changed.
- `flutter test --exclude-tags golden` — root suite plus **all 17 package suites** pass.
- `flutter build apk --debug --flavor dev` — builds. Worth calling out: CI never reached this step, so the native-library bumps in this group (`sqlite3_flutter_libs` 0.5.42 → 0.6.0+eol, `sqlite3` 2.9.4 → 3.5.0, `video_player_android` 2.9.5 → 2.12.0) were previously untested.
- `fst create` scaffolds rebuilt from this tree for both **default** and **minimal-drift**, each passing its own `setup.sh`, analyze, format and test gates.

iOS was not built locally; its CI failure was the same codegen compile error as the others, which is fixed here.

## Note for the reviewer

`./tool/codegen.sh` also rewrites three tracked `di.module.dart` files (an injectable import-alias renumber in bookmarks / collections / notifications). **That is pre-existing and unrelated** — it reproduces identically on an unmodified `main` — so it is deliberately left out of this PR. CI does not catch it because the generated-file gate covers the drift, ObjectBox and l10n outputs but not `di.module.dart`. Worth a separate PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented requests from being retried when response-body processing times out, avoiding duplicate request attempts.
  - Added coverage to verify correct retry behavior.

- **Maintenance**
  - Updated platform integrations, analytics, connectivity, media, notifications, fonts, and supporting tooling for improved compatibility and stability.
  - Added safeguards to keep database tooling versions compatible with the workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->