### PR TITLE
fix: regenerate stale di.module.dart across four packages

### DIFF
--- a/packages/features/bookmarks/lib/src/di.module.dart
+++ b/packages/features/bookmarks/lib/src/di.module.dart
@@ -46,8 +46,8 @@ import 'package:feature_bookmarks/src/presentation/bloc/bookmarks_list/bookmarks
     as _i330;
 import 'package:injectable/injectable.dart' as _i526;
 import 'package:network/network.dart' as _i372;
+import 'package:rev_sync/rev_sync.dart' as _i520;
 import 'package:shared_contracts/shared_contracts.dart' as _i856;
-import 'package:rev_sync/rev_sync.dart' as _i846;
 import 'package:uuid/uuid.dart' as _i706;
 
 class FeatureBookmarksPackageModule extends _i526.MicroPackageModule {
@@ -67,8 +67,8 @@ class FeatureBookmarksPackageModule extends _i526.MicroPackageModule {
       () => _i353.BookmarksSyncService(
         gh<_i524.BookmarksLocalDataSource>(),
         gh<_i436.BookmarksRemoteDataSource>(),
-        gh<_i846.ConnectivitySource>(),
-        gh<_i846.SyncCursorStore>(),
+        gh<_i520.ConnectivitySource>(),
+        gh<_i520.SyncCursorStore>(),
       ),
     );
     gh.lazySingleton<_i263.BookmarksRepository>(

--- a/packages/features/collections/lib/src/di.module.dart
+++ b/packages/features/collections/lib/src/di.module.dart
@@ -44,8 +44,8 @@ import 'package:feature_collections/src/presentation/bloc/collections_list/colle
     as _i352;
 import 'package:injectable/injectable.dart' as _i526;
 import 'package:network/network.dart' as _i372;
+import 'package:rev_sync/rev_sync.dart' as _i520;
 import 'package:shared_contracts/shared_contracts.dart' as _i856;
-import 'package:rev_sync/rev_sync.dart' as _i846;
 import 'package:uuid/uuid.dart' as _i706;
 
 class FeatureCollectionsPackageModule extends _i526.MicroPackageModule {
@@ -65,8 +65,8 @@ class FeatureCollectionsPackageModule extends _i526.MicroPackageModule {
       () => _i342.CollectionsSyncService(
         gh<_i214.CollectionsLocalDataSource>(),
         gh<_i596.CollectionsRemoteDataSource>(),
-        gh<_i846.ConnectivitySource>(),
-        gh<_i846.SyncCursorStore>(),
+        gh<_i520.ConnectivitySource>(),
+        gh<_i520.SyncCursorStore>(),
       ),
     );
     gh.lazySingleton<_i709.CollectionsRepository>(

--- a/packages/features/notifications/lib/src/di.module.dart
+++ b/packages/features/notifications/lib/src/di.module.dart
@@ -30,8 +30,8 @@ import 'package:feature_notifications/src/presentation/bloc/notifications_bloc.d
     as _i503;
 import 'package:injectable/injectable.dart' as _i526;
 import 'package:network/network.dart' as _i372;
+import 'package:rev_sync/rev_sync.dart' as _i520;
 import 'package:shared_contracts/shared_contracts.dart' as _i856;
-import 'package:rev_sync/rev_sync.dart' as _i846;
 
 class FeatureNotificationsPackageModule extends _i526.MicroPackageModule {
   // initializes the registration of main-scope dependencies inside of GetIt
@@ -50,7 +50,7 @@ class FeatureNotificationsPackageModule extends _i526.MicroPackageModule {
       () => _i33.NotificationsSyncService(
         gh<_i1001.NotificationsLocalDataSource>(),
         gh<_i929.NotificationsRemoteDataSource>(),
-        gh<_i846.ConnectivitySource>(),
+        gh<_i520.ConnectivitySource>(),
       ),
     );
     gh.lazySingleton<_i705.NotificationsRepository>(

--- a/packages/sync_connectivity_plus/lib/src/di.module.dart
+++ b/packages/sync_connectivity_plus/lib/src/di.module.dart
@@ -7,7 +7,7 @@ import 'dart:async' as _i687;
 
 import 'package:connectivity_plus/connectivity_plus.dart' as _i895;
 import 'package:injectable/injectable.dart' as _i526;
-import 'package:rev_sync/rev_sync.dart' as _i846;
+import 'package:rev_sync/rev_sync.dart' as _i520;
 import 'package:sync_connectivity_plus/src/connectivity_plus_module.dart'
     as _i462;
 import 'package:sync_connectivity_plus/src/connectivity_plus_source.dart'
@@ -21,7 +21,7 @@ class SyncConnectivityPlusPackageModule extends _i526.MicroPackageModule {
     gh.lazySingleton<_i895.Connectivity>(
       () => connectivityPlusModule.provideConnectivity(),
     );
-    gh.lazySingleton<_i846.ConnectivitySource>(
+    gh.lazySingleton<_i520.ConnectivitySource>(
       () => _i916.ConnectivityPlusSource(gh<_i895.Connectivity>()),
     );
   }


### PR DESCRIPTION
## What

Regenerates the four committed DI modules that had drifted from the generator:

- `packages/features/bookmarks/lib/src/di.module.dart`
- `packages/features/collections/lib/src/di.module.dart`
- `packages/features/notifications/lib/src/di.module.dart`
- `packages/sync_connectivity_plus/lib/src/di.module.dart`

The first three are what `./tool/codegen.sh` rewrites. The fourth has the same
defect but sits outside that script's reach — see
[the gate proposal](#proposal-widen-the-gate-not-implemented-here) — so it was
regenerated by running `build_runner` inside the package directly.

The change is mechanical: injectable derives each import's alias from its URI, so
`package:rev_sync/rev_sync.dart` generates as `_i520` and sorts *before*
`package:shared_contracts/...`. The committed files carried `_i846` and placed it
*after* shared_contracts. Same registrations, same types, same order — no
behavioral change.

## Why it drifted

Not a dependency bump — it reproduces on an unmodified checkout of `main`.

It traces to the rev_sync extraction (c0335f9), which rewrote the import URI in
place instead of rerunning the generator. The previous line was:

```dart
import 'package:sync/sync.dart' as _i846;
```

For *that* URI both the alias and the position after `shared_contracts` were
correct (`sync` > `shared_contracts` alphabetically). Only the URI was changed to
`rev_sync`, so both facts became stale in the same edit.

### A latent hazard this also clears

In `collections`, `_i846` was bound to **two imports at once** —
`add_to_collection_cubit.dart` and `rev_sync.dart`. That collision was originally
the generator's own doing (`package:sync/sync.dart` happened to hash to the same
value as the cubit), and it survived the URI rewrite. Dart merges same-prefix
namespaces, so it compiled — but any name exported by both libraries would have
become an ambiguous-import error. `rev_sync` hashes to `_i520`, so regenerating
retires the shared prefix.

## Why CI didn't catch it

The `Generate code & verify ObjectBox binding is up to date` step runs
`codegen.sh` and then diff-gates only:

- `packages/database_drift/lib/src/app_database.g.dart` + `drift_schemas`
- `packages/database/lib/objectbox.g.dart` + `objectbox-model.json`
- (separately) `packages/localization/lib/l10n/app_localizations*.dart`

`di.module.dart` is tracked but ungated. Worse, the later `Verify formatting` and
`Analyze` steps run against the **freshly regenerated** tree, so the committed
file is never the thing being examined. The stale version can only be observed by
someone reading it in git — which is why it sat here.

Note these files are tracked *by naming accident*, not by intent: `.gitignore`
ignores `*.g.dart`, `*.freezed.dart`, `*.config.dart`, `*.gen.dart`, and the
ObjectBox/Drift outputs are re-included with explicit `!` negations.
`di.module.dart` matches none of those patterns, so it is committed by default.

## Proposal: widen the gate (not implemented here)

Adding a diff guard for `di.module.dart` alongside the existing ones would stop
this recurring:

```bash
di_files="$(git ls-files '*di.module.dart')"
if ! git diff --quiet --exit-code -- $di_files; then
  echo "::error::Generated DI modules are out of date. Run ./tool/codegen.sh and commit the result."
  git diff --stat -- $di_files
  exit 1
fi
```

**But that alone is only half a gate**, and the gap is worth fixing in the same
pass. `codegen.sh` regenerates DI modules only for `packages/features/*/` and the
two database packages:

```bash
for pkg in packages/features/*/; do ...
```

Eight infra packages also declare `build_runner` and ship a tracked
`di.module.dart` — `analytics`, `app_platform`, `config`, `network`,
`shared_contracts`, `storage`, `sync_connectivity_plus`, `theme` — and none of
them is ever rebuilt by `codegen.sh`. (It *does* `dart format` all 14 modules at
the end, which is why they stay format-clean; it just never regenerates them.) A
guard placed after `codegen.sh` would therefore be structurally blind to those
eight, reproducing the exact blind spot being closed.

### Concrete evidence: this already bit a fourth file

That blind spot is not hypothetical. Running `build_runner` inside the infra
packages surfaced the same defect in `sync_connectivity_plus`, which
`./tool/codegen.sh` alone never reveals:

```diff
 packages/sync_connectivity_plus/lib/src/di.module.dart
-import 'package:rev_sync/rev_sync.dart' as _i846;
+import 'package:rev_sync/rev_sync.dart' as _i520;
-    gh.lazySingleton<_i846.ConnectivitySource>(
+    gh.lazySingleton<_i520.ConnectivitySource>(
```

It is fixed in this PR (second commit). Worth noting for review: **a guard added
today would not have caught this file**, because the guard runs after
`codegen.sh` and `codegen.sh` never rebuilds it. The remaining seven infra
modules were checked the same way and are currently in sync.

So the suggested follow-up is a pair:

1. Extend `codegen.sh` to regenerate infra packages that declare `build_runner`.
2. Add the `di.module.dart` diff guard to `ci.yml`.

Done in that order, the guard is meaningful for all 14 tracked modules rather
than just the 6 feature ones. Done in the other order, it would have missed the
`sync_connectivity_plus` drift this PR is fixing.

## Verification

Run locally on the final state of this branch, all green:

- `./tool/codegen.sh` — reruns produce no further diff (idempotent)
- `fvm flutter analyze` — **No issues found!**
- `fvm flutter test --exclude-tags golden` — **45 passed** (root)
- All 17 package suites — **405 passed**, 0 failures
- `dart format --output=none --set-exit-if-changed` over tracked Dart — 0 changed
- `.githooks/pre-push` in full — `✓ pre-push checks passed`

<details>
<summary>Unrelated local-environment note</summary>

The pre-push hook cannot run through git on a machine using FVM 3.2.1: git sets
`GIT_DIR` for hooks, and `fvm` then fails resolving its cache
(`Invalid argument(s): "~/fvm/cache.git" is not the root of a git directory`).
Reproduces on any repo/branch — `GIT_DIR=… fvm dart --version` fails while a bare
`fvm dart --version` succeeds. The hook itself passes when invoked directly with
`GIT_DIR` unset, which is how it was verified above. Not caused by this change
and not addressed here.

</details>
