### PR TITLE
chore: gate di.module.dart against generator drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,34 @@ jobs:
             exit 1
           fi
 
+      # The injectable micro-package modules (packages/**/lib/src/di.module.dart)
+      # are tracked but were previously ungated: they match none of .gitignore's
+      # generated-file patterns (*.g.dart, *.config.dart, ...) so they are
+      # committed by default, and the format/analyze steps below inspect the
+      # freshly regenerated tree rather than what is in git. A stale module could
+      # therefore sit on main indefinitely — four of them did, including an
+      # import alias bound to two different libraries at once.
+      #
+      # codegen.sh (run above) rebuilds every package that owns one, so any
+      # difference here means the committed output no longer matches the
+      # generator. test/architecture/di_module_codegen_coverage_test.dart keeps
+      # that coverage honest, so this guard cannot quietly go blind.
+      # Matched with a glob pathspec rather than an expanded file list: git
+      # applies the glob itself, so the check never depends on the shell
+      # word-splitting a newline-separated `git ls-files` result.
+      - name: Verify generated DI modules are up to date
+        run: |
+          if [ -z "$(git ls-files -- '*di.module.dart')" ]; then
+            echo "::error::No tracked di.module.dart files found. Has the DI module layout changed? Update this guard."
+            exit 1
+          fi
+          if ! git diff --quiet --exit-code -- '*di.module.dart'; then
+            echo "::error::Generated DI modules are out of date. Run ./tool/codegen.sh and commit the regenerated di.module.dart files."
+            git diff --stat -- '*di.module.dart'
+            git diff -- '*di.module.dart'
+            exit 1
+          fi
+
       # Localizations are generated (generate: true) and the output under
       # packages/localization/lib/l10n/ is tracked in git, so editing an .arb
       # without regenerating AppLocalizations would drift undetected. Regenerate

--- a/test/architecture/di_module_codegen_coverage_test.dart
+++ b/test/architecture/di_module_codegen_coverage_test.dart
@@ -1,0 +1,174 @@
+// Architecture guardrail: every tracked `di.module.dart` must sit in a package
+// that `tool/codegen.sh` actually rebuilds.
+//
+// CI diff-guards these files: it runs codegen.sh, then fails if any tracked
+// di.module.dart changed. That guard is only as wide as the script — a module
+// in a package codegen.sh never builds is never regenerated, so it can never
+// differ, so the guard silently passes while the committed file rots.
+//
+// That is not hypothetical. codegen.sh once looped over `packages/features/*/`
+// only, leaving the eight infra modules tracked but unbuilt; the rev_sync
+// import alias in sync_connectivity_plus drifted there and went unnoticed
+// through every green CI run until someone regenerated it by hand.
+//
+// So this test asserts the coverage relationship itself: for each module found
+// on disk, the owning package must match one of the globs in codegen.sh's build
+// loop, must not be in that loop's skip list, and must declare build_runner
+// (without it build_runner cannot run there at all). Adding a new package with
+// a DI module that the script would not reach fails here, at test time, instead
+// of years later as a mystery diff.
+//
+// Pure file-scan, no third-party dependency, runs in the normal
+// `fvm flutter test` / CI flow.
+
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  final script = File('tool/codegen.sh');
+
+  test('tool/codegen.sh exists (run from the repository root)', () {
+    expect(
+      script.existsSync(),
+      isTrue,
+      reason:
+          'Expected to find tool/codegen.sh relative to the current directory. '
+          'Run this test from the repository root.',
+    );
+  });
+
+  // Read defensively at registration time so a missing script surfaces as the
+  // friendly failure above rather than a raw FileSystemException that aborts
+  // the whole suite load.
+  final source = script.existsSync() ? script.readAsStringSync() : '';
+  final globs = _buildLoopGlobs(source);
+  final skipped = _buildLoopSkips(source);
+  final modules = _trackedDiModules();
+
+  test('the build loop in codegen.sh is still parseable', () {
+    expect(
+      globs,
+      isNotEmpty,
+      reason:
+          'Could not parse the `for pkg in ...` build loop out of '
+          'tool/codegen.sh. Has the loop moved or changed shape? Update '
+          '_buildLoopGlobs to match.',
+    );
+  });
+
+  test('di.module.dart files are discoverable under packages/', () {
+    expect(
+      modules,
+      isNotEmpty,
+      reason:
+          'Found no di.module.dart under packages/. Either the DI module '
+          'layout changed or this test is running from the wrong directory — '
+          'in both cases the CI diff guard needs revisiting too.',
+    );
+  });
+
+  test('every DI module lives in a package codegen.sh rebuilds', () {
+    final unreachable = <String>[];
+
+    for (final packageDir in modules) {
+      if (skipped.contains(packageDir)) {
+        unreachable.add(
+          "$packageDir — excluded by the build loop's skip list, but it owns "
+          'a tracked di.module.dart',
+        );
+        continue;
+      }
+      if (!globs.any((g) => g.hasMatch('$packageDir/'))) {
+        unreachable.add(
+          '$packageDir — matches none of the build-loop globs '
+          '(${globs.map((g) => g.pattern).join(', ')})',
+        );
+      }
+    }
+
+    expect(
+      unreachable,
+      isEmpty,
+      reason:
+          'These packages ship a tracked di.module.dart that tool/codegen.sh '
+          'never regenerates. CI\'s "Verify generated DI modules are up to '
+          'date" step diffs the committed output against a fresh run, so an '
+          'unreachable module is invisible to it and can drift forever. '
+          'Widen the build loop in tool/codegen.sh to cover them:\n\n'
+          '${unreachable.map((u) => '  $u').join('\n')}',
+    );
+  });
+
+  test('every package owning a DI module declares build_runner', () {
+    final missing = <String>[];
+
+    for (final packageDir in modules) {
+      final pubspec = File('$packageDir/pubspec.yaml');
+      if (!pubspec.existsSync() ||
+          !pubspec.readAsStringSync().contains('build_runner')) {
+        missing.add(packageDir);
+      }
+    }
+
+    expect(
+      missing,
+      isEmpty,
+      reason:
+          'These packages ship a di.module.dart but do not declare '
+          'build_runner, so codegen.sh skips them even though its globs match '
+          '— the same blind spot, one layer down:\n\n'
+          '${missing.map((m) => '  $m').join('\n')}',
+    );
+  });
+}
+
+/// Package directories (repo-relative, no trailing slash) that contain a
+/// `di.module.dart`, mirroring the `find` in codegen.sh's format pass.
+List<String> _trackedDiModules() {
+  final root = Directory('packages');
+  if (!root.existsSync()) return const [];
+
+  return root
+      .listSync(recursive: true, followLinks: false)
+      .whereType<File>()
+      .where((f) => f.uri.pathSegments.last == 'di.module.dart')
+      .map((f) => f.path.replaceAll(r'\', '/'))
+      // Build output under .dart_tool is not source; codegen.sh prunes it too.
+      .where((p) => !p.contains('/.dart_tool/'))
+      // packages/<...>/lib/src/di.module.dart -> packages/<...>
+      .map((p) => p.split('/lib/').first)
+      .toSet()
+      .toList()
+    ..sort();
+}
+
+/// Compiles the shell globs from codegen.sh's `for pkg in <globs>; do` header
+/// into regexes anchored on a trailing slash (the loop iterates directories).
+List<RegExp> _buildLoopGlobs(String source) {
+  final header = RegExp('for pkg in ([^;]+); do').firstMatch(source);
+  if (header == null) return const [];
+
+  return header
+      .group(1)!
+      .split(RegExp(r'\s+'))
+      .where((g) => g.startsWith('packages/'))
+      .map((g) => RegExp('^${g.split('*').map(RegExp.escape).join('[^/]+')}\$'))
+      .toList();
+}
+
+/// Package directories excluded inside the build loop via
+/// `case ... ) continue ;;` — these are built elsewhere in the script.
+Set<String> _buildLoopSkips(String source) {
+  final arm = RegExp(
+    r'case\s+"\$\{pkg%/\}"\s+in\s*\n\s*([^)]+)\)\s*continue',
+  ).firstMatch(source);
+  if (arm == null) return const {};
+
+  return arm
+      .group(1)!
+      .split('|')
+      .map((p) => p.trim())
+      .where((p) => p.isNotEmpty)
+      .toSet();
+}

--- a/tool/codegen.sh
+++ b/tool/codegen.sh
@@ -2,15 +2,23 @@
 #
 # Generate build_runner output across the workspace.
 #
-# Feature packages under packages/features/<name> own internal codegen
-# (retrofit / json_serializable / freezed part files) that is git-ignored and
-# regenerated on demand. The app-root build_runner does NOT generate code inside
-# path-dependency packages, so each feature package must be built individually —
-# otherwise the app fails to compile against missing `part '*.g.dart'` files.
+# Workspace packages own internal codegen (retrofit / json_serializable /
+# freezed part files) that is git-ignored and regenerated on demand, plus the
+# injectable micro-package module (di.module.dart) which IS tracked. The
+# app-root build_runner does NOT generate code inside path-dependency packages,
+# so each package must be built individually — otherwise the app fails to
+# compile against missing `part '*.g.dart'` files.
 #
-# Build the feature packages first, then the app root, so the app's analysis and
-# build see the generated parts. The ObjectBox binding under packages/database is
-# a tracked exception (committed, holds stable schema UIDs) and is regenerated +
+# This covers infra packages (packages/<name>) as well as feature packages
+# (packages/features/<name>). It used to build only the latter, which left the
+# eight infra di.module.dart files tracked but never regenerated — so a stale
+# one could sit in git indefinitely. That is exactly how the rev_sync import
+# alias in sync_connectivity_plus drifted; CI now diff-guards these files, and
+# the guard is only meaningful if every package holding one is rebuilt here.
+#
+# Build the packages first, then the app root, so the app's analysis and build
+# see the generated parts. The ObjectBox binding under packages/database is a
+# tracked exception (committed, holds stable schema UIDs) and is regenerated +
 # verified separately in CI, so it is not built here.
 #
 # Prefers the FVM-pinned SDK when `fvm` is installed (this template pins Flutter
@@ -35,9 +43,17 @@ run_pkg() {
   echo "::endgroup::"
 }
 
-for pkg in packages/features/*/; do
+# packages/*/ also matches the packages/features/ container directory, which has
+# no pubspec.yaml and is skipped by the guard below. The two database packages
+# are handled by the dedicated loop further down (Drift additionally needs a
+# schema dump; ObjectBox is excluded from this script entirely), so skip them
+# here rather than building them twice.
+for pkg in packages/*/ packages/features/*/; do
   [ -f "${pkg}pubspec.yaml" ] || continue
   grep -q 'build_runner' "${pkg}pubspec.yaml" || continue
+  case "${pkg%/}" in
+    packages/database | packages/database_drift) continue ;;
+  esac
   run_pkg "${pkg%/}"
 done
 


### PR DESCRIPTION
> **Stacked on #202** — base is `fix/stale-di-module-codegen`, not `main`.
> Merge #202 first. The new gate fails against today's `main`, by design: `main`
> still holds the four stale modules that #202 regenerates.

Follow-up to #202, which fixed four stale `di.module.dart` files. This closes the
hole that let them rot through every green CI run.

## Why a gate alone isn't enough

The obvious fix is a diff guard: run `codegen.sh`, fail if any tracked
`di.module.dart` changed. But the guard is only ever as wide as the script it
follows. A module in a package `codegen.sh` never builds is never regenerated, so
it can never differ, so the guard passes while the file rots.

That is not a hypothetical — it is exactly how the fourth file in #202
(`sync_connectivity_plus`) drifted. **A gate added on its own would not have
caught it.** So this PR does the three parts in the order they have to happen.

## 1. `codegen.sh` rebuilds infra packages

The loop covered only `packages/features/*/`. Eight infra packages declare
`build_runner` and each ships a tracked `di.module.dart` — `analytics`,
`app_platform`, `config`, `network`, `shared_contracts`, `storage`,
`sync_connectivity_plus`, `theme` — and none was ever regenerated.

The script already `dart format`s all 14 modules at the end, which is why they
stayed format-clean the whole time while their *contents* drifted. That is what
made this so quiet.

```diff
-for pkg in packages/features/*/; do
+for pkg in packages/*/ packages/features/*/; do
   [ -f "${pkg}pubspec.yaml" ] || continue
   grep -q 'build_runner' "${pkg}pubspec.yaml" || continue
+  case "${pkg%/}" in
+    packages/database | packages/database_drift) continue ;;
+  esac
   run_pkg "${pkg%/}"
 done
```

`packages/*/` also matches the `packages/features/` container directory, which
has no `pubspec.yaml` and falls out at the existing guard. The two database
packages are skipped because the loop below owns them — Drift additionally needs
a schema dump, and the ObjectBox binding is deliberately excluded from this
script (stable schema UIDs, verified separately).

## 2. `ci.yml` diff-gates the modules

A new step after codegen, mirroring the existing ObjectBox / Drift / l10n guards.

These files match none of `.gitignore`'s generated-file patterns (`*.g.dart`,
`*.config.dart`, …), so they are tracked by default rather than by intent — and
the `Verify formatting` / `Analyze` steps only ever inspect the freshly
regenerated tree. The committed output was never the thing being checked.

One deliberate difference from the existing guards: this one matches with a **git
glob pathspec** rather than interpolating a `git ls-files` result.

```bash
if ! git diff --quiet --exit-code -- '*di.module.dart'; then
```

The existing guards interpolate a space-separated list, which quietly depends on
the shell word-splitting it. A newline-separated `git ls-files` result makes that
assumption load-bearing — and it does not hold in every shell. I hit this while
testing: the first draft used `$di_files` and **silently passed on seeded
drift**. Letting git apply the glob removes the assumption entirely.

## 3. A guardrail test keeps the gate honest

`test/architecture/di_module_codegen_coverage_test.dart` asserts the coverage
relationship the gate depends on, so it cannot go blind again. It parses the
build loop's globs and skip list straight out of `codegen.sh` and checks every
`di.module.dart` on disk against them — nothing is hardcoded, so it holds up
under `fst create` scaffolds that strip packages.

Adding a package with a DI module the script would not reach now fails at test
time. Reverting the loop to its old form produces:

```
every DI module lives in a package codegen.sh rebuilds [E]
  packages/analytics — matches none of the build-loop globs (^packages/features/[^/]+/$)
  packages/app_platform — matches none of the build-loop globs (^packages/features/[^/]+/$)
  ... 8 packages, each named
```

## Verification

Each claim below was checked by running it, including the failure directions —
a guard that has only ever been seen passing has not been tested.

| Check | Result |
|---|---|
| Guard on a clean tree | passes |
| Guard with seeded drift (`_i520` → `_i846`) | **fails**, names the file |
| Guardrail test, current loop | passes |
| Guardrail test, loop reverted to old form | **fails**, names all 8 packages |
| `./tool/codegen.sh` full run | builds 8 infra + 6 feature + drift + app root, **no diff** |
| `fvm flutter analyze` | No issues found! |
| Root tests | 50 passed |
| All 17 package suites | 405 passed |
| `.githooks/pre-push` | `✓ pre-push checks passed` |
| `ci.yml` | parses as YAML; new step ordered after codegen, before format/analyze |

## Merge order

1. #202 (regenerates the four stale modules)
2. this PR

Reversed, CI here goes red on `main`'s existing drift. Please don't delete
`fix/stale-di-module-codegen` when merging #202 while this PR still points at it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of generated dependency-injection modules by detecting files that are missing, outdated, or not covered by code generation.

- **Documentation**
  - Updated code-generation guidance to include infrastructure and feature packages.

- **Tests**
  - Added architecture checks to verify dependency-injection modules are properly generated and supported by their packages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->