### PR TITLE
fix: let the pre-push hook run under git's hook environment

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -11,6 +11,25 @@
 #
 set -euo pipefail
 
+# Git exports GIT_DIR (and friends) when it runs a hook, and those variables
+# leak into every child process. FVM resolves its pinned SDK by inspecting its
+# own cache with a git subprocess — the inherited GIT_DIR makes that lookup
+# resolve against THIS repository instead, and fvm aborts before running
+# anything:
+#
+#   Invalid argument(s): The provided value "~/fvm/cache.git" is not the root
+#   of a git directory
+#
+# The failure is unconditional, so without this the hook can never run through
+# `git push` on an FVM machine — it is not a property of the branch or the
+# diff, and repairing the fvm cache does not help (git honours GIT_DIR over
+# `-C` even for a valid bare repo).
+#
+# Dropping the variables is safe for our own git calls below: during pre-push
+# the working directory is the repository root, so `git ls-files` rediscovers
+# the repo on its own.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
+
 # Prefer the FVM-pinned SDK (this repo pins Flutter via .fvmrc); fall back to a
 # plain toolchain if FVM is not installed.
 if command -v fvm >/dev/null 2>&1; then


### PR DESCRIPTION
## The hook could never run

`.githooks/pre-push` fails unconditionally through `git push` on any machine
using FVM. Not sometimes, not for certain diffs — every push, every branch:

```
✖ Code generation failed. Resolve build_runner errors before pushing.
Invalid argument(s): The provided value "~/fvm/cache.git" is not the root of a
git directory
```

Git exports `GIT_DIR` when it invokes a hook, and it leaks into every child
process. FVM resolves its pinned SDK by inspecting its own cache with a git
subprocess; the inherited `GIT_DIR` makes that lookup resolve against *this*
repository instead, so fvm aborts before the first check runs.

The practical effect is worse than a broken script: the formatting and analyzer
gates this hook exists to enforce were never actually enforced locally, and the
only way to push at all was `--no-verify` — precisely the habit the hook is
meant to prevent.

## Fix

```bash
unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE
```

Safe for the hook's own git calls: during pre-push the working directory is the
repository root, so `git ls-files` rediscovers the repo unaided — verified, the
same 429 tracked Dart files before and after.

I captured the environment a real hook actually receives, rather than assuming
which variables git sets:

```
GIT_DIR=…/flutter-starter-template/.git/worktrees/…
GIT_EDITOR=true
GIT_EXEC_PATH=/opt/homebrew/opt/git/libexec/git-core
GIT_PREFIX=
```

`GIT_DIR` is the only harmful one — `GIT_WORK_TREE` and `GIT_INDEX_FILE` are not
even set for pre-push. They are unset anyway because git does set them for other
hooks, and this line should not need revisiting if the hook is ever reused.

## Repairing the fvm cache does *not* fix this

Worth recording, because it is the obvious first guess and it is wrong. The
cache at `~/fvm/cache.git` is a valid `flutter/flutter` mirror (correct remote,
carries tag `3.44.0`); its only oddity is a working tree where fvm expects a
bare repo.

That is not the cause. Git honours `GIT_DIR` over `-C` even for a pristine bare
repository — confirmed against a freshly created one:

```console
$ git init --bare /tmp/x.git
$ git -C /tmp/x.git rev-parse --git-dir
.
$ GIT_DIR=/some/repo/.git git -C /tmp/x.git rev-parse --git-dir
/some/repo/.git          # ← ambient GIT_DIR wins
$ GIT_DIR=/some/repo/.git git -C /tmp/x.git rev-parse --is-bare-repository
false                    # ← reports the *other* repo
```

So wiping and re-cloning the cache would cost a 690 MB re-download and change
nothing. Upgrading FVM may eventually fix it upstream (3.2.1 here), but that is
a per-machine action and this hook should not depend on everyone doing it.

## Verification

Proven end-to-end, not just simulated — **this branch was pushed through the
fixed hook, with no `--no-verify`**:

```
▶ pre-push: generating code (build_runner)…
▶ pre-push: verifying formatting (dart format)…
Formatted 429 files (0 changed) in 0.58 seconds.
▶ pre-push: analyzing (flutter analyze)…
No issues found! (ran in 1.6s)
✓ pre-push checks passed
 * [new branch]      fix/pre-push-hook-fvm-git-dir -> fix/pre-push-hook-fvm-git-dir
```

Before the change the identical invocation died at the first gate.

## Note for anyone using git worktrees

`core.hooksPath` is an absolute path and is shared repo-wide, so a push from a
worktree runs the hook from the **primary checkout**, not from the worktree's
own copy. Editing `.githooks/pre-push` inside a worktree therefore has no effect
on pushes from it — I hit this while testing and it briefly looked like the fix
had failed.

Consequence after merge: pull `main` in your primary checkout for the fix to
take effect, even if you work in worktrees. To test hooks from a worktree
without merging first:

```bash
git -c core.hooksPath="$(pwd)/.githooks" push …
```

No CI implications — this file is not executed by any workflow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pre-push checks in environments with inherited Git settings.
  * Prevented Git and version-management commands from being affected by conflicting repository variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->